### PR TITLE
Fix multisite selector

### DIFF
--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
+use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\UuidEntryModel;
 use Statamic\Facades\Entry;
 use Statamic\Stache\Repositories\CollectionRepository;
@@ -75,7 +76,7 @@ class ImportEntries extends Command
             'uri' => $entry->uri(),
             'date' => $entry->hasDate() ? $entry->date() : null,
             'collection' => $entry->collectionHandle(),
-            'data' => $entry->data(),
+            'data' => $entry->data()->except(EntryQueryBuilder::COLUMNS),
             'published' => $entry->published(),
             'status' => $entry->status(),
         ]);

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -79,6 +79,8 @@ class ImportEntries extends Command
             'data' => $entry->data()->except(EntryQueryBuilder::COLUMNS),
             'published' => $entry->published(),
             'status' => $entry->status(),
+            'created_at' => $entry->lastModified(),
+            'updated_at' => $entry->lastModified(),
         ]);
     }
 }

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -19,7 +19,7 @@ class EntryModel extends Eloquent
 
     public function origin()
     {
-        return $this->belongsTo(self::class);
+        return $this->belongsTo(static::class);
     }
 
     public function getAttribute($key)

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -24,6 +24,13 @@ class EntryModel extends Eloquent
 
     public function getAttribute($key)
     {
+        // Because the import script was importing `updated_at` into the
+        // json data column, we will explicitly reference other SQL
+        // columns first to prevent errors with that bad data.
+        if (in_array($key, EntryQueryBuilder::COLUMNS)) {
+            return parent::getAttribute($key);
+        }
+
         return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
     }
 }

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -11,7 +11,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {
     use QueriesTaxonomizedEntries;
 
-    protected $columns = [
+    const COLUMNS = [
         'id', 'site', 'origin_id', 'published', 'status', 'slug', 'uri',
         'date', 'collection', 'created_at', 'updated_at',
     ];
@@ -29,7 +29,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             $column = 'origin_id';
         }
 
-        if (! in_array($column, $this->columns)) {
+        if (! in_array($column, self::COLUMNS)) {
             $column = 'data->'.$column;
         }
 


### PR DESCRIPTION
- [x] Fix import command to not import columns into JSON that exist as separate columns.
- [x] Fix `updated_at` not casting to carbon when it exists in the JSON, due to the above.
- [x] Fix `origin()` relationship on UuidEntryModels, so that proper `uuid`s are returned.

Closes #28.