### PR TITLE
Support all models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor
 .phpunit.result.cache
+.php_cs.cache

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package provides support for storing your Statamic data in a database rathe
 
 Todo:
 - [x] taxonomies
-- [ ] navigations
+- [x] navigations
 - [x] globals 
 - [ ] form submissions
 - [ ] collections 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This package provides support for storing your Statamic data in a database rathe
 Todo:
 - [x] taxonomies
 - [ ] navigations
-- [ ] globals 
+- [x] globals 
 - [ ] form submissions
+- [ ] collections 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 This package provides support for storing your Statamic data in a database rather than the filesystem.
 
+**Multisite is not tested yet!**
+
 Todo:
 - [x] taxonomies
 - [x] navigations
 - [x] globals 
 - [ ] form submissions
-- [ ] collections 
+- [x] collections 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,6 @@
 
 This package provides support for storing your Statamic data in a database rather than the filesystem.
 
-**Multisite is not tested yet!**
-
-Todo:
-- [x] taxonomies
-- [x] navigations
-- [x] globals 
-- [ ] form submissions
-- [x] collections 
-
 ## Installation
 
 Install using Composer:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This package provides support for storing your Statamic data in a database rather than the filesystem.
 
-This driver currently supports entries but not taxonomies, navigations, globals, or form submissions. We'll be working on those in the future.
+Todo:
+- [x] taxonomies
+- [ ] navigations
+- [ ] globals 
+- [ ] form submissions
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're starting from scratch, we can use traditional incrementing integers fo
 
 - Delete `content/collections/pages/home.md`
 - Change the structure `tree` in `content/collections/pages.yaml` to `{}`.
-- Copy the `create_entries_table` migration into `database/migrations`.
+- Copy all migrations into `database/migrations`.
 - Run `php artisan migrate`.
 
 ### Starting from an existing site (using UUIDs)

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -4,6 +4,7 @@ return [
 
     'entries' => [
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
+        'entry' => \Statamic\Eloquent\Entries\Entry::class,
     ],
 
     'collections' => [

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -22,4 +22,12 @@ return [
         'model' =>  \Statamic\Eloquent\Globals\VariablesModel::class,
     ],
 
+    'navigations' => [
+        'model' =>  \Statamic\Eloquent\Structures\NavModel::class,
+    ],
+
+    'nav-trees' => [
+        'model' =>  \Statamic\Eloquent\Structures\NavTreeModel::class,
+    ],
+
 ];

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -6,6 +6,10 @@ return [
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
     ],
 
+    'collections' => [
+        'model' => \Statamic\Eloquent\Entries\CollectionModel::class,
+    ],
+
     'taxonomies' => [
         'model' =>  \Statamic\Eloquent\Taxonomies\TaxonomyModel::class,
     ],

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -7,7 +7,9 @@ return [
     ],
 
     'collections' => [
-        'model' => \Statamic\Eloquent\Entries\CollectionModel::class,
+        'model' => \Statamic\Eloquent\Collections\CollectionModel::class,
+    ],
+
     'trees' => [
         'model' => \Statamic\Eloquent\Structures\TreeModel::class,
     ],

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -6,4 +6,12 @@ return [
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
     ],
 
+    'taxonomies' => [
+        'model' =>  \Statamic\Eloquent\Taxonomies\TaxonomyModel::class,
+    ],
+
+    'terms' => [
+        'model' =>  \Statamic\Eloquent\Taxonomies\TermModel::class,
+    ],
+
 ];

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -8,6 +8,8 @@ return [
 
     'collections' => [
         'model' => \Statamic\Eloquent\Entries\CollectionModel::class,
+    'trees' => [
+        'model' => \Statamic\Eloquent\Structures\TreeModel::class,
     ],
 
     'taxonomies' => [

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -14,4 +14,12 @@ return [
         'model' =>  \Statamic\Eloquent\Taxonomies\TermModel::class,
     ],
 
+    'global-sets' => [
+        'model' =>  \Statamic\Eloquent\Globals\GlobalSetModel::class,
+    ],
+
+    'variables' => [
+        'model' =>  \Statamic\Eloquent\Globals\VariablesModel::class,
+    ],
+
 ];

--- a/database/migrations/2021_05_18_160811_create_taxonomies_table.php
+++ b/database/migrations/2021_05_18_160811_create_taxonomies_table.php
@@ -17,6 +17,7 @@ class CreateTaxonomiesTable extends Migration
             $table->increments('id');
             $table->string('handle');
             $table->string('title');
+            $table->json('sites')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2021_05_18_160811_create_taxonomies_table.php
+++ b/database/migrations/2021_05_18_160811_create_taxonomies_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaxonomiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('taxonomies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('handle');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('taxonomies');
+    }
+}

--- a/database/migrations/2021_05_19_082853_create_terms_table.php
+++ b/database/migrations/2021_05_19_082853_create_terms_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTermsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('taxonomy_terms', function (Blueprint $table) {
+            $table->id();
+            $table->string('site');
+            $table->string('slug');
+            $table->string('uri')->nullable();
+            $table->string('taxonomy');
+            $table->json('data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('taxonomy_terms');
+    }
+}

--- a/database/migrations/2021_05_19_122354_create_globals_table.php
+++ b/database/migrations/2021_05_19_122354_create_globals_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateGlobalsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('global_sets', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle');
+            $table->string('title');
+            $table->json('localizations');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('global_sets');
+    }
+}

--- a/database/migrations/2021_05_19_143631_create_navigations_table.php
+++ b/database/migrations/2021_05_19_143631_create_navigations_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNavigationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('navigations', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle');
+            $table->string('title');
+            $table->json('collections')->nullable();
+            $table->integer('maxDepth')->nullable();
+            $table->boolean('expectsRoot')->default(false);
+            $table->string('initialPath')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('navigations');
+    }
+}

--- a/database/migrations/2021_05_27_082335_create_navigation_trees_table.php
+++ b/database/migrations/2021_05_27_082335_create_navigation_trees_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNavigationTreesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('navigation_trees', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle');
+            $table->string('initialPath')->nullable();
+            $table->string('locale')->nullable();
+            $table->json('tree')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('navigation_trees');
+    }
+}

