### PR TITLE
Store origin data alongside localized data

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -13,7 +13,7 @@ class Entry extends FileEntry
 
     public static function fromModel(Model $model)
     {
-        $data = isset($model->data['localized_fields']) ? collect($model->data)->only($model->data['localized_fields']) : $model->data;
+        $data = isset($model->data['__localized_fields']) ? collect($model->data)->only($model->data['__localized_fields']) : $model->data;
 
         $entry = (new static())
             ->origin($model->origin_id)
@@ -69,7 +69,7 @@ class Entry extends FileEntry
 
                 $data = $origin->data()->merge($data);
 
-                $data->put('localized_fields', $localizedFields);
+                $data->put('__localized_fields', $localizedFields);
 
                 if (! in_array('date', $localizedFields)) {
                     $date = $origin->hasDate() ? $origin->date() : null;

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -81,6 +81,10 @@ class Entry extends FileEntry
             }
         }
 
+        if ($parent = $this->parent()) {
+            $data->put('parent', (string) $parent->id);
+        }
+
         $attributes = [
             'origin_id'  => $origin?->id(),
             'site'       => $this->locale(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -49,13 +49,23 @@ class Entry extends FileEntry
             }
 
             if ($origin) {
-                $localizedFields = $blueprint
+                $localizedBlueprintFields = $blueprint
                     ->fields()
                     ->localizable()
                     ->all()
                     ->map
                     ->handle()
                     ->all();
+
+                // remove any fields in entry data that are marked as localized but value is blank
+                $localizedFields = [];
+                foreach ($localizedBlueprintFields as $blueprintField) {
+                    if ($data->get($blueprintField) == '') {
+                        $data->forget($blueprintField);
+                    } else {
+                        $localizedFields[] = $blueprintField;
+                    }
+                }
 
                 $data = $origin->data()->merge($data);
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -48,13 +48,13 @@ class Entry extends FileEntry
     {
         $class = app('statamic.eloquent.entries.model');
 
-        $data = $this->data();
-        $date = $this->hasDate() ? $this->date() : null;
+        $data = $source->data();
+        $date = $source->hasDate() ? $source->date() : null;
 
-        $origin = $this->origin();
+        $origin = $source->origin();
 
-        if ($this->hasOrigin()) {
-            if ($blueprint = $this->blueprint()) {
+        if ($source->hasOrigin()) {
+            if ($blueprint = $source->blueprint()) {
                 $localizedBlueprintFields = $blueprint
                     ->fields()
                     ->localizable()
@@ -87,23 +87,23 @@ class Entry extends FileEntry
             }
         }
 
-        if ($parent = $this->parent()) {
+        if ($parent = $source->parent()) {
             $data->put('parent', (string) $parent->id);
         }
 
         $attributes = [
             'origin_id'  => $origin?->id(),
-            'site'       => $this->locale(),
-            'slug'       => $this->slug(),
-            'uri'        => $this->uri(),
+            'site'       => $source->locale(),
+            'slug'       => $source->slug(),
+            'uri'        => $source->uri(),
             'date'       => $date,
-            'collection' => $this->collectionHandle(),
-            'blueprint'  => $this->blueprint ?? $this->blueprint()->handle(),
+            'collection' => $source->collectionHandle(),
+            'blueprint'  => $source->blueprint ?? $source->blueprint()->handle(),
             'data'       => $data->except(EntryQueryBuilder::COLUMNS)->except(['parent']),
-            'published'  => $this->published(),
-            'status'     => $this->status(),
-            'updated_at' => $this->lastModified(),
-            'order'      => $this->order(),
+            'published'  => $source->published(),
+            'status'     => $source->status(),
+            'updated_at' => $source->lastModified(),
+            'order'      => $source->order(),
         ];
 
         if ($id = $source->id()) {

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -22,7 +22,7 @@ class Entry extends FileEntry
             ->date($model->date)
             ->collection($model->collection)
             ->data($data)
-            ->blueprint($model->data['blueprint'] ?? null)
+            ->blueprint($model->blueprint ?? $model->data['blueprint'] ?? null)
             ->published($model->published)
             ->model($model);
 
@@ -44,10 +44,6 @@ class Entry extends FileEntry
         $date = $this->hasDate() ? $this->date() : null;
 
         if ($blueprint = $this->blueprint()) {
-            if ($this->collection()->entryBlueprints()->count() > 1) {
-                $data->put('blueprint', $blueprint->handle());
-            }
-
             if ($origin) {
                 $localizedBlueprintFields = $blueprint
                     ->fields()
@@ -84,6 +80,7 @@ class Entry extends FileEntry
             'uri'        => $this->uri(),
             'date'       => $date,
             'collection' => $this->collectionHandle(),
+            'blueprint'  => $this->blueprint ?? $this->blueprint()->handle(),
             'data'       => $data->except(EntryQueryBuilder::COLUMNS),
             'published'  => $this->published(),
             'status'     => $this->status(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -13,13 +13,15 @@ class Entry extends FileEntry
 
     public static function fromModel(Model $model)
     {
+        $data = isset($model->data['localized_fields']) ? collect($model->data)->only($model->data['localized_fields']) : $model->data;
+
         $entry = (new static())
             ->origin($model->origin_id)
             ->locale($model->site)
             ->slug($model->slug)
             ->date($model->date)
             ->collection($model->collection)
-            ->data($model->data)
+            ->data($data)
             ->blueprint($model->data['blueprint'] ?? null)
             ->published($model->published)
             ->model($model);
@@ -37,8 +39,14 @@ class Entry extends FileEntry
 
         $data = $this->data();
 
+        if ($origin = $this->origin()) {
+            $localizedFields = $data->keys()->all();
+            $data = $origin->data()->merge($data);
+            $data->put('localized_fields', $localizedFields);
+        }
+
         if ($this->blueprint && $this->collection()->entryBlueprints()->count() > 1) {
-            $data['blueprint'] = $this->blueprint;
+            $data->put('blueprint', $this->blueprint);
         }
 
         $attributes = [

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -42,13 +42,11 @@ class Entry extends FileEntry
         $date = $this->hasDate() ? $this->date() : null;
 
         if ($blueprint = $this->blueprint()) {
-
             if ($this->collection()->entryBlueprints()->count() > 1) {
                 $data->put('blueprint', $blueprint->handle());
             }
 
             if ($origin) {
-
                 $localizedFields = $blueprint
                     ->fields()
                     ->localizable()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -38,6 +38,8 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         $data = $this->data();
+        $data->put('parent', $this->parent());
+
         $origin = $this->origin();
         $date = $this->hasDate() ? $this->date() : null;
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -43,12 +43,12 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         $data = $this->data();
-
-        $origin = $this->origin();
         $date = $this->hasDate() ? $this->date() : null;
 
-        if ($blueprint = $this->blueprint()) {
-            if ($origin) {
+        $origin = $this->origin();
+
+        if ($this->hasOrigin()) {
+            if ($blueprint = $this->blueprint()) {
                 $localizedBlueprintFields = $blueprint
                     ->fields()
                     ->localizable()
@@ -57,17 +57,19 @@ class Entry extends FileEntry
                     ->handle()
                     ->all();
 
+                $originData = $origin->data();
+
                 // remove any fields in entry data that are marked as localized but value is blank
                 $localizedFields = [];
                 foreach ($localizedBlueprintFields as $blueprintField) {
-                    if ($data->get($blueprintField) == '') {
+                    if ($data->get($blueprintField) === $originData->get($blueprintField)) {
                         $data->forget($blueprintField);
                     } else {
                         $localizedFields[] = $blueprintField;
                     }
                 }
 
-                $data = $origin->data()->merge($data);
+                $data = $originData->merge($data);
 
                 $data->put('__localized_fields', $localizedFields);
 
@@ -78,7 +80,7 @@ class Entry extends FileEntry
         }
 
         $attributes = [
-            'origin_id'  => $this->origin()?->id(),
+            'origin_id'  => $origin?->id(),
             'site'       => $this->locale(),
             'slug'       => $this->slug(),
             'uri'        => $this->uri(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -43,7 +43,6 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         $data = $this->data();
-        $data->put('parent', $this->parent());
 
         $origin = $this->origin();
         $date = $this->hasDate() ? $this->date() : null;
@@ -86,7 +85,7 @@ class Entry extends FileEntry
             'date'       => $date,
             'collection' => $this->collectionHandle(),
             'blueprint'  => $this->blueprint ?? $this->blueprint()->handle(),
-            'data'       => $data->except(EntryQueryBuilder::COLUMNS),
+            'data'       => $data->except(EntryQueryBuilder::COLUMNS)->except(['parent']),
             'published'  => $this->published(),
             'status'     => $this->status(),
             'updated_at' => $this->lastModified(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -59,13 +59,15 @@ class Entry extends FileEntry
 
                 $originData = $origin->data();
 
-                // remove any fields in entry data that are marked as localized but value is blank
+                // remove any fields in entry data that are marked as localized but value is present, and does not match origin
                 $localizedFields = [];
                 foreach ($localizedBlueprintFields as $blueprintField) {
-                    if ($data->get($blueprintField) === $originData->get($blueprintField)) {
-                        $data->forget($blueprintField);
-                    } else {
-                        $localizedFields[] = $blueprintField;
+                    if ($data->has($blueprintField)) {
+                        if ($data->get($blueprintField) === $originData->get($blueprintField)) {
+                            $data->forget($blueprintField);
+                        } else {
+                            $localizedFields[] = $blueprintField;
+                        }
                     }
                 }
 

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -58,6 +58,8 @@ class EntryRepository extends StacheRepository
 
         Blink::put("eloquent-entry-{$entry->id()}", $entry);
         Blink::put("eloquent-entry-{$entry->uri()}", $entry);
+
+        $entry->descendants()->each->save();
     }
 
     public function delete($entry)

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -38,7 +38,6 @@ class EntryTest extends TestCase
             'slug' => 'the-slug',
             'data' => [
                 'foo' => 'bar',
-                'parent' => null,
             ],
             'site'       => 'en',
             'uri'        => '/blog/the-slug',

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -158,6 +158,7 @@ class EntryTest extends TestCase
 
         $collection = (new Collection)
             ->handle('pages')
+            ->dated(true)
             ->propagate(true)
             ->sites(['en', 'fr', 'de'])
             ->save();

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Entries;
 
+use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
+use Statamic\Facades;
 use Tests\TestCase;
 
 class EntryTest extends TestCase
@@ -54,5 +56,127 @@ class EntryTest extends TestCase
         $entry = (new Entry())->fromModel($model)->collection($collection);
 
         $this->assertEquals(collect($model->toArray())->except(['updated_at'])->all(), collect($entry->toModel()->toArray())->except('updated_at')->all());
+    }
+
+    /** @test */
+    public function it_propagates_entry_if_configured()
+    {
+        Facades\Site::setConfig([
+            'default' => 'en',
+            'sites' => [
+                'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+                'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+                'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+                'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+            ],
+        ]);
+
+        $collection = (new Collection)
+            ->handle('pages')
+            ->propagate(true)
+            ->sites(['en', 'fr', 'de'])
+            ->save();
+
+        $entry = (new Entry)
+            ->id(1)
+            ->locale('en')
+            ->collection($collection);
+
+        $return = $entry->save();
+
+        $this->assertIsObject($fr = $entry->descendants()->get('fr'));
+        $this->assertIsObject($de = $entry->descendants()->get('de'));
+        $this->assertNull($entry->descendants()->get('es')); // collection not configured for this site
+    }
+
+    /** @test */
+    public function it_propagates_updating_origin_data_to_descendent_models()
+    {
+        Facades\Site::setConfig([
+            'default' => 'en',
+            'sites' => [
+                'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+                'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+                'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+                'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+            ],
+        ]);
+
+        $blueprint = Facades\Blueprint::makeFromFields(['foo' => ['type' => 'test', 'localizable' => true]])->setHandle('test');
+        $blueprint->save();
+
+        BlueprintRepository::shouldReceive('in')->with('collections/pages')->andReturn(collect(['test' => $blueprint]));
+
+        $collection = (new Collection)
+            ->handle('pages')
+            ->propagate(true)
+            ->sites(['en', 'fr', 'de'])
+            ->save();
+
+        $entry = (new Entry)
+            ->id(1)
+            ->locale('en')
+            ->collection($collection)
+            ->blueprint('test')
+            ->data([
+                'foo' => 'bar',
+                'roo' => 'rar',
+            ]);
+
+        $return = $entry->save();
+
+        $this->assertNull($entry->descendants()->get('fr')->model()->data['too'] ?? null);
+        $this->assertNull($entry->descendants()->get('de')->model()->data['too'] ?? null);
+
+        $blueprint->ensureField('too', ['type' => 'test', 'localizable' => true]);
+        $entry->merge(['too' => 'tar']);
+
+        Facades\Entry::save($entry);
+
+        $this->assertNotNull($entry->descendants()->get('fr')->model()->data['too'] ?? null);
+        $this->assertNotNull($entry->descendants()->get('de')->model()->data['too'] ?? null);
+    }
+
+    /** @test */
+    public function it_propagates_origin_date_to_descendent_models()
+    {
+        Facades\Site::setConfig([
+            'default' => 'en',
+            'sites' => [
+                'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+                'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+                'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+                'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+            ],
+        ]);
+
+        $blueprint = Facades\Blueprint::makeFromFields(['foo' => ['type' => 'test', 'localizable' => true]])->setHandle('test');
+        $blueprint->save();
+
+        BlueprintRepository::shouldReceive('in')->with('collections/pages')->andReturn(collect(['test' => $blueprint]));
+
+        $collection = (new Collection)
+            ->handle('pages')
+            ->propagate(true)
+            ->sites(['en', 'fr', 'de'])
+            ->save();
+
+        $entry = (new Entry)
+            ->id(1)
+            ->date('2023-01-01')
+            ->locale('en')
+            ->collection($collection)
+            ->blueprint('test');
+
+        $return = $entry->save();
+
+        $this->assertEquals($entry->descendants()->get('fr')->model()->date, '2023-01-01 00:00:00');
+
+        $blueprint->ensureField('too', ['type' => 'test', 'localizable' => true]);
+        $entry->date('2024-01-01');
+
+        Facades\Entry::save($entry);
+
+        $this->assertEquals($entry->descendants()->get('fr')->model()->date, '2024-01-01 00:00:00');
     }
 }

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -38,6 +38,7 @@ class EntryTest extends TestCase
             'slug' => 'the-slug',
             'data' => [
                 'foo' => 'bar',
+                'parent' => null,
             ],
             'site'       => 'en',
             'uri'        => '/blog/the-slug',

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -165,9 +165,9 @@ class EntryTest extends TestCase
 
         $entry = (new Entry)
             ->id(1)
+            ->collection($collection)
             ->date('2023-01-01')
             ->locale('en')
-            ->collection($collection)
             ->blueprint('test');
 
         $return = $entry->save();


### PR DESCRIPTION
As discussed [here](https://github.com/statamic/eloquent-driver/issues/112), we should store origin entry data alongside localisation data so it can be queried at the database level.

Let me know if youre happy with this approach as I'll need to add some test coverage on this before it should be merged.

