### PR TITLE
Fixed taxonomy not being respected when querying specific ids

### DIFF
--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -137,6 +137,11 @@ class TermQueryBuilder extends EloquentQueryBuilder
             $column = 'slug';
             $values = collect($values)
                 ->map(function ($value) {
+                    $taxonomy = Str::before($value.'', '::');
+                    if ($taxonomy) {
+                        $this->taxonomies[] = $taxonomy;
+                    }
+
                     return Str::after($value, '::');
                 })
                 ->all();


### PR DESCRIPTION
Having multiple terms with the same slug, in different taxonomies attached to the same collection, wrong terms will "bleed" into the list when querying `whereIn('id', [...])` through the OrderedQueryBuilder, as the taxonomy will not be filtered later on.