### PR TITLE
Fix ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^3.0"
+        "statamic/cms": "dev-entries-with-int-id"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "statamic/cms": "dev-entries-with-int-id"
+        "statamic/cms": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4"

--- a/database/migrations/2020_01_01_000000_create_entries_table.php
+++ b/database/migrations/2020_01_01_000000_create_entries_table.php
@@ -23,6 +23,7 @@ class CreateEntriesTable extends Migration
             $table->string('uri')->nullable();
             $table->string('date')->nullable();
             $table->string('collection');
+            $table->string('blueprint');
             $table->json('data');
             $table->timestamps();
         });

--- a/database/migrations/2020_01_01_000000_create_entries_table_with_strings.php
+++ b/database/migrations/2020_01_01_000000_create_entries_table_with_strings.php
@@ -23,6 +23,7 @@ class CreateEntriesTableWithStrings extends Migration
             $table->string('uri')->nullable();
             $table->string('date')->nullable();
             $table->string('collection');
+            $table->string('blueprint');
             $table->json('data');
             $table->timestamps();
         });

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -16,6 +16,7 @@ class Entry extends FileEntry
             ->slug($model->slug)
             ->date($model->date)
             ->collection($model->collection)
+            ->blueprint($model->blueprint)
             ->data($model->data)
             ->published($model->published)
             ->model($model);
@@ -32,6 +33,7 @@ class Entry extends FileEntry
             'uri' => $this->uri(),
             'date' => $this->hasDate() ? $this->date() : null,
             'collection' => $this->collectionHandle(),
+            'blueprint' => $this->blueprint(),
             'data' => $this->data(),
             'published' => $this->published(),
             'status' => $this->status(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -26,7 +26,6 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         return $class::findOrNew($this->id())->fill([
-            'id' => $this->id() ?? $class::generateId(),
             'origin_id' => $this->originId(),
             'site' => $this->locale(),
             'slug' => $this->slug(),
@@ -70,7 +69,7 @@ class Entry extends FileEntry
         }
 
         if (! $this->model->origin) {
-            return null;
+            return;
         }
 
         return self::fromModel($this->model->origin);

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -26,9 +26,4 @@ class EntryModel extends Eloquent
     {
         return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
     }
-  
-    public static function generateId()
-    {
-        return null;
-    }
 }

--- a/src/Entries/UuidEntryModel.php
+++ b/src/Entries/UuidEntryModel.php
@@ -9,8 +9,12 @@ class UuidEntryModel extends EntryModel
     public $incrementing = false;
     protected $keyType = 'string';
 
-    public static function generateId()
+    protected static function boot()
     {
-        return (string) Str::uuid();
+        parent::boot();
+
+        static::creating(function ($entry) {
+            $entry->{$entry->getKeyName()} = (string) Str::uuid();
+        });
     }
 }


### PR DESCRIPTION
If you use the `id` column, there was an error when saving because the `generateId` call returned null and you can't pass null into a non-nullable column. You need to not send the `id` column value for `EntryModel` but include for `UuidEntryModel`.

Added `creating` hook so it's added every time a model is created, only on the UuidEntryModel.