### PR TITLE
Fix form submission creation

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -28,7 +28,7 @@ class Submission extends FileEntry
         $class = app('statamic.eloquent.forms.submission_model');
         $timestamp = (new $class)->fromDateTime($this->date());
 
-        $model = $class::findOrNew($this->id());
+        $model = $class::findOrNew($this->id);
 
         return (! empty($model->id)) ? $model->fill([
             'data' => $this->data,


### PR DESCRIPTION
Uses the existing ID or null, allowing for incremental ID for new records.

Resolves #121