--- a/database/migrations/2021_05_27_082335_create_navigation_trees_table.php
+++ b/database/migrations/2021_05_27_082335_create_navigation_trees_table.php
@@ -13,9 +13,10 @@ class CreateNavigationTreesTable extends Migration
      */
     public function up()
     {
-        Schema::create('navigation_trees', function (Blueprint $table) {
+        Schema::create('trees', function (Blueprint $table) {
             $table->id();
             $table->string('handle');
+            $table->string('type');
             $table->string('initialPath')->nullable();
             $table->string('locale')->nullable();
             $table->json('tree')->nullable();
@@ -30,6 +31,6 @@ class CreateNavigationTreesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('navigation_trees');
+        Schema::dropIfExists('trees');
     }
 }

--- a/database/migrations/2021_05_28_114212_create_collections_table.php
+++ b/database/migrations/2021_05_28_114212_create_collections_table.php
@@ -29,6 +29,7 @@ class CreateCollectionsTable extends Migration
             $table->string('sort_dir')->nullable();
             $table->string('sort_field')->nullable();
             $table->string('mount')->nullable();
+            $table->string('search_index')->nullable();
             $table->json('taxonomies')->nullable();
             $table->boolean('revisions')->default(false);
             $table->json('inject')->nullable();

--- a/database/migrations/2021_05_28_114212_create_collections_table.php
+++ b/database/migrations/2021_05_28_114212_create_collections_table.php
@@ -23,7 +23,7 @@ class CreateCollectionsTable extends Migration
             $table->string('future_date_behavior')->nullable();
             $table->boolean('default_publish_state')->default(true);
             $table->boolean('ampable')->default(false);
-            $table->string('sites')->nullable();
+            $table->json('sites')->nullable();
             $table->string('template')->nullable();
             $table->string('layout')->nullable();
             $table->string('sort_dir')->nullable();

--- a/database/migrations/2021_05_28_114212_create_collections_table.php
+++ b/database/migrations/2021_05_28_114212_create_collections_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCollectionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('collections', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle');
+            $table->string('title');
+            $table->json('routes')->nullable();
+            $table->boolean('dated')->default(false);
+            $table->string('past_date_behavior')->nullable();
+            $table->string('future_date_behavior')->nullable();
+            $table->boolean('default_publish_state')->default(true);
+            $table->boolean('ampable')->default(false);
+            $table->string('sites')->nullable();
+            $table->string('template')->nullable();
+            $table->string('layout')->nullable();
+            $table->string('sort_dir')->nullable();
+            $table->string('sort_field')->nullable();
+            $table->string('mount')->nullable();
+            $table->json('taxonomies')->nullable();
+            $table->boolean('revisions')->default(false);
+            $table->json('inject')->nullable();
+            $table->json('structure')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('collections');
+    }
+}

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -13,6 +13,7 @@ class Collection extends FileEntry
     public static function fromModel(Model $model)
     {
         return (new static)
+            ->searchIndex($model->search_index)
             ->structureContents($model->structure)
             ->sortDirection($model->sort_dir)
             ->sortField($model->sort_field)
@@ -49,6 +50,7 @@ class Collection extends FileEntry
             'layout' => $this->layout,
             'sort_dir' => $this->sortDirection(),
             'sort_field' => $this->sortField(),
+            'search_index' => $this->searchIndex(),
             'mount' => $this->mount,
             'taxonomies' => $this->taxonomies,
             'revisions' => $this->revisions,

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Statamic\Eloquent\Entries;
+namespace Statamic\Eloquent\Collections;
 
-use Statamic\Eloquent\Entries\CollectionModel as Model;
+use Statamic\Eloquent\Collections\CollectionModel as Model;
+use Statamic\Eloquent\Structures\CollectionStructure;
 use Statamic\Entries\Collection as FileEntry;
 
 class Collection extends FileEntry
@@ -67,5 +68,13 @@ class Collection extends FileEntry
         $this->id($model->id);
 
         return $this;
+    }
+
+    protected function makeStructureFromContents()
+    {
+        return (new CollectionStructure)
+            ->handle($this->handle())
+            ->expectsRoot($this->structureContents['root'] ?? false)
+            ->maxDepth($this->structureContents['max_depth'] ?? null);
     }
 }

--- a/src/Collections/CollectionModel.php
+++ b/src/Collections/CollectionModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Eloquent\Entries;
+namespace Statamic\Eloquent\Collections;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 

--- a/src/Collections/CollectionModel.php
+++ b/src/Collections/CollectionModel.php
@@ -15,6 +15,7 @@ class CollectionModel extends Eloquent
         'inject' => 'json',
         'taxonomies' => 'json',
         'structure' => 'json',
+        'sites' => 'json',
         'revisions' => 'bool',
         'dated' => 'bool',
         'default_publish_state' => 'bool',

--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Statamic\Eloquent\Entries;
+namespace Statamic\Eloquent\Collections;
 
 use Illuminate\Support\Collection as IlluminateCollection;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
+use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Stache\Repositories\CollectionRepository as StacheRepository;
 
 class CollectionRepository extends StacheRepository

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Statamic\Eloquent\Entries;
+
+use Statamic\Eloquent\Entries\CollectionModel as Model;
+use Statamic\Entries\Collection as FileEntry;
+
+
+class Collection extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        return (new static)
+            ->structure($model->structure)
+            ->sortDirection($model->sort_dir)
+            ->sortField($model->sort_field)
+            ->layout($model->layout)
+            ->template($model->template)
+            ->sites($model->sites)
+            ->futureDateBehavior($model->future_date_behavior)
+            ->pastDateBehavior($model->past_date_behavior)
+            ->ampable($model->ampable)
+            ->dated($model->dated)
+            ->title($model->title)
+            ->handle($model->handle)
+            ->routes($model->routes)
+            ->taxonomies($model->taxonomies)
+            ->mount($model->mount)
+            ->model($model);
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.collections.model');
+
+        return $class::findOrNew($this->model?->id)->fill([
+            'title' => $this->title,
+            'handle' => $this->handle,
+            'routes' => $this->routes,
+            'dated' => $this->dated,
+            'past_date_behavior' => $this->pastDateBehavior(),
+            'future_date_behavior' => $this->futureDateBehavior(),
+            'default_publish_state' => $this->defaultPublishState,
+            'ampable' => $this->ampable,
+            'sites' => $this->sites,
+            'template' => $this->template,
+            'layout' => $this->layout,
+            'sort_dir' => $this->sortDirection(),
+            'sort_field' => $this->sortField(),
+            'mount' => $this->mount,
+            'taxonomies' => $this->taxonomies,
+            'revisions' => $this->revisions,
+            'inject' => $this->cascade,
+            'structure' => $this->hasStructure() ? $this->structureContents() : null,
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        $this->id($model->id);
+
+        return $this;
+    }
+}

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Statamic\Eloquent\Entries;
 
 use Statamic\Eloquent\Entries\CollectionModel as Model;
 use Statamic\Entries\Collection as FileEntry;
-
 
 class Collection extends FileEntry
 {
@@ -14,7 +12,7 @@ class Collection extends FileEntry
     public static function fromModel(Model $model)
     {
         return (new static)
-            ->structure($model->structure)
+            ->structureContents($model->structure)
             ->sortDirection($model->sort_dir)
             ->sortField($model->sort_field)
             ->layout($model->layout)

--- a/src/Entries/CollectionModel.php
+++ b/src/Entries/CollectionModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Eloquent\Entries;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
+
+class CollectionModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'collections';
+
+    protected $casts = [
+        'routes' => 'json',
+        'inject' => 'json',
+        'taxonomies' => 'json',
+        'structure' => 'json',
+        'revisions' => 'bool',
+        'dated' => 'bool',
+        'default_publish_state' => 'bool',
+        'ampable' => 'bool',
+    ];
+
+}

--- a/src/Entries/CollectionModel.php
+++ b/src/Entries/CollectionModel.php
@@ -3,7 +3,6 @@
 namespace Statamic\Eloquent\Entries;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Support\Arr;
 
 class CollectionModel extends Eloquent
 {
@@ -21,5 +20,4 @@ class CollectionModel extends Eloquent
         'default_publish_state' => 'bool',
         'ampable' => 'bool',
     ];
-
 }

--- a/src/Entries/CollectionRepository.php
+++ b/src/Entries/CollectionRepository.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Stache\Repositories\CollectionRepository as StacheRepository;
+use Illuminate\Support\Collection as IlluminateCollection;
 
 class CollectionRepository extends StacheRepository
 {
@@ -17,5 +19,56 @@ class CollectionRepository extends StacheRepository
         $query->get()->each(function ($entry) {
             EntryModel::where('id', $entry->id())->update(['uri' => $entry->uri()]);
         });
+    }
+
+    public function all(): IlluminateCollection
+    {
+        return $this->transform(CollectionModel::all());
+    }
+
+    public function find($handle): ?CollectionContract
+    {
+        $model = CollectionModel::whereHandle($handle)->first();
+
+        return $model
+            ? app(CollectionContract::class)->fromModel($model)
+            : null;
+    }
+
+    public function findByHandle($handle): ?CollectionContract
+    {
+        $model = CollectionModel::whereHandle($handle)->first();
+
+        return $model
+            ? app(CollectionContract::class)->fromModel($model)
+            : null;
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+
+    protected function transform($items, $columns = [])
+    {
+        return IlluminateCollection::make($items)->map(function ($model) {
+            return Collection::fromModel($model);
+        });
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            CollectionContract::class => Collection::class,
+        ];
     }
 }

