### PR TITLE
Fix id

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -26,7 +26,6 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         return $class::findOrNew($this->id())->fill([
-            'id' => $this->id() ?? $class::generateId(),
             'origin_id' => $this->originId(),
             'site' => $this->locale(),
             'slug' => $this->slug(),
@@ -70,7 +69,7 @@ class Entry extends FileEntry
         }
 
         if (! $this->model->origin) {
-            return null;
+            return;
         }
 
         return self::fromModel($this->model->origin);

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -69,7 +69,7 @@ class Entry extends FileEntry
         }
 
         if (! $this->model->origin) {
-            return;
+            return null;
         }
 
         return self::fromModel($this->model->origin);

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -26,9 +26,4 @@ class EntryModel extends Eloquent
     {
         return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
     }
-  
-    public static function generateId()
-    {
-        return null;
-    }
 }

--- a/src/Entries/UuidEntryModel.php
+++ b/src/Entries/UuidEntryModel.php
@@ -9,8 +9,12 @@ class UuidEntryModel extends EntryModel
     public $incrementing = false;
     protected $keyType = 'string';
 
-    public static function generateId()
+    protected static function boot()
     {
-        return (string) Str::uuid();
+        parent::boot();
+
+        static::creating(function ($entry) {
+            $entry->{$entry->getKeyName()} = (string) Str::uuid();
+        });
     }
 }


### PR DESCRIPTION
If you have `id` as an integer, you can't send null to it, as it throws an error.

To solve, we don't set the `id` in the creation, so that the DB can generate the correct one, when `EntryModel` is used.

When `UuidEntryModel` is used, we listen for the `creating` event and set the `id` to a generated UUID.