### PR TITLE
Fixed asset calling delete on null

### DIFF
--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -15,7 +15,7 @@ namespace Statamic\Eloquent\Assets;
          $asset->container()->contents()->forget($asset->path())->save();
 
          $handle = $asset->containerHandle().'::'.$asset->metaPath();
-         app('statamic.eloquent.assets.model')::where('handle', $handle)->first()->delete();
+         app('statamic.eloquent.assets.model')::where('handle', $handle)->first()?->delete();
 
          Stache::store('assets::'.$asset->containerHandle())->delete($asset);
      }


### PR DESCRIPTION
Deleting an asset will fail if it doesn't have a metadata entry - `Call to a member function delete() on null`