--- a/src/Entries/CollectionRepository.php
+++ b/src/Entries/CollectionRepository.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Support\Collection as IlluminateCollection;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Stache\Repositories\CollectionRepository as StacheRepository;
-use Illuminate\Support\Collection as IlluminateCollection;
 
 class CollectionRepository extends StacheRepository
 {

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Support\Carbon;
 use Statamic\Eloquent\Entries\EntryModel as Model;
 use Statamic\Entries\Entry as FileEntry;
 
@@ -58,6 +59,28 @@ class Entry extends FileEntry
         return $this;
     }
 
+    /**
+     * This overwrite is needed to prevent Statamic to save updated_at also into the data. We track updated_at already in the database.
+     *
+     * @param null $user
+     * @return $this|Entry|FileEntry|\Statamic\Taxonomies\LocalizedTerm
+     */
+    public function updateLastModified($user = null)
+    {
+        if (! config('statamic.system.track_last_update')) {
+            return $this;
+        }
+
+        $user
+            ? $this->set('updated_by', $user->id())
+            : $this->remove('updated_by');
+
+        // ensure 'updated_at' does not exists in the data of the entry.
+        $this->remove('updated_at');
+
+        return $this;
+    }
+
     public function lastModified()
     {
         return $this->model->updated_at;
@@ -76,7 +99,7 @@ class Entry extends FileEntry
         }
 
         if (! $this->model->origin) {
-            return null;
+            return;
         }
 
         return self::fromModel($this->model->origin);

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -19,7 +19,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     protected function transform($items, $columns = [])
     {
         return EntryCollection::make($items)->map(function ($model) {
-            return Entry::fromModel($model);
+            return app('statamic.eloquent.entries.entry')::fromModel($model);
         });
     }
 

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -11,7 +11,7 @@ class EntryRepository extends StacheRepository
     public static function bindings(): array
     {
         return [
-            EntryContract::class => Entry::class,
+            EntryContract::class => app('statamic.eloquent.entries.entry'),
             QueryBuilder::class => EntryQueryBuilder::class,
         ];
     }

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Statamic\Eloquent\Globals;
+
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Globals\GlobalSet as GlobalSetContract;
+use Statamic\Eloquent\Taxonomies\Taxonomy;
+use Statamic\Eloquent\Taxonomies\TaxonomyModel;
+use Statamic\Globals\GlobalCollection;
+use \Statamic\Stache\Repositories\GlobalRepository as StacheRepository;
+
+
+class GlobalRepository extends StacheRepository
+{
+
+    protected function transform($items, $columns = [])
+    {
+        return GlobalCollection::make($items)->map(function ($model) {
+            return GlobalSet::fromModel($model);
+        });
+    }
+
+
+    public static function bindings(): array
+    {
+        return [
+            GlobalSetContract::class => GlobalSet::class,
+        ];
+    }
+
+    public function find($handle): ?GlobalSetContract
+    {
+        return app(GlobalSetContract::class)->fromModel(GlobalSetModel::whereHandle($handle)->firstOrFail());
+    }
+
+    public function findByHandle($handle): ?GlobalSetContract
+    {
+        return app(GlobalSetContract::class)->fromModel(GlobalSetModel::whereHandle($handle)->firstOrFail());
+    }
+
+    public function all(): GlobalCollection
+    {
+        return $this->transform(GlobalSetModel::all());
+    }
+
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+}

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -1,15 +1,10 @@
 <?php
 
-
 namespace Statamic\Eloquent\Globals;
 
-use Illuminate\Support\Collection;
 use Statamic\Contracts\Globals\GlobalSet as GlobalSetContract;
-use Statamic\Eloquent\Taxonomies\Taxonomy;
-use Statamic\Eloquent\Taxonomies\TaxonomyModel;
 use Statamic\Globals\GlobalCollection;
-use \Statamic\Stache\Repositories\GlobalRepository as StacheRepository;
-
+use Statamic\Stache\Repositories\GlobalRepository as StacheRepository;
 
 class GlobalRepository extends StacheRepository
 {
@@ -19,7 +14,6 @@ class GlobalRepository extends StacheRepository
             return GlobalSet::fromModel($model);
         });
     }
-
 
     public function find($handle): ?GlobalSetContract
     {
@@ -35,7 +29,6 @@ class GlobalRepository extends StacheRepository
     {
         return $this->transform(GlobalSetModel::all());
     }
-
 
     public function save($entry)
     {

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -13,7 +13,6 @@ use \Statamic\Stache\Repositories\GlobalRepository as StacheRepository;
 
 class GlobalRepository extends StacheRepository
 {
-
     protected function transform($items, $columns = [])
     {
         return GlobalCollection::make($items)->map(function ($model) {
@@ -21,13 +20,6 @@ class GlobalRepository extends StacheRepository
         });
     }
 
-
-    public static function bindings(): array
-    {
-        return [
-            GlobalSetContract::class => GlobalSet::class,
-        ];
-    }
 
     public function find($handle): ?GlobalSetContract
     {
@@ -57,5 +49,12 @@ class GlobalRepository extends StacheRepository
     public function delete($entry)
     {
         $entry->model()->delete();
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            GlobalSetContract::class => GlobalSet::class,
+        ];
     }
 }

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace Statamic\Eloquent\Globals;
+
+
+use Statamic\Eloquent\Taxonomies\Term;
+use Statamic\Eloquent\Globals\GlobalSetModel as Model;
+use Statamic\Globals\GlobalSet as FileEntry;
+
+class GlobalSet extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        $global = (new static)
+            ->handle($model->handle)
+            ->title($model->title)
+            ->model($model);
+
+        foreach($model->localizations as $localization) {
+            $global->addLocalization(Variables::fromModel(VariablesModel::make($localization)));
+        }
+
+        return $global;
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.global-sets.model');
+
+        $localizations = $this->localizations()->map(function($value, $key) {
+            return $value->toModel()->toArray();
+        });
+
+        return $class::findOrNew($this->model?->id)->fill([
+            'handle' => $this->handle(),
+            'title' => $this->title(),
+            'localizations' => $localizations,
+        ]);
+    }
+
+    public function makeLocalization($site)
+    {
+        return (new Variables)
+            ->globalSet($this)
+            ->locale($site);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        $this->id($model->id);
+
+        return $this;
+    }
+}

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace Statamic\Eloquent\Globals;
 
