### PR TITLE
Support sub-queries

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -29,7 +29,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             $column = 'origin_id';
         }
 
-        if (! in_array($column, $this->columns)) {
+        if (! in_array($column, $this->columns) && is_string($column)) {
             $column = 'data->'.$column;
         }
 


### PR DESCRIPTION
When you use sub-queries, `column` is a closure, and we want to pass it directly back.