### PR TITLE
Use `jsonb` data type for PostgreSQL to increase perfomance

### DIFF
--- a/database/migrations/create_asset_containers_table.php.stub
+++ b/database/migrations/create_asset_containers_table.php.stub
@@ -13,11 +13,7 @@ return new class extends Migration {
             $table->string('handle')->unique();
             $table->string('title');
             $table->string('disk');
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('settings')->nullable();
-            }
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_asset_containers_table.php.stub
+++ b/database/migrations/create_asset_containers_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_asset_containers_table.php.stub
+++ b/database/migrations/create_asset_containers_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_asset_containers_table.php.stub
+++ b/database/migrations/create_asset_containers_table.php.stub
@@ -12,7 +12,11 @@ return new class extends Migration {
             $table->string('handle')->unique();
             $table->string('title');
             $table->string('disk');
-            $table->json('settings')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('settings')->nullable();
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -10,7 +10,11 @@ return new class extends Migration {
         Schema::create($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->id();
             $table->string('handle')->index();
-            $table->json('data')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data')->nullable();
+            } else {
+                $table->json('data')->nullable();
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -11,11 +11,7 @@ return new class extends Migration {
         Schema::create($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->id();
             $table->string('handle')->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data')->nullable();
-            } else {
-                $table->json('data')->nullable();
-            }
+            $table->jsonb('data')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_blueprints_table.php.stub
+++ b/database/migrations/create_blueprints_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;

--- a/database/migrations/create_blueprints_table.php.stub
+++ b/database/migrations/create_blueprints_table.php.stub
@@ -12,7 +12,11 @@ return new class extends Migration {
             $table->id();
             $table->string('namespace')->nullable()->default(null)->index();
             $table->string('handle');
-            $table->json('data');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data');
+            } else {
+                $table->json('data');
+            }
             $table->timestamps();
 
             $table->unique(['handle', 'namespace']);

--- a/database/migrations/create_blueprints_table.php.stub
+++ b/database/migrations/create_blueprints_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;

--- a/database/migrations/create_blueprints_table.php.stub
+++ b/database/migrations/create_blueprints_table.php.stub
@@ -13,11 +13,7 @@ return new class extends Migration {
             $table->id();
             $table->string('namespace')->nullable()->default(null)->index();
             $table->string('handle');
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data');
-            } else {
-                $table->json('data');
-            }
+            $table->jsonb('data');
             $table->timestamps();
 
             $table->unique(['handle', 'namespace']);

--- a/database/migrations/create_collections_table.php.stub
+++ b/database/migrations/create_collections_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_collections_table.php.stub
+++ b/database/migrations/create_collections_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_collections_table.php.stub
+++ b/database/migrations/create_collections_table.php.stub
@@ -12,11 +12,7 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('settings')->nullable();
-            }
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_collections_table.php.stub
+++ b/database/migrations/create_collections_table.php.stub
@@ -11,7 +11,11 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->json('settings')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('settings')->nullable();
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_entries_table.php.stub
+++ b/database/migrations/create_entries_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_entries_table.php.stub
+++ b/database/migrations/create_entries_table.php.stub
@@ -18,11 +18,7 @@ return new class extends Migration {
             $table->string('uri')->nullable()->index();
             $table->string('date')->nullable();
             $table->string('collection')->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data');
-            } else {
-                $table->json('data');
-            }
+            $table->jsonb('data');
             $table->timestamps();
 
             $table->foreign('origin_id')

--- a/database/migrations/create_entries_table.php.stub
+++ b/database/migrations/create_entries_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_entries_table.php.stub
+++ b/database/migrations/create_entries_table.php.stub
@@ -17,7 +17,11 @@ return new class extends Migration {
             $table->string('uri')->nullable()->index();
             $table->string('date')->nullable();
             $table->string('collection')->index();
-            $table->json('data');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data');
+            } else {
+                $table->json('data');
+            }
             $table->timestamps();
 
             $table->foreign('origin_id')

--- a/database/migrations/create_entries_table_with_string_ids.php.stub
+++ b/database/migrations/create_entries_table_with_string_ids.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_entries_table_with_string_ids.php.stub
+++ b/database/migrations/create_entries_table_with_string_ids.php.stub
@@ -18,11 +18,7 @@ return new class extends Migration {
             $table->string('uri')->nullable()->index();
             $table->string('date')->nullable();
             $table->string('collection')->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data');
-            } else {
-                $table->json('data');
-            }
+            $table->jsonb('data');
             $table->timestamps();
 
             $table->primary('id');

--- a/database/migrations/create_entries_table_with_string_ids.php.stub
+++ b/database/migrations/create_entries_table_with_string_ids.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_entries_table_with_string_ids.php.stub
+++ b/database/migrations/create_entries_table_with_string_ids.php.stub
@@ -17,7 +17,11 @@ return new class extends Migration {
             $table->string('uri')->nullable()->index();
             $table->string('date')->nullable();
             $table->string('collection')->index();
-            $table->json('data');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data');
+            } else {
+                $table->json('data');
+            }
             $table->timestamps();
 
             $table->primary('id');

--- a/database/migrations/create_fieldsets_table.php.stub
+++ b/database/migrations/create_fieldsets_table.php.stub
@@ -11,11 +11,7 @@ return new class extends Migration {
         Schema::create($this->prefix('fieldsets'), function (Blueprint $table) {
             $table->id();
             $table->string('handle')->unique();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data');
-            } else {
-                $table->json('data');
-            }
+            $table->jsonb('data');
             $table->timestamps();
         });
     }

--- a/database/migrations/create_fieldsets_table.php.stub
+++ b/database/migrations/create_fieldsets_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_fieldsets_table.php.stub
+++ b/database/migrations/create_fieldsets_table.php.stub
@@ -10,7 +10,11 @@ return new class extends Migration {
         Schema::create($this->prefix('fieldsets'), function (Blueprint $table) {
             $table->id();
             $table->string('handle')->unique();
-            $table->json('data');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data');
+            } else {
+                $table->json('data');
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_fieldsets_table.php.stub
+++ b/database/migrations/create_fieldsets_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_form_submissions_table.php.stub
+++ b/database/migrations/create_form_submissions_table.php.stub
@@ -10,7 +10,11 @@ return new class extends Migration {
         Schema::create($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->id();
             $table->foreignId('form_id')->constrained($this->prefix('forms'))->cascadeOnDelete();
-            $table->json('data')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data')->nullable();
+            } else {
+                $table->json('data')->nullable();
+            }      
             $table->timestamps(6);
 
             $table->unique(['form_id', 'created_at']);

--- a/database/migrations/create_form_submissions_table.php.stub
+++ b/database/migrations/create_form_submissions_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_form_submissions_table.php.stub
+++ b/database/migrations/create_form_submissions_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_form_submissions_table.php.stub
+++ b/database/migrations/create_form_submissions_table.php.stub
@@ -11,11 +11,7 @@ return new class extends Migration {
         Schema::create($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->id();
             $table->foreignId('form_id')->constrained($this->prefix('forms'))->cascadeOnDelete();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data')->nullable();
-            } else {
-                $table->json('data')->nullable();
-            }      
+            $table->jsonb('data')->nullable();
             $table->timestamps(6);
 
             $table->unique(['form_id', 'created_at']);

--- a/database/migrations/create_forms_table.php.stub
+++ b/database/migrations/create_forms_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_forms_table.php.stub
+++ b/database/migrations/create_forms_table.php.stub
@@ -12,11 +12,7 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('settings')->nullable();
-            } 
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_forms_table.php.stub
+++ b/database/migrations/create_forms_table.php.stub
@@ -11,7 +11,11 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->json('settings')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('settings')->nullable();
+            } 
             $table->timestamps();
         });
     }

--- a/database/migrations/create_forms_table.php.stub
+++ b/database/migrations/create_forms_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -12,11 +12,7 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('localizations');
-            } else {
-                $table->json('localizations');
-            }
+            $table->jsonb('localizations');
             $table->timestamps();
         });
     }

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -11,7 +11,11 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->json('localizations');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('localizations');
+            } else {
+                $table->json('localizations');
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_navigation_trees_table.php.stub
+++ b/database/migrations/create_navigation_trees_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_navigation_trees_table.php.stub
+++ b/database/migrations/create_navigation_trees_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_navigation_trees_table.php.stub
+++ b/database/migrations/create_navigation_trees_table.php.stub
@@ -12,8 +12,13 @@ return new class extends Migration {
             $table->string('handle');
             $table->string('type')->index();
             $table->string('locale')->nullable()->index();
-            $table->json('tree')->nullable();
-            $table->json('settings')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('tree')->nullable();
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('tree')->nullable();
+                $table->json('settings')->nullable();
+            }
             $table->timestamps();
 
             $table->unique(['handle', 'type', 'locale']);

--- a/database/migrations/create_navigation_trees_table.php.stub
+++ b/database/migrations/create_navigation_trees_table.php.stub
@@ -13,13 +13,8 @@ return new class extends Migration {
             $table->string('handle');
             $table->string('type')->index();
             $table->string('locale')->nullable()->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('tree')->nullable();
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('tree')->nullable();
-                $table->json('settings')->nullable();
-            }
+            $table->jsonb('tree')->nullable();
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
 
             $table->unique(['handle', 'type', 'locale']);

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -11,7 +11,6 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->string('locale')->nullable()->index();
             $table->jsonb('settings')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -11,7 +11,12 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->json('settings')->nullable();
+            $table->string('locale')->nullable()->index();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('settings')->nullable();
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -13,11 +13,7 @@ return new class extends Migration {
             $table->string('handle')->unique();
             $table->string('title');
             $table->string('locale')->nullable()->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('settings')->nullable();
-            }
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_revisions_table.php.stub
+++ b/database/migrations/create_revisions_table.php.stub
@@ -13,7 +13,11 @@ return new class extends Migration {
             $table->string('action')->index();
             $table->string('user')->nullable();
             $table->string('message')->nullable();
-            $table->json('attributes')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('attributes')->nullable();
+            } else {
+                $table->json('attributes')->nullable();
+            }
             $table->timestamps();
 
             $table->unique(['key', 'created_at']);

--- a/database/migrations/create_revisions_table.php.stub
+++ b/database/migrations/create_revisions_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_revisions_table.php.stub
+++ b/database/migrations/create_revisions_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_revisions_table.php.stub
+++ b/database/migrations/create_revisions_table.php.stub
@@ -14,11 +14,7 @@ return new class extends Migration {
             $table->string('action')->index();
             $table->string('user')->nullable();
             $table->string('message')->nullable();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('attributes')->nullable();
-            } else {
-                $table->json('attributes')->nullable();
-            }
+            $table->jsonb('attributes')->nullable();
             $table->timestamps();
 
             $table->unique(['key', 'created_at']);

--- a/database/migrations/create_taxonomies_table.php.stub
+++ b/database/migrations/create_taxonomies_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_taxonomies_table.php.stub
+++ b/database/migrations/create_taxonomies_table.php.stub
@@ -12,7 +12,11 @@ return new class extends Migration {
             $table->string('handle')->unique();
             $table->string('title');
             $table->json('sites')->nullable();
-            $table->json('settings')->nullable();
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('settings')->nullable();
+            } else {
+                $table->json('settings')->nullable();
+            } 
             $table->timestamps();
         });
     }

