### PR TITLE
force the column returns with table name as alias

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -76,4 +76,15 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 
         return parent::count();
     }
+    
+    protected function selectableColumns($columns = ['*'])
+    {
+        $columns = parent::selectableColumns($columns);
+
+        // force the column returns with table name as alias
+        // it helps to resolve the problem of same column name
+        //  overrided by a joint table
+        $result = array_map(fn($column) => $this->builder->getModel()->getTable() . ".$column", $columns);
+        return $result;
+    }
 }

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -84,7 +84,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         // force the column returns with table name as alias
         // it helps to resolve the problem of same column name
         //  overrided by a joint table
-        $result = array_map(fn($column) => $this->builder->getModel()->getTable() . ".$column", $columns);
+        $result = array_map(fn ($column) => $this->builder->getModel()->getTable().".$column", $columns);
         return $result;
     }
 }

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -76,7 +76,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 
         return parent::count();
     }
-    
+
     protected function selectableColumns($columns = ['*'])
     {
         $columns = parent::selectableColumns($columns);
@@ -85,6 +85,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         // it helps to resolve the problem of same column name
         //  overrided by a joint table
         $result = array_map(fn ($column) => $this->builder->getModel()->getTable().".$column", $columns);
+
         return $result;
     }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -690,7 +690,7 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     /** @test */
-    public function entries_retrieval_with_join_table()
+    public function entries_can_be_retrieved_and_are_not_null_when_using_join()
     {
         Collection::make('posts')->save();
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe', 'location' => 4])->create();

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -688,7 +688,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
     }
-    
+
     /** @test */
     public function entries_retrieval_with_join_table()
     {
@@ -698,32 +698,29 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
         Collection::make('locations')->save();
 
-        foreach(range(4,6) as $index) {
+        foreach (range(4, 6) as $index) {
             EntryFactory::id($index)->slug('location-'.$index)->collection('locations')
             ->data(['title' => 'Location '.$index])->create();
         }
 
         $query = Entry::query()
-            ->join('entries as e',fn($join) => $join
+            ->join('entries as e', fn ($join) => $join
                 ->whereColumn('e.id', 'entries.id')
                 ->where('e.collection', 'posts')
-            )->leftJoin('entries as locations', function($join) {
+            )->leftJoin('entries as locations', function ($join) {
                 $join
                     ->where('locations.collection', 'locations')
-                    ->on('locations.id', 'e.data->location')
-                    ;
-            })
-            ;
-        ;
+                    ->on('locations.id', 'e.data->location');
+            });
 
         $entries = $query->get();
 
-        foreach($entries as $entry) {
+        foreach ($entries as $entry) {
             // ensure no null id
             $this->assertNotNull($entry->id);
         }
 
         // the collection should be posts but not locations
-        $this->assertNotEquals($entries->first()->collection->handle, 'locations');        
+        $this->assertNotEquals($entries->first()->collection->handle, 'locations');
     }
 }


### PR DESCRIPTION
it helps to resolve the problem of same column name overrided by a joint table