### PR TITLE
Use Entry facade for origins to avoid duplicate queries

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Eloquent\Entries\EntryModel as Model;
 use Statamic\Entries\Entry as FileEntry;
+use Statamic\Facades\Entry as EntryFacade;
 
 class Entry extends FileEntry
 {
@@ -99,9 +100,7 @@ class Entry extends FileEntry
 
         if ($this->origin) {
             if (! $this->origin instanceof EntryContract) {
-                if ($model = $class::find($this->origin)) {
-                    $this->origin = self::fromModel($model);
-                }
+                $this->origin = EntryFacade::find($this->origin);
             }
 
             return $this->origin;
@@ -111,10 +110,6 @@ class Entry extends FileEntry
             return;
         }
 
-        if ($model = $class::find($this->model->origin_id)) {
-            $this->origin = self::fromModel($model);
-        }
-
-        return $this->origin ?? null;
+        return EntryFacade::find($this->model->origin_id);
     }
 }


### PR DESCRIPTION
To eliminate duplicate queries as noted here:
https://github.com/statamic/eloquent-driver/issues/110#issuecomment-1419022238