--- a/database/migrations/create_taxonomies_table.php.stub
+++ b/database/migrations/create_taxonomies_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_taxonomies_table.php.stub
+++ b/database/migrations/create_taxonomies_table.php.stub
@@ -12,12 +12,8 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->json('sites')->nullable();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('settings')->nullable();
-            } else {
-                $table->json('settings')->nullable();
-            } 
+            $table->jsonb('sites')->nullable();
+            $table->jsonb('settings')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_terms_table.php.stub
+++ b/database/migrations/create_terms_table.php.stub
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_terms_table.php.stub
+++ b/database/migrations/create_terms_table.php.stub
@@ -13,7 +13,11 @@ return new class extends Migration {
             $table->string('slug');
             $table->string('uri')->nullable()->index();
             $table->string('taxonomy')->index();
-            $table->json('data');
+            if (DB::connection()->getDriverName() === 'pgsql') {
+                $table->jsonb('data');
+            } else {
+                $table->json('data');
+            }              
             $table->timestamps();
 
             $table->unique(['slug', 'taxonomy', 'site']);

--- a/database/migrations/create_terms_table.php.stub
+++ b/database/migrations/create_terms_table.php.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 

--- a/database/migrations/create_terms_table.php.stub
+++ b/database/migrations/create_terms_table.php.stub
@@ -14,11 +14,7 @@ return new class extends Migration {
             $table->string('slug');
             $table->string('uri')->nullable()->index();
             $table->string('taxonomy')->index();
-            if (DB::connection()->getDriverName() === 'pgsql') {
-                $table->jsonb('data');
-            } else {
-                $table->json('data');
-            }              
+            $table->jsonb('data');
             $table->timestamps();
 
             $table->unique(['slug', 'taxonomy', 'site']);


### PR DESCRIPTION
To improve perfomance for Postgres databases, the `json` columns can use the `jsonb` data type.

This is will reduce responsetimes drastically when dealing with large datasets.