### PR TITLE
Split configs for asset containers, collection trees and navigation trees

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -18,12 +18,14 @@ return [
     ],
 
     'collections' => [
-        'driver'       => 'eloquent',
-        'model'        => \Statamic\Eloquent\Collections\CollectionModel::class,
-        // Uncomment the setting below if you need to specify a different driver for your collections tree.
-        // 'tree_driver' => 'eloquent',
-        'tree'         => \Statamic\Eloquent\Structures\CollectionTree::class,
-        'tree_model'   => \Statamic\Eloquent\Structures\TreeModel::class,
+        'driver' => 'eloquent',
+        'model'  => \Statamic\Eloquent\Collections\CollectionModel::class,
+    ],
+
+    'collection_trees' => [
+        'driver' => 'eloquent',
+        'model'  => \Statamic\Eloquent\Structures\TreeModel::class,
+        'tree'   => \Statamic\Eloquent\Structures\CollectionTree::class,
     ],
 
     'entries' => [

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -5,10 +5,14 @@ return [
     'connection'   => env('STATAMIC_ELOQUENT_CONNECTION', ''),
     'table_prefix' => env('STATAMIC_ELOQUENT_PREFIX', ''),
 
+    'asset_containers' => [
+        'driver' => 'eloquent',
+        'model'  => \Statamic\Eloquent\Assets\AssetContainerModel::class,
+    ],
+
     'assets' => [
-        'driver'          => 'eloquent',
-        'container_model' => \Statamic\Eloquent\Assets\AssetContainerModel::class,
-        'model'           => \Statamic\Eloquent\Assets\AssetModel::class,
+        'driver' => 'eloquent',
+        'model'  => \Statamic\Eloquent\Assets\AssetModel::class,
     ],
 
     'blueprints' => [

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -49,8 +49,12 @@ return [
     'navigations' => [
         'driver'     => 'eloquent',
         'model'      => \Statamic\Eloquent\Structures\NavModel::class,
-        'tree'       => \Statamic\Eloquent\Structures\NavTree::class,
-        'tree_model' => \Statamic\Eloquent\Structures\TreeModel::class,
+    ],
+
+    'navigation_trees' => [
+        'driver' => 'eloquent',
+        'model'  => \Statamic\Eloquent\Structures\TreeModel::class,
+        'tree'   => \Statamic\Eloquent\Structures\NavTree::class,
     ],
 
     'revisions' => [

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -18,10 +18,12 @@ return [
     ],
 
     'collections' => [
-        'driver'     => 'eloquent',
-        'model'      => \Statamic\Eloquent\Collections\CollectionModel::class,
-        'tree'       => \Statamic\Eloquent\Structures\CollectionTree::class,
-        'tree_model' => \Statamic\Eloquent\Structures\TreeModel::class,
+        'driver'       => 'eloquent',
+        'model'        => \Statamic\Eloquent\Collections\CollectionModel::class,
+        // Uncomment the setting below if you need to specify a different driver for your collections tree.
+        // 'tree_driver' => 'eloquent',
+        'tree'         => \Statamic\Eloquent\Structures\CollectionTree::class,
+        'tree_model'   => \Statamic\Eloquent\Structures\TreeModel::class,
     ],
 
     'entries' => [

--- a/src/Commands/ImportAssets.php
+++ b/src/Commands/ImportAssets.php
@@ -61,6 +61,10 @@ class ImportAssets extends Command
 
     private function importAssetContainers()
     {
+        if (! $this->confirm('Do you want to import asset containers?')) {
+            return;
+        }
+
         $containers = AssetContainerFacade::all();
 
         $this->withProgressBar($containers, function ($container) {
@@ -74,6 +78,10 @@ class ImportAssets extends Command
 
     private function importAssets()
     {
+        if (! $this->confirm('Do you want to import assets?')) {
+            return;
+        }
+
         $assets = AssetFacade::all();
 
         $this->withProgressBar($assets, function ($asset) {

--- a/src/Commands/ImportCollections.php
+++ b/src/Commands/ImportCollections.php
@@ -73,8 +73,8 @@ class ImportCollections extends Command
 
     private function importCollections()
     {
-        $importCollections = $this->confirm('Do you want to import collections?'));
-        $importCollectionTrees = $this->confirm('Do you want to import collections trees?'));
+        $importCollections = $this->confirm('Do you want to import collections?');
+        $importCollectionTrees = $this->confirm('Do you want to import collections trees?');
 
         $collections = CollectionFacade::all();
 

--- a/src/Commands/ImportCollections.php
+++ b/src/Commands/ImportCollections.php
@@ -73,15 +73,21 @@ class ImportCollections extends Command
 
     private function importCollections()
     {
+        $importCollections = $this->confirm('Do you want to import collections?'));
+        $importCollectionTrees = $this->confirm('Do you want to import collections trees?'));
+
         $collections = CollectionFacade::all();
 
-        $this->withProgressBar($collections, function ($collection) {
-            $lastModified = $collection->fileLastModified();
-            EloquentCollection::makeModelFromContract($collection)
-                ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
-                ->save();
+        $this->withProgressBar($collections, function ($collection) use ($importCollections, $importCollectionTrees) {
+            if ($importCollections) {
+                $lastModified = $collection->fileLastModified();
 
-            if ($structure = $collection->structure()) {
+                EloquentCollection::makeModelFromContract($collection)
+                    ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
+                    ->save();
+            }
+
+            if ($importCollectionTrees && ($structure = $collection->structure())) {
                 $structure->trees()->each(function ($tree) {
                     $lastModified = $tree->fileLastModified();
                     app('statamic.eloquent.collections.tree')::makeModelFromContract($tree)

--- a/src/Commands/ImportNavs.php
+++ b/src/Commands/ImportNavs.php
@@ -59,8 +59,8 @@ class ImportNavs extends Command
 
     private function importNavs()
     {
-        $importNavigations = $this->confirm('Do you want to import navs?'));
-        $importNavigationTrees = $this->confirm('Do you want to import nav trees?'));
+        $importNavigations = $this->confirm('Do you want to import navs?');
+        $importNavigationTrees = $this->confirm('Do you want to import nav trees?');
 
         $navs = NavFacade::all();
 

--- a/src/Commands/ImportNavs.php
+++ b/src/Commands/ImportNavs.php
@@ -59,20 +59,27 @@ class ImportNavs extends Command
 
     private function importNavs()
     {
+        $importNavigations = $this->confirm('Do you want to import navs?'));
+        $importNavigationTrees = $this->confirm('Do you want to import nav trees?'));
+
         $navs = NavFacade::all();
 
-        $this->withProgressBar($navs, function ($nav) {
-            $lastModified = $nav->fileLastModified();
-            EloquentNav::makeModelFromContract($nav)
-                ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
-                ->save();
-
-            $nav->trees()->each(function ($tree) {
-                $lastModified = $tree->fileLastModified();
-                EloquentNavTree::makeModelFromContract($tree)
+        $this->withProgressBar($navs, function ($nav) use ($importNavigations, $importNavigationTrees) {
+            if ($importNavigations) {
+                $lastModified = $nav->fileLastModified();
+                EloquentNav::makeModelFromContract($nav)
                     ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                     ->save();
-            });
+            }
+
+            if ($importNavigationTrees) {
+                $nav->trees()->each(function ($tree) {
+                    $lastModified = $tree->fileLastModified();
+                    EloquentNavTree::makeModelFromContract($tree)
+                        ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
+                        ->save();
+                });
+            }
         });
 
         $this->newLine();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -165,7 +165,7 @@ class ServiceProvider extends AddonServiceProvider
 
     private function registerCollectionTrees()
     {
-        // Use the collections' driver as a fallback to ensure brackwards compatibility.
+        // Use the collections' driver as a fallback to ensure backwards compatibility.
         $collectionsDriver = config('statamic.eloquent-driver.collections.driver', 'file');
 
         if (config('statamic.eloquent-driver.collection_trees.driver', $collectionsDriver) != 'eloquent') {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -177,14 +177,14 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.collections.tree', function () {
             // Use the old related config as a fallback to ensure backwards compatibility.
             $collectionsOldTree = config('statamic.eloquent-driver.collections.tree');
-            
+
             return config('statamic.eloquent-driver.collection_trees.tree', $collectionsOldTree);
         });
 
         $this->app->bind('statamic.eloquent.collections.tree_model', function () {
             // Use the old related config as a fallback to ensure backwards compatibility.
             $collectionsOldTreeModel = config('statamic.eloquent-driver.collections.tree_model');
-            
+
             return config('statamic.eloquent-driver.collection_trees.model', $collectionsOldTreeModel);
         });
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -156,7 +156,7 @@ class ServiceProvider extends AddonServiceProvider
 
         if ($collectionsDriver == 'eloquent') {
             Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
-    
+
             $this->app->bind('statamic.eloquent.collections.model', function () {
                 return config('statamic.eloquent-driver.collections.model');
             });
@@ -164,11 +164,11 @@ class ServiceProvider extends AddonServiceProvider
 
         if ($collectionsTreeDriver == 'eloquent') {
             Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
-    
+
             $this->app->bind('statamic.eloquent.collections.tree', function () {
                 return config('statamic.eloquent-driver.collections.tree');
             });
-    
+
             $this->app->bind('statamic.eloquent.collections.tree_model', function () {
                 return config('statamic.eloquent-driver.collections.tree_model');
             });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -175,17 +175,17 @@ class ServiceProvider extends AddonServiceProvider
         Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
 
         $this->app->bind('statamic.eloquent.collections.tree', function () {
-            // Use the old related config as a fallback to ensure backwards compatibility.
-            $collectionsOldTree = config('statamic.eloquent-driver.collections.tree');
-
-            return config('statamic.eloquent-driver.collection_trees.tree', $collectionsOldTree);
+            return config(
+                'statamic.eloquent-driver.collection_trees.tree',
+                config('statamic.eloquent-driver.collections.tree')
+            );
         });
 
         $this->app->bind('statamic.eloquent.collections.tree_model', function () {
-            // Use the old related config as a fallback to ensure backwards compatibility.
-            $collectionsOldTreeModel = config('statamic.eloquent-driver.collections.tree_model');
-
-            return config('statamic.eloquent-driver.collection_trees.model', $collectionsOldTreeModel);
+            return config(
+                'statamic.eloquent-driver.collection_trees.model',
+                config('statamic.eloquent-driver.collections.tree_model')
+            );
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -103,6 +103,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerGlobals();
         $this->registerRevisions();
         $this->registerStructures();
+        $this->registerStructureTrees();
         $this->registerTaxonomies();
         $this->registerTerms();
     }
@@ -165,27 +166,24 @@ class ServiceProvider extends AddonServiceProvider
 
     private function registerCollectionTrees()
     {
-        // Use the collections' driver as a fallback to ensure backwards compatibility.
-        $collectionsDriver = config('statamic.eloquent-driver.collections.driver', 'file');
+        // if we have this config key then we started on 2.1.0 or earlier when
+        // navigations and trees were driven from the same config key
+        // so we use this config instead of the new ones
+        // lets remove this when we hit 3.0.0
+        $usingOldConfigKeys = config()->has('statamic.eloquent-driver.collections.tree_model');
 
-        if (config('statamic.eloquent-driver.collection_trees.driver', $collectionsDriver) != 'eloquent') {
+        if (config($usingOldConfigKeys ? 'statamic.eloquent-driver.collections.driver' : 'statamic.eloquent-driver.collection_trees.driver', 'file') != 'eloquent') {
             return;
         }
 
         Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
 
-        $this->app->bind('statamic.eloquent.collections.tree', function () {
-            return config(
-                'statamic.eloquent-driver.collection_trees.tree',
-                config('statamic.eloquent-driver.collections.tree')
-            );
+        $this->app->bind('statamic.eloquent.collections.tree', function () use ($usingOldConfigKeys) {
+            return config($usingOldConfigKeys ? 'statamic.eloquent-driver.collections.tree' : 'statamic.eloquent-driver.collection_trees.tree');
         });
 
-        $this->app->bind('statamic.eloquent.collections.tree_model', function () {
-            return config(
-                'statamic.eloquent-driver.collection_trees.model',
-                config('statamic.eloquent-driver.collections.tree_model')
-            );
+        $this->app->bind('statamic.eloquent.collections.tree_model', function () use ($usingOldConfigKeys) {
+            return config($usingOldConfigKeys ? 'statamic.eloquent-driver.collections.tree_model' : 'statamic.eloquent-driver.collection_trees.model');
         });
     }
 
@@ -270,15 +268,28 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.navigations.model', function () {
             return config('statamic.eloquent-driver.navigations.model');
         });
+    }
+
+    private function registerStructureTrees()
+    {
+        // if we have this config key then we started on 2.1.0 or earlier when
+        // navigations and trees were driven from the same config key
+        // so we use this config instead of the new ones
+        // lets remove this when we hit 3.0.0
+        $usingOldConfigKeys = config()->has('statamic.eloquent-driver.navigations.tree_model');
+
+        if (config($usingOldConfigKeys ? 'statamic.eloquent-driver.navigations.driver' : 'statamic.eloquent-driver.navigation_trees.driver', 'file') != 'eloquent') {
+            return;
+        }
 
         Statamic::repository(NavTreeRepositoryContract::class, NavTreeRepository::class);
 
-        $this->app->bind('statamic.eloquent.navigations.tree', function () {
-            return config('statamic.eloquent-driver.navigations.tree');
+        $this->app->bind('statamic.eloquent.navigations.tree', function () use ($usingOldConfigKeys) {
+            return config($usingOldConfigKeys ? 'statamic.eloquent-driver.navigations.tree' : 'statamic.eloquent-driver.navigation_trees.tree');
         });
 
-        $this->app->bind('statamic.eloquent.navigations.tree_model', function () {
-            return config('statamic.eloquent-driver.navigations.tree_model');
+        $this->app->bind('statamic.eloquent.navigations.tree_model', function () use ($usingOldConfigKeys) {
+            return config($usingOldConfigKeys ? 'statamic.eloquent-driver.navigations.tree_model' : 'statamic.eloquent-driver.navigation_trees.model');
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -142,11 +142,11 @@ class ServiceProvider extends AddonServiceProvider
         if (config($usingOldConfigKeys ? 'statamic.eloquent-driver.assets.driver' : 'statamic.eloquent-driver.asset_containers.driver', 'file') != 'eloquent') {
             return;
         }
-      
+
         $this->app->bind('statamic.eloquent.assets.container_model', function () use ($usingOldConfigKeys) {
             return config($usingOldConfigKeys ? 'statamic.eloquent-driver.assets.container_model' : 'statamic.eloquent-driver.asset_containers.model');
         });
-      
+
         Statamic::repository(AssetContainerRepositoryContract::class, AssetContainerRepository::class);
     }
 
@@ -173,6 +173,14 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
+        $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
+            return config('statamic.eloquent-driver.blueprints.blueprint_model');
+        });
+
+        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
+            return config('statamic.eloquent-driver.blueprints.fieldset_model');
+        });
+
         $this->app->singleton(
             'Statamic\Fields\BlueprintRepository',
             'Statamic\Eloquent\Fields\BlueprintRepository'
@@ -182,14 +190,6 @@ class ServiceProvider extends AddonServiceProvider
             'Statamic\Fields\FieldsetRepository',
             'Statamic\Eloquent\Fields\FieldsetRepository'
         );
-
-        $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
-            return config('statamic.eloquent-driver.blueprints.blueprint_model');
-        });
-
-        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
-            return config('statamic.eloquent-driver.blueprints.fieldset_model');
-        });
     }
 
     private function registerCollections()
@@ -198,11 +198,11 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
-
         $this->app->bind('statamic.eloquent.collections.model', function () {
             return config('statamic.eloquent-driver.collections.model');
         });
+
+        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
     }
 
     private function registerCollectionTrees()
@@ -217,8 +217,6 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
-
         $this->app->bind('statamic.eloquent.collections.tree', function () use ($usingOldConfigKeys) {
             return config($usingOldConfigKeys ? 'statamic.eloquent-driver.collections.tree' : 'statamic.eloquent-driver.collection_trees.tree');
         });
@@ -226,6 +224,8 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.collections.tree_model', function () use ($usingOldConfigKeys) {
             return config($usingOldConfigKeys ? 'statamic.eloquent-driver.collections.tree_model' : 'statamic.eloquent-driver.collection_trees.model');
         });
+
+        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
     }
 
     private function registerEntries()
@@ -242,13 +242,13 @@ class ServiceProvider extends AddonServiceProvider
             return config('statamic.eloquent-driver.entries.model');
         });
 
-        Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
-
         $this->app->bind(EntryQueryBuilder::class, function ($app) {
             return new EntryQueryBuilder(
                 $app['statamic.eloquent.entries.model']::query()
             );
         });
+
+        Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
     }
 
     private function registerForms()
@@ -257,8 +257,6 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(FormRepositoryContract::class, FormRepository::class);
-
         $this->app->bind('statamic.eloquent.forms.model', function () {
             return config('statamic.eloquent-driver.forms.model');
         });
@@ -266,6 +264,8 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.forms.submission_model', function () {
             return config('statamic.eloquent-driver.forms.submission_model');
         });
+
+        Statamic::repository(FormRepositoryContract::class, FormRepository::class);
     }
 
     private function registerGlobals()
@@ -274,8 +274,6 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(GlobalRepositoryContract::class, GlobalRepository::class);
-
         $this->app->bind('statamic.eloquent.global_sets.model', function () {
             return config('statamic.eloquent-driver.global_sets.model');
         });
@@ -283,6 +281,8 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.global_sets.variables_model', function () {
             return config('statamic.eloquent-driver.global_sets.variables_model');
         });
+
+        Statamic::repository(GlobalRepositoryContract::class, GlobalRepository::class);
     }
 
     private function registerRevisions()
@@ -291,11 +291,11 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(RevisionRepositoryContract::class, RevisionRepository::class);
-
         $this->app->bind('statamic.eloquent.revisions.model', function () {
             return config('statamic.eloquent-driver.revisions.model');
         });
+
+        Statamic::repository(RevisionRepositoryContract::class, RevisionRepository::class);
     }
 
     private function registerStructures()
@@ -304,11 +304,11 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(NavigationRepositoryContract::class, NavigationRepository::class);
-
         $this->app->bind('statamic.eloquent.navigations.model', function () {
             return config('statamic.eloquent-driver.navigations.model');
         });
+
+        Statamic::repository(NavigationRepositoryContract::class, NavigationRepository::class);
     }
 
     private function registerStructureTrees()
@@ -323,8 +323,6 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(NavTreeRepositoryContract::class, NavTreeRepository::class);
-
         $this->app->bind('statamic.eloquent.navigations.tree', function () use ($usingOldConfigKeys) {
             return config($usingOldConfigKeys ? 'statamic.eloquent-driver.navigations.tree' : 'statamic.eloquent-driver.navigation_trees.tree');
         });
@@ -332,6 +330,8 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.navigations.tree_model', function () use ($usingOldConfigKeys) {
             return config($usingOldConfigKeys ? 'statamic.eloquent-driver.navigations.tree_model' : 'statamic.eloquent-driver.navigation_trees.model');
         });
+
+        Statamic::repository(NavTreeRepositoryContract::class, NavTreeRepository::class);
     }
 
     public function registerTaxonomies()
@@ -340,11 +340,11 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(TaxonomyRepositoryContract::class, TaxonomyRepository::class);
-
         $this->app->bind('statamic.eloquent.taxonomies.model', function () {
             return config('statamic.eloquent-driver.taxonomies.model');
         });
+
+        Statamic::repository(TaxonomyRepositoryContract::class, TaxonomyRepository::class);
     }
 
     public function registerTerms()
@@ -352,8 +352,6 @@ class ServiceProvider extends AddonServiceProvider
         if (config('statamic.eloquent-driver.terms.driver', 'file') != 'eloquent') {
             return;
         }
-
-        Statamic::repository(TermRepositoryContract::class, TermRepository::class);
 
         $this->app->bind('statamic.eloquent.terms.model', function () {
             return config('statamic.eloquent-driver.terms.model');
@@ -364,6 +362,8 @@ class ServiceProvider extends AddonServiceProvider
                 $app['statamic.eloquent.terms.model']::query()
             );
         });
