### PR TITLE
get attributes from within the json blob

### DIFF
--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -28,6 +28,6 @@ class EntryModel extends Eloquent
 
     public function getAttribute($key)
     {
-        return Arr::get($this->data, $key, parent::getAttribute($key));
+        return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
     }
 }

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent\Entries;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
 
 class EntryModel extends Eloquent
 {
@@ -23,5 +24,10 @@ class EntryModel extends Eloquent
     public function origin()
     {
         return $this->belongsTo(self::class);
+    }
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->data, $key, parent::getAttribute($key));
     }
 }


### PR DESCRIPTION
This allows one to get data from within the JSON blob as if it was a native model. i.e. `$entry->foo` grabs `$data['foo']`.