-
-use Statamic\Eloquent\Taxonomies\Term;
 use Statamic\Eloquent\Globals\GlobalSetModel as Model;
 use Statamic\Globals\GlobalSet as FileEntry;
 
@@ -19,7 +16,7 @@ class GlobalSet extends FileEntry
             ->title($model->title)
             ->model($model);
 
-        foreach($model->localizations as $localization) {
+        foreach ($model->localizations as $localization) {
             $global->addLocalization(Variables::fromModel(VariablesModel::make($localization)));
         }
 
@@ -30,7 +27,7 @@ class GlobalSet extends FileEntry
     {
         $class = app('statamic.eloquent.global-sets.model');
 
-        $localizations = $this->localizations()->map(function($value, $key) {
+        $localizations = $this->localizations()->map(function ($value, $key) {
             return $value->toModel()->toArray();
         });
 

--- a/src/Globals/GlobalSetModel.php
+++ b/src/Globals/GlobalSetModel.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Statamic\Eloquent\Globals;
+
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
+
+class GlobalSetModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'global_sets';
+
+    protected $casts = [
+        'localizations' => 'json'
+    ];
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
+    }
+}

--- a/src/Globals/GlobalSetModel.php
+++ b/src/Globals/GlobalSetModel.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Statamic\Eloquent\Globals;
-
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Support\Arr;
@@ -14,7 +12,7 @@ class GlobalSetModel extends Eloquent
     protected $table = 'global_sets';
 
     protected $casts = [
-        'localizations' => 'json'
+        'localizations' => 'json',
     ];
 
     public function getAttribute($key)

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Statamic\Eloquent\Globals;
 
 use Statamic\Eloquent\Globals\VariablesModel as Model;
@@ -23,8 +22,7 @@ class Variables extends FileEntry
 
         return $class::make([
             'locale' => $this->locale,
-            'data' => $data ,
+            'data' => $data,
         ]);
     }
-
 }

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Statamic\Eloquent\Globals;
+
+use Statamic\Eloquent\Globals\VariablesModel as Model;
+use Statamic\Globals\Variables as FileEntry;
+
+class Variables extends FileEntry
+{
+    public static function fromModel(Model $model)
+    {
+        return (new static)
+            ->locale($model->locale)
+            ->data($model->data);
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.variables.model');
+
+        $data = $this->data();
+
+        return $class::make([
+            'locale' => $this->locale,
+            'data' => $data ,
+        ]);
+    }
+
+}

--- a/src/Globals/VariablesModel.php
+++ b/src/Globals/VariablesModel.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Statamic\Eloquent\Globals;
-
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Support\Arr;

--- a/src/Globals/VariablesModel.php
+++ b/src/Globals/VariablesModel.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Statamic\Eloquent\Globals;
+
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
+
+class VariablesModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'global_set_variables';
+
+    protected $casts = [
+
+    ];
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -61,6 +61,10 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.entries.model', function () {
             return config('statamic-eloquent-driver.entries.model');
         });
+
+        $this->app->bind('statamic.eloquent.collections.model', function () {
+            return config('statamic-eloquent-driver.collections.model');
+        });
     }
 
     public function registerTaxonomies()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,11 +4,11 @@ namespace Statamic\Eloquent;
 
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
-use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
-use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
 use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
 use Statamic\Contracts\Structures\NavigationRepository as NavigationRepositoryContract;
 use Statamic\Contracts\Structures\NavTreeRepository as NavTreeRepositoryContract;
+use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
+use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
 use Statamic\Eloquent\Commands\ImportEntries;
 use Statamic\Eloquent\Entries\CollectionRepository;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,15 +5,17 @@ namespace Statamic\Eloquent;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
 use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
+use Statamic\Contracts\Structures\CollectionTreeRepository as CollectionTreeRepositoryContract;
 use Statamic\Contracts\Structures\NavigationRepository as NavigationRepositoryContract;
 use Statamic\Contracts\Structures\NavTreeRepository as NavTreeRepositoryContract;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
+use Statamic\Eloquent\Collections\CollectionRepository;
 use Statamic\Eloquent\Commands\ImportEntries;
-use Statamic\Eloquent\Entries\CollectionRepository;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\EntryRepository;
 use Statamic\Eloquent\Globals\GlobalRepository;
+use Statamic\Eloquent\Structures\CollectionTreeRepository;
 use Statamic\Eloquent\Structures\NavigationRepository;
 use Statamic\Eloquent\Structures\NavTreeRepository;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
@@ -42,6 +44,7 @@ class ServiceProvider extends AddonServiceProvider
     public function register()
     {
         $this->registerEntries();
+        $this->registerCollections();
         $this->registerTaxonomies();
         $this->registerGlobals();
         $this->registerStructures();
@@ -50,7 +53,6 @@ class ServiceProvider extends AddonServiceProvider
     protected function registerEntries()
     {
         Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
-        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
 
         $this->app->bind(EntryQueryBuilder::class, function ($app) {
             return new EntryQueryBuilder(
@@ -61,9 +63,19 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.entries.model', function () {
             return config('statamic-eloquent-driver.entries.model');
         });
+    }
+
+    protected function registerCollections()
+    {
+        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
+        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
 
         $this->app->bind('statamic.eloquent.collections.model', function () {
             return config('statamic-eloquent-driver.collections.model');
+        });
+
+        $this->app->bind('statamic.eloquent.trees.model', function () {
+            return config('statamic-eloquent-driver.trees.model');
         });
     }
 
@@ -109,8 +121,8 @@ class ServiceProvider extends AddonServiceProvider
             return config('statamic-eloquent-driver.navigations.model');
         });
 
