### PR TITLE
Fix SQLite skipped tests

### DIFF
--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -380,7 +380,7 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entries_are_found_using_where_json_contains()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -404,7 +404,7 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entries_are_found_using_where_json_doesnt_contain()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -428,7 +428,7 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entries_are_found_using_or_where_json_contains()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -447,7 +447,7 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entries_are_found_using_or_where_json_doesnt_contain()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -481,7 +481,7 @@ class TermQueryBuilderTest extends TestCase
     /** @test **/
     public function terms_are_found_using_where_json_contains()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -506,7 +506,7 @@ class TermQueryBuilderTest extends TestCase
     /** @test **/
     public function terms_are_found_using_where_json_doesnt_contain()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -531,7 +531,7 @@ class TermQueryBuilderTest extends TestCase
     /** @test **/
     public function terms_are_found_using_or_where_json_contains()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 
@@ -551,7 +551,7 @@ class TermQueryBuilderTest extends TestCase
     /** @test **/
     public function terms_are_found_using_or_where_json_doesnt_contain()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -211,4 +211,11 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $migration = require __DIR__.'/../database/migrations/create_entries_table_with_string_ids.php.stub';
         $migration->up();
     }
+
+    protected function isUsingSqlite()
+    {
+        $connection = config('database.default');
+
+        return config("database.connections.{$connection}.driver") === 'sqlite';
+    }
 }


### PR DESCRIPTION
Testbench 7.12.1 introduces a change where if the sqlite file doesn't exist, it'll change the `database.default` config to their custom testing connection.

In our tests, we were checking for whether `database.default` was `sqlite`, which now be `false`, so the skipped tests would run, and cause an error.

This PR changes the condition to look for the `driver` of the appropriate database connection instead.
