### PR TITLE
Cast global set origin attribute to a collection

### DIFF
--- a/src/Globals/VariablesModel.php
+++ b/src/Globals/VariablesModel.php
@@ -11,7 +11,9 @@ class VariablesModel extends BaseModel
 
     protected $table = 'global_set_variables';
 
-    protected $casts = [];
+    protected $casts = [
+        'origin' => 'collection',
+    ];
 
     public function getAttribute($key)
     {


### PR DESCRIPTION
As it tries to get the values from it with `values()` but it's an array so you'll get:
```
Call to a member function values() on array
```

See: https://github.com/statamic/cms/blob/8d5b25d7c264bbacfebda2a1ff6ae412b4bb0b02/src/Data/HasOrigin.php#L13