### PR TITLE
Bring submission events inline with Statamic

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -66,13 +66,13 @@ class Submission extends FileEntry
         if (SubmissionSaving::dispatch($this) === false) {
             return false;
         }
-        
+
         $model = $this->toModel();
         $model->save();
         $isNew = $model->wasRecentlyCreated;
-        
+
         $this->model($model->fresh());
-        
+
         if ($isNew) {
             SubmissionCreated::dispatch($this);
         }


### PR DESCRIPTION
See:
https://github.com/statamic/cms/blob/3.4/src/Forms/Submission.php#L10
https://github.com/statamic/cms/blob/3.4/src/Forms/Submission.php#L152
https://github.com/statamic/cms/blob/3.4/src/Forms/Submission.php#L164

Currently we're missing events that are fired by default statamic and not by this module. 
Making code depending on these events unpredictable and most-likely non-functional.

This PR will bring those events inline with how they work in default Statamic.