### PR TITLE
Remove Id attribute to fill array

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -33,7 +33,6 @@ class Entry extends FileEntry
         }
 
         return $class::findOrNew($this->id())->fill([
-            'id' => $this->id(),
             'origin_id' => $this->originId(),
             'site' => $this->locale(),
             'slug' => $this->slug(),


### PR DESCRIPTION
Hi,

I removed the Id attribute from the array on the findOrNew method because unnecessary and it was causing an SQL error on Postgresql.

SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "id" of relation "entries" violates not-null constraint
DETAIL:  Failing row contains (null, default, null, t, published, test, null, null, pages, {"title":"Test","content":null,"parent":null,"updated_by":"af32c..., 2021-10-09 14:17:08, 2021-10-09 14:17:08). (SQL: insert into "entries" ("id", "origin_id", "site", "slug", "uri", "date", "collection", "data", "published", "status", "updated_at", "created_at") values (?, ?, default, test, ?, ?, pages, {"title":"Test","content":null,"parent":null,"updated_by":"af32c6a1-5213-4d94-8cf7-bbfd51bb32dd"}, 1, published, 2021-10-09 14:17:08, 2021-10-09 14:17:08) returning "id")