+
+        Statamic::repository(TermRepositoryContract::class, TermRepository::class);
     }
 
     protected function migrationsPath($filename)

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -151,25 +151,28 @@ class ServiceProvider extends AddonServiceProvider
 
     private function registerCollections()
     {
-        if (config('statamic.eloquent-driver.collections.driver', 'file') != 'eloquent') {
-            return;
+        $collectionsDriver = config('statamic.eloquent-driver.collections.driver', 'file');
+        $collectionsTreeDriver = config('statamic.eloquent-driver.collections.tree_driver', $collectionsDriver);
+
+        if ($collectionsDriver == 'eloquent') {
+            Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
+    
+            $this->app->bind('statamic.eloquent.collections.model', function () {
+                return config('statamic.eloquent-driver.collections.model');
+            });
         }
 
-        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
-
-        $this->app->bind('statamic.eloquent.collections.model', function () {
-            return config('statamic.eloquent-driver.collections.model');
-        });
-
-        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
-
-        $this->app->bind('statamic.eloquent.collections.tree', function () {
-            return config('statamic.eloquent-driver.collections.tree');
-        });
-
-        $this->app->bind('statamic.eloquent.collections.tree_model', function () {
-            return config('statamic.eloquent-driver.collections.tree_model');
-        });
+        if ($collectionsTreeDriver == 'eloquent') {
+            Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
+    
+            $this->app->bind('statamic.eloquent.collections.tree', function () {
+                return config('statamic.eloquent-driver.collections.tree');
+            });
+    
+            $this->app->bind('statamic.eloquent.collections.tree_model', function () {
+                return config('statamic.eloquent-driver.collections.tree_model');
+            });
+        }
     }
 
     private function registerEntries()

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -3,7 +3,6 @@
 namespace Statamic\Eloquent\Structures;
 
 use Statamic\Contracts\Structures\Tree as TreeContract;
-use Statamic\Eloquent\Structures\NavTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\NavTreeRepository as StacheRepository;
 

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent\Structures;
 
 use Statamic\Contracts\Structures\Tree as TreeContract;
+use Statamic\Eloquent\Structures\NavTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\NavTreeRepository as StacheRepository;
 
@@ -22,6 +23,11 @@ class NavTreeRepository extends StacheRepository
 
     public function save($entry)
     {
+        // if we are using flat files for the config, but eloquent for the data
+        if (! $entry instanceof NavTree) {
+            return parent::save($entry);
+        }
+
         $model = $entry->toModel();
         $model->save();
 
@@ -32,6 +38,11 @@ class NavTreeRepository extends StacheRepository
 
     public function delete($entry)
     {
+        // if we are using flat files for the config, but eloquent for the data
+        if (! $entry instanceof NavTree) {
+            return parent::save($entry);
+        }
+
         $entry->model()->delete();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/statamic/eloquent-driver/issues/147

This small pull request enables the possibility to define a different driver for collections and collection trees.

This can be useful if you want your collection definitions to be stored as flat files (so they're available and synced throughout all environments), but have eloquent entries which has a direct impact on the tree structure (which would not be the same in all environments).

All tests are passing, but I saw no config-based tests I could alter or enrich. However, it was tested in all 5 possible configurations on a local site:
- driver -> eloquent
tree_driver -> commented

- driver -> file
tree_driver -> commented

- driver -> eloquent
tree_driver -> eloquent

- driver -> eloquent
tree_driver -> file

- driver -> file
tree_driver -> eloquent

Let me know if you need me to do some changes !

**P.S.** This is a non breaking change, so people that don't have the new key in their published config file won't be affected.

**Second P.S.** My intent is to do the same kind of changes where a split would be possible for other "models" (i.e. navigations) without introducing breaking changes.