### PR TITLE
Fixing some model references to configurable references

### DIFF
--- a/src/Commands/ImportCollections.php
+++ b/src/Commands/ImportCollections.php
@@ -10,7 +10,6 @@ use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Structures\CollectionTreeRepository as CollectionTreeRepositoryContract;
 use Statamic\Eloquent\Collections\Collection as EloquentCollection;
-use Statamic\Eloquent\Structures\CollectionTree as EloquentCollectionTree;
 use Statamic\Entries\Collection as StacheCollection;
 use Statamic\Facades\Collection as CollectionFacade;
 use Statamic\Stache\Repositories\CollectionRepository;
@@ -85,7 +84,7 @@ class ImportCollections extends Command
             if ($structure = $collection->structure()) {
                 $structure->trees()->each(function ($tree) {
                     $lastModified = $tree->fileLastModified();
-                    EloquentCollectionTree::makeModelFromContract($tree)
+                    app('statamic.eloquent.collections.tree')::makeModelFromContract($tree)
                         ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                         ->save();
                 });

--- a/src/Commands/ImportForms.php
+++ b/src/Commands/ImportForms.php
@@ -8,7 +8,6 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Contracts\Forms\Submission as SubmissionContract;
 use Statamic\Eloquent\Forms\Form;
-use Statamic\Eloquent\Forms\SubmissionModel;
 use Statamic\Facades\File;
 use Statamic\Forms\Form as StacheForm;
 use Statamic\Forms\FormRepository;
@@ -65,7 +64,7 @@ class ImportForms extends Command
             $model->save();
 
             $form->submissions()->each(function ($submission) use ($model) {
-                $timestamp = (new SubmissionModel())->fromDateTime($submission->date());
+                $timestamp = app('statamic.eloquent.forms.submission_model')::make()->fromDateTime($submission->date());
 
                 $model->submissions()->firstOrNew(['created_at' => $timestamp])->fill([
                     'data'       => $submission->data(),

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -21,7 +21,7 @@ class BlueprintRepository extends StacheRepository
                 return null;
             }
 
-            $blueprintModel = ($namespace ? $this->filesIn($namespace) : BlueprintModel::whereNull('namespace'))
+            $blueprintModel = ($namespace ? $this->filesIn($namespace) : app('statamic.eloquent.blueprints.blueprint_model')::whereNull('namespace'))
                 ->where('handle', $handle)
                 ->first();
 
@@ -83,7 +83,7 @@ class BlueprintRepository extends StacheRepository
         return Blink::store(self::BLINK_NAMESPACE_PATHS)->once($namespace ?? 'none', function () use ($namespace) {
             $namespace = str_replace('/', '.', $namespace);
 
-            if (count(($blueprintModels = BlueprintModel::where('namespace', $namespace)->get())) == 0) {
+            if (count($blueprintModels = app('statamic.eloquent.blueprints.blueprint_model')::where('namespace', $namespace)->get()) == 0) {
                 return collect();
             }
 

--- a/src/Forms/FormModel.php
+++ b/src/Forms/FormModel.php
@@ -16,6 +16,6 @@ class FormModel extends BaseModel
 
     public function submissions()
     {
-        return $this->hasMany(SubmissionModel::class, 'form_id');
+        return $this->hasMany(app('statamic.eloquent.forms.submission_model'), 'form_id');
     }
 }

--- a/src/Forms/FormRepository.php
+++ b/src/Forms/FormRepository.php
@@ -21,7 +21,7 @@ class FormRepository extends StacheRepository
 
     public function all()
     {
-        return FormModel::all()
+        return app('statamic.eloquent.forms.model')::all()
             ->map(function ($form) {
                 return app(FormContract::class)::fromModel($form);
             });

--- a/src/Forms/SubmissionModel.php
+++ b/src/Forms/SubmissionModel.php
@@ -18,6 +18,6 @@ class SubmissionModel extends BaseModel
 
     public function form()
     {
-        return $this->belongsTo(FormModel::class, 'id');
+        return $this->belongsTo(app('statamic.eloquent.forms.model'), 'id');
     }
 }

--- a/src/Structures/NavigationRepository.php
+++ b/src/Structures/NavigationRepository.php
@@ -25,13 +25,13 @@ class NavigationRepository extends StacheRepository
 
     public function all(): Collection
     {
-        return $this->transform(NavModel::all());
+        return $this->transform(app('statamic.eloquent.navigations.model')::all());
     }
 
     public function findByHandle($handle): ?NavContract
     {
         return Blink::once("eloquent-nav-{$handle}", function () use ($handle) {
-            $model = NavModel::whereHandle($handle)->first();
+            $model = app('statamic.eloquent.navigations.model')::whereHandle($handle)->first();
 
             return $model ? app(NavContract::class)->fromModel($model) : null;
         });


### PR DESCRIPTION
There are some references to models which are not called via app('...') but directly. That means that overriding those references is not possible. This PR fixes that.