### PR TITLE
Add expectation to mocked version to fix assertion counts

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,7 +37,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $uses = array_flip(class_uses_recursive(static::class));
 
         if ($this->shouldFakeVersion) {
-            \Facades\Statamic\Version::shouldReceive('get')->andReturn('3.0.0-testing');
+            \Facades\Statamic\Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn('3.0.0-testing');
             $this->addToAssertionCount(-1); // Dont want to assert this
         }
 


### PR DESCRIPTION
The test suite currently outputs a whole bunch of `This test did not perform any assertions` messages. This is because of a change in a later version of Mockery.

See https://github.com/statamic/cms/pull/6689 for a more detailed explanation. This PR is just applying the same fix.
