### PR TITLE
Add a default `lastModified`

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Support\Carbon;
 use Statamic\Eloquent\Entries\EntryModel as Model;
 use Statamic\Entries\Entry as FileEntry;
 
@@ -61,7 +62,7 @@ class Entry extends FileEntry
 
     public function lastModified()
     {
-        return $this->model->updated_at;
+        return $this->model->updated_at ?? Carbon::now();
     }
 
     public function origin($origin = null)


### PR DESCRIPTION
Useful when you're duplicating an entry and the new entry has a new model and therefore doesn't have a `lastModified` value