### PR TITLE
Add possibility to define custom entry class

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -4,7 +4,7 @@ return [
 
     'entries' => [
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
-        'base' => \Statamic\Eloquent\Entries\EntryModel::class,
+        'base' => \Statamic\Eloquent\Entries\Entry::class,
     ],
 
 ];

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -4,6 +4,7 @@ return [
 
     'entries' => [
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
+        'base' => \Statamic\Eloquent\Entries\EntryModel::class,
     ],
 
 ];

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -19,7 +19,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     protected function transform($items, $columns = [])
     {
         return EntryCollection::make($items)->map(function ($model) {
-            return Entry::fromModel($model);
+            return config('statamic-eloquent-driver.entries.base', Entry::class)::fromModel($model);
         });
     }
 

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -11,7 +11,7 @@ class EntryRepository extends StacheRepository
     public static function bindings(): array
     {
         return [
-            EntryContract::class => Entry::class,
+            EntryContract::class => config('statamic-eloquent-driver.entries.base', Entry::class),
             QueryBuilder::class => EntryQueryBuilder::class,
         ];
     }


### PR DESCRIPTION
Recently I tried to [customize how the Live Preview is rendered](https://statamic.dev/extending/live-preview#customizing-how-an-entry-is-rendered). For this I had to create either a)[ a custom entry class](https://statamic.dev/extending/repositories#custom-data-classes) or b) [create a custom entry repository](https://statamic.dev/extending/repositories#custom-repositories) and change the bindings there.

Unfortunately none of the two ways is really compatible with this Eloquent driver (or did I miss something? 🤔). 

Therefore I created the possibility to define your own Entry data class. This should allow you to override all functions of the Entry class, including `toLivePreviewResponse(...)` in my case. I'm sure this will be useful for other people too, as overriding the Entry class functions is quite common in the Statamic docs.

This pull request allows you to define your own Entry class in `config/statamic-eloquent-driver.php`

```
    'entries' => [
        'model' => \Statamic\Eloquent\Entries\EntryModel::class,
        'base' => \Statamic\Eloquent\Entries\Entry::class,
    ],
```

Feedback is welcome ☺️