### PR TITLE
Change entry collection order update be a job

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -22,6 +22,7 @@ return [
         'model'      => \Statamic\Eloquent\Collections\CollectionModel::class,
         'tree'       => \Statamic\Eloquent\Structures\CollectionTree::class,
         'tree_model' => \Statamic\Eloquent\Structures\TreeModel::class,
+        'update_entry_order_queue' => 'default',
     ],
 
     'entries' => [

--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Eloquent\Collections;
 
 use Illuminate\Support\Collection as IlluminateCollection;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
+use Statamic\Eloquent\Jobs\UpdateCollectionEntryOrder;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\CollectionRepository as StacheRepository;
 
@@ -81,6 +82,11 @@ class CollectionRepository extends StacheRepository
 
     public function updateEntryOrder(CollectionContract $collection, $ids = null)
     {
-        $collection->queryEntries()->get()->each->save();
+        $collection->queryEntries()
+            ->get(['id'])
+            ->each(function ($entry) {
+                UpdateCollectionEntryOrder::dispatch($entry->id())
+                    ->onQueue(config('statamic.eloquent-driver.collections.update_entry_order_queue', 'default'));
+            });
     }
 }

--- a/src/Jobs/UpdateCollectionEntryOrder.php
+++ b/src/Jobs/UpdateCollectionEntryOrder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Eloquent\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Statamic\Facades\Entry;
+
+class UpdateCollectionEntryOrder implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public $entryId;
+
+    public function __construct($entryId)
+    {
+        $this->entryId = $entryId;
+    }
+
+    public function handle()
+    {
+        if ($entry = Entry::find($this->entryId)) {
+            $entry->save();
+        }
+    }
+}


### PR DESCRIPTION
When updating the Entry Collection order with a large number of entries and an external search provider the performance can cause timeouts and page load failures.

Lets resolve this by making the update take place inside a job.

Fixes: #105