### PR TITLE
Update entry order when saving a tree and collections are stored in files

### DIFF
--- a/src/Listeners/UpdateStructuredEntryOrder.php
+++ b/src/Listeners/UpdateStructuredEntryOrder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Statamic\Eloquent\Listeners;
+
+use Statamic\Eloquent\Collections\CollectionRepository;
+use Statamic\Events\CollectionTreeSaved;
+
+class UpdateStructuredEntryOrder
+{
+    public function handle(CollectionTreeSaved $event)
+    {
+        $tree = $event->tree;
+        $collection = $tree->collection();
+
+        if (config('statamic.eloquent-driver.entries.driver', 'file') !== 'eloquent') {
+            return;
+        }
+
+        if (config('statamic.eloquent-driver.collections.driver') === 'eloquent') {
+            // If the collections are configured to use Eloquent, then the entry
+            // order will be updated through the regular event/listener flow.
+            return;
+        }
+
+        $diff = $tree->diff();
+
+        $ids = array_merge($diff->moved(), $diff->added());
+
+        if (empty($ids)) {
+            return;
+        }
+
+        app(CollectionRepository::class)->updateEntryOrder($collection, $ids);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,6 +21,7 @@ use Statamic\Eloquent\Entries\EntryQueryBuilder;
 use Statamic\Eloquent\Entries\EntryRepository;
 use Statamic\Eloquent\Forms\FormRepository;
 use Statamic\Eloquent\Globals\GlobalRepository;
+use Statamic\Eloquent\Listeners\UpdateStructuredEntryOrder;
 use Statamic\Eloquent\Revisions\RevisionRepository;
 use Statamic\Eloquent\Structures\CollectionTreeRepository;
 use Statamic\Eloquent\Structures\NavigationRepository;
@@ -28,6 +29,7 @@ use Statamic\Eloquent\Structures\NavTreeRepository;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
 use Statamic\Eloquent\Taxonomies\TermQueryBuilder;
 use Statamic\Eloquent\Taxonomies\TermRepository;
+use Statamic\Events\CollectionTreeSaved;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -39,6 +41,12 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $updateScripts = [
         \Statamic\Eloquent\Updates\AddOrderToEntriesTable::class,
+    ];
+
+    protected $listen = [
+        CollectionTreeSaved::class => [
+            UpdateStructuredEntryOrder::class,
+        ],
     ];
 
     public function boot()


### PR DESCRIPTION
Fixes #139

This adds an event listener that does the exact same thing as the core's UpdateStructuredEntryOrder listener.

It'll update the `order` column of entries when you save a tree.

It will only do it if entries are configured to be in Eloquent, and Collections are configured to not be.