-        $this->app->bind('statamic.eloquent.nav-trees.model', function () {
-            return config('statamic-eloquent-driver.nav-trees.model');
+        $this->app->bind('statamic.eloquent.trees.model', function () {
+            return config('statamic-eloquent-driver.trees.model');
         });
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,11 +4,16 @@ namespace Statamic\Eloquent;
 
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
+use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
+use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
 use Statamic\Eloquent\Commands\ImportEntries;
 use Statamic\Eloquent\Entries\CollectionRepository;
 use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\EntryRepository;
+use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
+use Statamic\Eloquent\Taxonomies\TermQueryBuilder;
+use Statamic\Eloquent\Taxonomies\TermRepository;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -32,6 +37,7 @@ class ServiceProvider extends AddonServiceProvider
     public function register()
     {
         $this->registerEntries();
+        $this->registerTaxonomies();
     }
 
     protected function registerEntries()
@@ -48,5 +54,27 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.entries.model', function () {
             return config('statamic-eloquent-driver.entries.model');
         });
+    }
+
+    public function registerTaxonomies()
+    {
+        Statamic::repository(TaxonomyRepositoryContract::class, TaxonomyRepository::class);
+        Statamic::repository(TermRepositoryContract::class, TermRepository::class);
+
+        $this->app->bind(TermQueryBuilder::class, function ($app) {
+            return new TermQueryBuilder(
+                $app['statamic.eloquent.terms.model']::query()
+            );
+        });
+
+        $this->app->bind('statamic.eloquent.terms.model', function () {
+            return config('statamic-eloquent-driver.terms.model');
+        });
+
+        $this->app->bind('statamic.eloquent.taxonomies.model', function () {
+            return config('statamic-eloquent-driver.taxonomies.model');
+        });
+
+
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -52,16 +52,20 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function registerEntries()
     {
+        $this->app->bind('statamic.eloquent.entries.entry', function () {
+            return config('statamic-eloquent-driver.entries.entry');
+        });
+
+        $this->app->bind('statamic.eloquent.entries.model', function () {
+            return config('statamic-eloquent-driver.entries.model');
+        });
+
         Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
 
         $this->app->bind(EntryQueryBuilder::class, function ($app) {
             return new EntryQueryBuilder(
                 $app['statamic.eloquent.entries.model']::query()
             );
-        });
-
-        $this->app->bind('statamic.eloquent.entries.model', function () {
-            return config('statamic-eloquent-driver.entries.model');
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,11 +6,13 @@ use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContr
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
+use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
 use Statamic\Eloquent\Commands\ImportEntries;
 use Statamic\Eloquent\Entries\CollectionRepository;
 use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\EntryRepository;
+use Statamic\Eloquent\Globals\GlobalRepository;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
 use Statamic\Eloquent\Taxonomies\TermQueryBuilder;
 use Statamic\Eloquent\Taxonomies\TermRepository;
@@ -38,6 +40,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         $this->registerEntries();
         $this->registerTaxonomies();
+        $this->registerGlobals();
     }
 
     protected function registerEntries()
@@ -76,5 +79,18 @@ class ServiceProvider extends AddonServiceProvider
         });
 
 
+    }
+
+    private function registerGlobals()
+    {
+        Statamic::repository(GlobalRepositoryContract::class, GlobalRepository::class);
+
+        $this->app->bind('statamic.eloquent.global-sets.model', function () {
+            return config('statamic-eloquent-driver.global-sets.model');
+        });
+
+        $this->app->bind('statamic.eloquent.variables.model', function () {
+            return config('statamic-eloquent-driver.variables.model');
+        });
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,12 +7,15 @@ use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
 use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
+use Statamic\Contracts\Structures\NavigationRepository as NavigationRepositoryContract;
+use Statamic\Contracts\Structures\NavTreeRepository as NavTreeRepositoryContract;
 use Statamic\Eloquent\Commands\ImportEntries;
 use Statamic\Eloquent\Entries\CollectionRepository;
-use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\EntryRepository;
 use Statamic\Eloquent\Globals\GlobalRepository;
+use Statamic\Eloquent\Structures\NavigationRepository;
+use Statamic\Eloquent\Structures\NavTreeRepository;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
 use Statamic\Eloquent\Taxonomies\TermQueryBuilder;
 use Statamic\Eloquent\Taxonomies\TermRepository;
@@ -41,6 +44,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerEntries();
         $this->registerTaxonomies();
         $this->registerGlobals();
+        $this->registerStructures();
     }
 
     protected function registerEntries()
@@ -77,8 +81,6 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.taxonomies.model', function () {
             return config('statamic-eloquent-driver.taxonomies.model');
         });
-
-
     }
 
     private function registerGlobals()
@@ -91,6 +93,20 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->app->bind('statamic.eloquent.variables.model', function () {
             return config('statamic-eloquent-driver.variables.model');
+        });
+    }
+
+    private function registerStructures()
+    {
+        Statamic::repository(NavigationRepositoryContract::class, NavigationRepository::class);
+        Statamic::repository(NavTreeRepositoryContract::class, NavTreeRepository::class);
+
+        $this->app->bind('statamic.eloquent.navigations.model', function () {
+            return config('statamic-eloquent-driver.navigations.model');
+        });
+
+        $this->app->bind('statamic.eloquent.nav-trees.model', function () {
+            return config('statamic-eloquent-driver.nav-trees.model');
         });
     }
 }

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Structures\CollectionStructure as StatamicCollectionStructure;
+
+class CollectionStructure extends StatamicCollectionStructure
+{
+    public function newTreeInstance()
+    {
+        return new CollectionTree;
+    }
+}

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Eloquent\Structures\TreeModel as Model;
+use Statamic\Structures\CollectionTree as FileEntry;
+use Statamic\Structures\CollectionTreeDiff;
+
+class CollectionTree extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        return (new static)
+            ->tree($model->tree)
+            ->handle($model->handle)
+            ->locale($model->locale)
+            ->initialPath($model->initialPath)
+            ->syncOriginal()
+            ->model($model);
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.trees.model');
+
+        return $class::findOrNew($this->model?->id)->fill([
+            'handle' => $this->handle(),
+            'initialPath' => $this->initialPath(),
+            'locale' => $this->locale(),
+            'tree' => $this->tree,
+            'type' => 'collection',
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        return $this;
+    }
+}

