### PR TITLE
Only save custom sort field and direction

### DIFF
--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -68,7 +68,7 @@ class Collection extends FileEntry
                 'default_status'       => $source->defaultPublishState,
                 'structure'            => $source->structureContents(),
                 'sort_dir'             => $source->sortDirection(),
-                'sort_field'           => $source->sortField(),
+                'sort_field'           => $source->orderable() ? null : $source->sortField(),
                 'taxonomies'           => $source->taxonomies,
                 'propagate'            => $source->propagate(),
                 'past_date_behavior'   => $source->pastDateBehavior(),

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -67,8 +67,8 @@ class Collection extends FileEntry
                 'revisions'            => $source->revisionsEnabled(),
                 'default_status'       => $source->defaultPublishState,
                 'structure'            => $source->structureContents(),
-                'sort_dir'             => $source->sortDirection(),
-                'sort_field'           => $source->orderable() ? null : $source->sortField(),
+                'sort_dir'             => $source->customSortDirection(),
+                'sort_field'           => $source->customSortField(),
                 'taxonomies'           => $source->taxonomies,
                 'propagate'            => $source->propagate(),
                 'past_date_behavior'   => $source->pastDateBehavior(),
@@ -101,5 +101,15 @@ class Collection extends FileEntry
             ->expectsRoot($this->structureContents['root'] ?? false)
             ->showSlugs($this->structureContents['slugs'] ?? false)
             ->maxDepth($this->structureContents['max_depth'] ?? null);
+    }
+
+    public function customSortField()
+    {
+        return $this->sortField;
+    }
+
+    public function customSortDirection()
+    {
+        return $this->sortDirection;
     }
 }


### PR DESCRIPTION
@robdekort found a lovely bug that when you have a dated collection and make it order able it wasn't honouring the order you set. So this fix changes it by not saving the `sortField` to the database when the collection is orderable.