### PR TITLE
Bug fix: Make sure we select all columns

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -15,6 +15,11 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         'id', 'site', 'origin_id', 'published', 'status', 'slug', 'uri',
         'date', 'collection', 'created_at', 'updated_at',
     ];
+    
+    public function select($columns = [])
+    {
+        return $this;
+    }
 
     protected function transform($items, $columns = [])
     {


### PR DESCRIPTION
With the recent changes on core (https://github.com/statamic/cms/pull/5068) this driver no longer works with collection tags (as reported here https://github.com/statamic/cms/issues/5108). The quick fix is to use a eloquent-driver specific select() that ensures we still get all columns.

It would be nice to make the select() actually work so only the appropriate keys from the data column are returned, but for now this feels better than it not working.