--- a/src/Structures/CollectionTreeRepository.php
+++ b/src/Structures/CollectionTreeRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Contracts\Structures\Tree as TreeContract;
+use Statamic\Stache\Repositories\CollectionTreeRepository as StacheRepository;
+
+class CollectionTreeRepository extends StacheRepository
+{
+    public function find(string $handle, string $site): ?TreeContract
+    {
+        $model = TreeModel::whereHandle($handle)
+            ->whereType('collection')
+            ->first();
+
+        return $model
+            ? app(CollectionTree::class)->fromModel($model)
+            : null;
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+}

--- a/src/Structures/CollectionTreeRepository.php
+++ b/src/Structures/CollectionTreeRepository.php
@@ -10,6 +10,7 @@ class CollectionTreeRepository extends StacheRepository
     public function find(string $handle, string $site): ?TreeContract
     {
         $model = TreeModel::whereHandle($handle)
+            ->where('locale', $site)
             ->whereType('collection')
             ->first();
 

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Structures\Nav as FileEntry;
+use Statamic\Eloquent\Structures\NavModel as Model;
+
+class Nav extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+       return (new static)
+            ->handle($model->handle)
+            ->title($model->title)
+            ->collections($model->collections)
+            ->maxDepth($model->maxDepth)
+            ->expectsRoot($model->expectsRoot)
+            ->initialPath($model->initialPath)
+            ->model($model);
+    }
+
+    public function newTreeInstance()
+    {
+        return new NavTree;
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.navigations.model');
+
+        return $class::findOrNew($this->model?->id)->fill([
+            'handle' => $this->handle(),
+            'title' => $this->title(),
+            'collections' => $this->collections()->map->handle(),
+            'maxDepth' => $this->maxDepth(),
+            'expectsRoot' => $this->expectsRoot(),
+            'initialPath' => $this->initialPath(),
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        $this->id($model->id);
+
+        return $this;
+    }
+}

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -1,10 +1,9 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Structures\Nav as FileEntry;
 use Statamic\Eloquent\Structures\NavModel as Model;
+use Statamic\Structures\Nav as FileEntry;
 
 class Nav extends FileEntry
 {
@@ -12,7 +11,7 @@ class Nav extends FileEntry
 
     public static function fromModel(Model $model)
     {
-       return (new static)
+        return (new static)
             ->handle($model->handle)
             ->title($model->title)
             ->collections($model->collections)

--- a/src/Structures/NavModel.php
+++ b/src/Structures/NavModel.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
-
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 

--- a/src/Structures/NavModel.php
+++ b/src/Structures/NavModel.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class NavModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'navigations';
+
+    protected $casts = [
+        'collections' => 'json',
+        'expectsRoot' => 'boolean',
+        'maxDepth' => 'integer',
+    ];
+}

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Eloquent\Structures\NavTree as Model;
+use Statamic\Eloquent\Structures\TreeModel as Model;
 use Statamic\Structures\NavTree as FileEntry;
 
 class NavTree extends FileEntry

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -1,10 +1,9 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Structures\NavTree as FileEntry;
 use Statamic\Eloquent\Structures\NavTreeModel as Model;
+use Statamic\Structures\NavTree as FileEntry;
 
 class NavTree extends FileEntry
 {
@@ -42,5 +41,4 @@ class NavTree extends FileEntry
 
         return $this;
     }
-
 }

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Structures\NavTree as FileEntry;
+use Statamic\Eloquent\Structures\NavTreeModel as Model;
+
+class NavTree extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        return (new static)
+            ->tree($model->tree)
+            ->handle($model->handle)
+            ->locale($model->locale)
+            ->initialPath($model->initialPath)
+            ->model($model);
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.nav-trees.model');
+
+        return $class::findOrNew($this->model?->id)->fill([
+            'handle' => $this->handle(),
+            'initialPath' => $this->initialPath(),
+            'locale' => $this->locale(),
+            'tree' => $this->tree,
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        return $this;
+    }
+
+}

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Eloquent\Structures\NavTreeModel as Model;
+use Statamic\Eloquent\Structures\NavTree as Model;
 use Statamic\Structures\NavTree as FileEntry;
 
 class NavTree extends FileEntry
@@ -21,13 +21,14 @@ class NavTree extends FileEntry
 
     public function toModel()
     {
-        $class = app('statamic.eloquent.nav-trees.model');
+        $class = app('statamic.eloquent.trees.model');
 
         return $class::findOrNew($this->model?->id)->fill([
             'handle' => $this->handle(),
             'initialPath' => $this->initialPath(),
             'locale' => $this->locale(),
             'tree' => $this->tree,
+            'type' => 'navigation',
         ]);
     }
 

--- a/src/Structures/NavTreeModel.php
+++ b/src/Structures/NavTreeModel.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
-
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 

--- a/src/Structures/NavTreeModel.php
+++ b/src/Structures/NavTreeModel.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class NavTreeModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'navigation_trees';
+
+    protected $casts = [
+        'tree' => 'json',
+    ];
+}

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -11,6 +11,7 @@ class NavTreeRepository extends StacheRepository
     {
         $model = TreeModel::whereHandle($handle)
             ->whereType('navigation')
+            ->where('locale', $site)
             ->first();
 
         return $model

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -9,7 +9,9 @@ class NavTreeRepository extends StacheRepository
 {
     public function find(string $handle, string $site): ?TreeContract
     {
-        $model = NavTreeModel::whereHandle($handle)->first();
+        $model = TreeModel::whereHandle($handle)
+            ->whereType('navigation')
+            ->first();
 
         return $model
             ? app(TreeContract::class)->fromModel($model)

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+use Statamic\Contracts\Structures\Tree as TreeContract;
+use Statamic\Stache\Repositories\NavTreeRepository as StacheRepository;
+
+class NavTreeRepository extends StacheRepository
+{
+    public function find(string $handle, string $site): ?TreeContract
+    {
+        $model = NavTreeModel::whereHandle($handle)->first();
+        return $model
+            ? app(TreeContract::class)->fromModel($model)
+            : null;
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+
+    public static function bindings()
+    {
+        return [
+            TreeContract::class => NavTree::class,
+        ];
+    }
+}

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
 
 use Statamic\Contracts\Structures\Tree as TreeContract;
@@ -11,6 +10,7 @@ class NavTreeRepository extends StacheRepository
     public function find(string $handle, string $site): ?TreeContract
     {
         $model = NavTreeModel::whereHandle($handle)->first();
+
         return $model
             ? app(TreeContract::class)->fromModel($model)
             : null;

--- a/src/Structures/NavigationRepository.php
+++ b/src/Structures/NavigationRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace Statamic\Eloquent\Structures;
+
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Structures\Nav as NavContract;
+use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
+use Statamic\Eloquent\Taxonomies\Taxonomy;
+use Statamic\Eloquent\Taxonomies\TaxonomyModel;
+use Statamic\Stache\Repositories\NavigationRepository as StacheRepository;
+
+class NavigationRepository extends StacheRepository
+{
+    protected function transform($items, $columns = [])
+    {
+        return Collection::make($items)->map(function ($model) {
+            return Nav::fromModel($model);
+        });
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            NavContract::class => Nav::class,
+        ];
+    }
+
+    public function all(): Collection
+    {
+        return $this->transform(NavModel::all());
+    }
+
+    public function findByHandle($handle): ?NavContract
+    {
+        $model = NavModel::whereHandle($handle)->first();
+        return $model
+            ? app(NavContract::class)->fromModel($model)
+            : null;
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+}

--- a/src/Structures/NavigationRepository.php
+++ b/src/Structures/NavigationRepository.php
@@ -1,13 +1,9 @@
 <?php
 
-
 namespace Statamic\Eloquent\Structures;
 
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Structures\Nav as NavContract;
-use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
-use Statamic\Eloquent\Taxonomies\Taxonomy;
-use Statamic\Eloquent\Taxonomies\TaxonomyModel;
 use Statamic\Stache\Repositories\NavigationRepository as StacheRepository;
 
 class NavigationRepository extends StacheRepository
@@ -34,6 +30,7 @@ class NavigationRepository extends StacheRepository
     public function findByHandle($handle): ?NavContract
     {
         $model = NavModel::whereHandle($handle)->first();
+
         return $model
             ? app(NavContract::class)->fromModel($model)
             : null;

--- a/src/Structures/TreeModel.php
+++ b/src/Structures/TreeModel.php
@@ -4,11 +4,11 @@ namespace Statamic\Eloquent\Structures;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class NavTreeModel extends Eloquent
+class TreeModel extends Eloquent
 {
     protected $guarded = [];
 
-    protected $table = 'navigation_trees';
+    protected $table = 'trees';
 
     protected $casts = [
         'tree' => 'json',

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Statamic\Eloquent\Taxonomies\TaxonomyModel as Model;
+use Statamic\Taxonomies\Taxonomy  as FileEntry;
+
+class Taxonomy extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        return (new static)
+            ->handle($model->handle)
+            ->title($model->title)
+            ->model($model);
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.taxonomies.model');
+
+        return $class::findOrNew($this->id())->fill([
+            'handle' => $this->handle(),
+            'title' => $this->title(),
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        $this->id($model->id);
+
+        return $this;
+    }
+}

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -21,7 +21,7 @@ class Taxonomy extends FileEntry
     {
         $class = app('statamic.eloquent.taxonomies.model');
 
-        return $class::findOrNew($this->id())->fill([
+        return $class::findOrNew($this->model?->id)->fill([
             'handle' => $this->handle(),
             'title' => $this->title(),
         ]);

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -14,6 +14,7 @@ class Taxonomy extends FileEntry
         return (new static)
             ->handle($model->handle)
             ->title($model->title)
+            ->sites($model->sites)
             ->model($model);
     }
 
@@ -24,6 +25,7 @@ class Taxonomy extends FileEntry
         return $class::findOrNew($this->model?->id)->fill([
             'handle' => $this->handle(),
             'title' => $this->title(),
+            'sites' => $this->sites,
         ]);
     }
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -25,7 +25,7 @@ class Taxonomy extends FileEntry
         return $class::findOrNew($this->model?->id)->fill([
             'handle' => $this->handle(),
             'title' => $this->title(),
-            'sites' => $this->sites,
+            'sites' => $this->sites(),
         ]);
     }
 

--- a/src/Taxonomies/TaxonomyModel.php
+++ b/src/Taxonomies/TaxonomyModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
+
+class TaxonomyModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'taxonomies';
+
+    protected $casts = [
+
+    ];
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
+    }
+}

--- a/src/Taxonomies/TaxonomyModel.php
+++ b/src/Taxonomies/TaxonomyModel.php
@@ -12,7 +12,7 @@ class TaxonomyModel extends Eloquent
     protected $table = 'taxonomies';
 
     protected $casts = [
-
+        'sites' => 'json',
     ];
 
     public function getAttribute($key)

--- a/src/Taxonomies/TaxonomyRepository.php
+++ b/src/Taxonomies/TaxonomyRepository.php
@@ -2,10 +2,9 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
-use \Statamic\Stache\Repositories\TaxonomyRepository as StacheRepository;
+use Statamic\Stache\Repositories\TaxonomyRepository as StacheRepository;
 
 class TaxonomyRepository extends StacheRepository
 {
@@ -31,6 +30,7 @@ class TaxonomyRepository extends StacheRepository
     public function findByHandle($handle): ?TaxonomyContract
     {
         $taxonomyModel = TaxonomyModel::whereHandle($handle)->first();
+
         return $taxonomyModel
             ? app(TaxonomyContract::class)->fromModel($taxonomyModel)
             : null;

--- a/src/Taxonomies/TaxonomyRepository.php
+++ b/src/Taxonomies/TaxonomyRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
+use \Statamic\Stache\Repositories\TaxonomyRepository as StacheRepository;
+class TaxonomyRepository extends StacheRepository
+{
+    protected function transform($items, $columns = [])
+    {
+        return Collection::make($items)->map(function ($model) {
+            return Taxonomy::fromModel($model);
+        });
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            TaxonomyContract::class => Taxonomy::class,
+        ];
+    }
+
+    public function all(): Collection
+    {
+        return $this->transform(TaxonomyModel::all());
+    }
+
+
+    public function findByHandle($handle): ?TaxonomyContract
+    {
+        return app(TaxonomyContract::class)->fromModel(TaxonomyModel::whereHandle($handle)->firstOrFail());
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+}

--- a/src/Taxonomies/TaxonomyRepository.php
+++ b/src/Taxonomies/TaxonomyRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
 use \Statamic\Stache\Repositories\TaxonomyRepository as StacheRepository;
+
 class TaxonomyRepository extends StacheRepository
 {
     protected function transform($items, $columns = [])
@@ -27,10 +28,12 @@ class TaxonomyRepository extends StacheRepository
         return $this->transform(TaxonomyModel::all());
     }
 
-
     public function findByHandle($handle): ?TaxonomyContract
     {
-        return app(TaxonomyContract::class)->fromModel(TaxonomyModel::whereHandle($handle)->firstOrFail());
+        $taxonomyModel = TaxonomyModel::whereHandle($handle)->first();
+        return $taxonomyModel
+            ? app(TaxonomyContract::class)->fromModel($taxonomyModel)
+            : null;
     }
 
     public function save($entry)

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -32,6 +32,7 @@ class Term extends FileEntry
         if ($this->blueprint && $this->taxonomy()->termBlueprints()->count() > 1) {
             $data['blueprint'] = $this->blueprint;
         }
+
         return $class::findOrNew($this->model?->id)->fill([
             'site' => $this->locale(),
             'slug' => $this->slug(),

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -19,6 +19,10 @@ class Term extends FileEntry
         $term = $term->model($model);
         $term = $term->blueprint($model->data['blueprint'] ?? null);
 
+        collect($model->data['localizations'] ?? [])->each(function ($data, $locale) use ($term) {
+            $term->dataForLocale($locale, $data);
+        });
+
         return $term;
     }
 
@@ -31,6 +35,12 @@ class Term extends FileEntry
         if ($this->blueprint && $this->taxonomy()->termBlueprints()->count() > 1) {
             $data['blueprint'] = $this->blueprint;
         }
+
+        $data['localizations'] = $this->localizations()->keys()->reduce(function ($localizations, $locale) {
+            $localizations[$locale] = $this->dataForLocale($locale)->toArray();
+
+            return $localizations;
+        }, []);
 
         return $class::findOrNew($this->model?->id)->fill([
             'site' => $this->locale(),

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Statamic\Eloquent\Taxonomies\TermModel as Model;
+use Statamic\Taxonomies\Term as FileEntry;
+
+class Term extends FileEntry
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        /** @var Term $term */
+        $term = new static;
+        $term = $term->slug($model->slug);
+        $term = $term->taxonomy($model->taxonomy);
+        $term = $term->data($model->data);
+        $term = $term->model($model);
+        $term = $term->blueprint($model->data['blueprint'] ?? null);
+
+
+        return $term;
+    }
+
+    public function toModel()
+    {
+        $class = app('statamic.eloquent.terms.model');
+
+        $data = $this->data();
+
+        if ($this->blueprint && $this->taxonomy()->termBlueprints()->count() > 1) {
+            $data['blueprint'] = $this->blueprint;
+        }
+        return $class::findOrNew($this->model?->id)->fill([
+            'site' => $this->locale(),
+            'slug' => $this->slug(),
+            'uri' => $this->uri(),
+            'taxonomy' => $this->taxonomy(),
+            'data' => $data,
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        $this->id($model->id);
+
+        return $this;
+    }
+
+    public function lastModified()
+    {
+        return $this->model->updated_at;
+    }
+}

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -19,7 +19,6 @@ class Term extends FileEntry
         $term = $term->model($model);
         $term = $term->blueprint($model->data['blueprint'] ?? null);
 
-
         return $term;
     }
 

--- a/src/Taxonomies/TermModel.php
+++ b/src/Taxonomies/TermModel.php
@@ -9,7 +9,7 @@ class TermModel extends Eloquent
 {
     protected $guarded = [];
 
-    protected $table = 'terms';
+    protected $table = 'taxonomy_terms';
 
     protected $casts = [
         'data' => 'json',

--- a/src/Taxonomies/TermModel.php
+++ b/src/Taxonomies/TermModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Arr;
+
+class TermModel extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $table = 'terms';
+
+    protected $casts = [
+        'data' => 'json',
+    ];
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
+    }
+}

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
+use Statamic\Facades\Site;
 use Statamic\Query\EloquentQueryBuilder;
 use Statamic\Taxonomies\TermCollection;
 
@@ -15,8 +16,13 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     protected function transform($items, $columns = [])
     {
-        return TermCollection::make($items)->map(function ($model) {
-            return Term::fromModel($model)->in($this->site);
+        $site = $this->site;
+        if(!$site) {
+            $site = Site::default()->handle();
+        }
+
+        return TermCollection::make($items)->map(function ($model) use($site) {
+            return Term::fromModel($model)->in($site);
         });
     }
 

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -7,6 +7,8 @@ use Statamic\Taxonomies\TermCollection;
 
 class TermQueryBuilder extends EloquentQueryBuilder
 {
+    protected $site = null;
+
     protected $columns = [
         'id', 'site', 'slug', 'uri', 'taxonomy', 'created_at', 'updated_at',
     ];
@@ -14,7 +16,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
     protected function transform($items, $columns = [])
     {
         return TermCollection::make($items)->map(function ($model) {
-            return Term::fromModel($model);
+            return Term::fromModel($model)->in($this->site);
         });
     }
 
@@ -25,5 +27,16 @@ class TermQueryBuilder extends EloquentQueryBuilder
         }
 
         return $column;
+    }
+
+    public function where($column, $operator = null, $value = null)
+    {
+        if ($column === 'site') {
+            $this->site = $operator;
+
+            return $this;
+        }
+
+        return parent::where($column, $operator, $value);
     }
 }

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Statamic\Eloquent\Entries\Entry;
+use Statamic\Entries\EntryCollection;
+use Statamic\Query\EloquentQueryBuilder;
+use Statamic\Taxonomies\TermCollection;
+
+
+class TermQueryBuilder extends EloquentQueryBuilder
+{
+    protected $columns = [
+        'id', 'site', 'slug', 'uri', 'taxonomy', 'created_at', 'updated_at',
+    ];
+
+    protected function transform($items, $columns = [])
+    {
+        return TermCollection::make($items)->map(function ($model) {
+            return Term::fromModel($model);
+        });
+    }
+
+    protected function column($column)
+    {
+        if ($column == 'origin') {
+            $column = 'origin_id';
+        }
+
+        if (! in_array($column, $this->columns)) {
+            $column = 'data->'.$column;
+        }
+
+        return $column;
+    }
+}

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -1,13 +1,9 @@
 <?php
 
-
 namespace Statamic\Eloquent\Taxonomies;
 
-use Statamic\Eloquent\Entries\Entry;
-use Statamic\Entries\EntryCollection;
 use Statamic\Query\EloquentQueryBuilder;
 use Statamic\Taxonomies\TermCollection;
-
 
 class TermQueryBuilder extends EloquentQueryBuilder
 {
@@ -24,10 +20,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     protected function column($column)
     {
-        if ($column == 'origin') {
-            $column = 'origin_id';
-        }
-
         if (! in_array($column, $this->columns)) {
             $column = 'data->'.$column;
         }

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
-use Illuminate\Database\Eloquent\Builder;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Stache\Repositories\TermRepository as StacheRepository;
 

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Statamic\Eloquent\Taxonomies;
+
+use Illuminate\Database\Eloquent\Builder;
+use Statamic\Contracts\Taxonomies\Term as TermContract;
+use Statamic\Stache\Repositories\TermRepository as StacheRepository;
+
+class TermRepository extends StacheRepository
+{
+    public function query()
+    {
+        $this->ensureAssociations();
+
+        return app(TermQueryBuilder::class);
+    }
+
+    public function find($id): ?Term
+    {
+        [$handle, $slug] = explode('::', $id);
+
+        $term = $this->query()
+            ->where('taxonomy', $handle)
+            ->where('slug', $slug);
+        $term = $term->first();
+
+        return $term;
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            TermContract::class => Term::class,
+        ];
+    }
+}

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -15,7 +15,7 @@ class TermRepository extends StacheRepository
         return app(TermQueryBuilder::class);
     }
 
-    public function find($id): LocalizedTerm
+    public function find($id): ?LocalizedTerm
     {
         [$handle, $slug] = explode('::', $id);
 

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Eloquent\Taxonomies;
 
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Stache\Repositories\TermRepository as StacheRepository;
+use Statamic\Taxonomies\LocalizedTerm;
 
 class TermRepository extends StacheRepository
 {
@@ -14,7 +15,7 @@ class TermRepository extends StacheRepository
         return app(TermQueryBuilder::class);
     }
 
-    public function find($id): ?Term
+    public function find($id): LocalizedTerm
     {
         [$handle, $slug] = explode('::', $id);
 


### PR DESCRIPTION
For large applications where we have a lot of data we like to save it to the database as the repo will become to large otherwise (Several Gigabytes).

This Package did help a lot by providing a way to save the entities to the Database. Although, many inconsistencies arise when Taxonomies, Globals or Navigation links to entities IDs. The main problem is, that e.g. after changing the order of a page Collection, the tree is enriched with DB IDs. When pushing this code to a staging environment, other IDs exists and many pages are broken when Entries were not found.

For this reason, we extended the eloquent-driver to add support for all types of data.

If you have any feedback and like to have this PR in this package I will clean it and test it even more.

## TODO:
- [x] taxonomies
- [x] navigations
- [x] globals 
- [x] collections
- [ ] form submissions
- [ ] test multisite 
- [ ] cleanup
- [x] ensure new slug mechanism is working (https://github.com/statamic/cms/issues/714#issuecomment-856150217)