### PR TITLE
Modify entries import to defer import of entries with origin

### DIFF
--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -56,10 +56,27 @@ class ImportEntries extends Command
     {
         $entries = Entry::all();
 
-        $this->withProgressBar($entries, function ($entry) {
+        $entriesWithOrigin = $entries->filter->hasOrigin();
+        $entriesWithoutOrigin = $entries->filter(function($entry) { return ! $entry->hasOrigin(); });
+
+        if ($entriesWithOrigin->count() > 0) {
+            $this->info('Importing origin entries');
+        }
+
+        $this->withProgressBar($entriesWithoutOrigin, function ($entry) {
             $lastModified = $entry->fileLastModified();
             $entry->toModel()->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])->save();
         });
+
+        if ($entriesWithOrigin->count() > 0) {
+            $this->newLine();
+            $this->info('Importing multi-site entries');
+
+            $this->withProgressBar($entriesWithOrigin, function ($entry) {
+                $lastModified = $entry->fileLastModified();
+                $entry->toModel()->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])->save();
+            });
+        }
 
         $this->newLine();
         $this->info('Entries imported');

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -57,7 +57,7 @@ class ImportEntries extends Command
         $entries = Entry::all();
 
         $entriesWithOrigin = $entries->filter->hasOrigin();
-        $entriesWithoutOrigin = $entries->filter(function($entry) {
+        $entriesWithoutOrigin = $entries->filter(function ($entry) {
             return ! $entry->hasOrigin();
         });
 

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -57,7 +57,9 @@ class ImportEntries extends Command
         $entries = Entry::all();
 
         $entriesWithOrigin = $entries->filter->hasOrigin();
-        $entriesWithoutOrigin = $entries->filter(function($entry) { return ! $entry->hasOrigin(); });
+        $entriesWithoutOrigin = $entries->filter(function($entry) {
+            return ! $entry->hasOrigin();
+        });
 
         if ($entriesWithOrigin->count() > 0) {
             $this->info('Importing origin entries');

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -72,7 +72,7 @@ class ImportEntries extends Command
 
         if ($entriesWithOrigin->count() > 0) {
             $this->newLine();
-            $this->info('Importing multi-site entries');
+            $this->info('Importing localized entries');
 
             $this->withProgressBar($entriesWithOrigin, function ($entry) {
                 $lastModified = $entry->fileLastModified();


### PR DESCRIPTION
This PR fixes issue #75 by importing entries with no origin before importing items that do have an origin.

Fixes: #75