### PR TITLE
Set origin id on entry model

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -98,7 +98,7 @@ class Entry extends FileEntry
             $this->origin = $origin;
 
             if ($this->model) {
-                $this->model->origin_id = $origin instanceof EntryContract ? $origin->id : $origin;
+                $this->model->origin_id = $origin instanceof EntryContract ? $origin->id() : $origin;
             }
 
             return $this;

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -97,6 +97,10 @@ class Entry extends FileEntry
         if (func_num_args() > 0) {
             $this->origin = $origin;
 
+            if ($this->model) {
+                $this->model->origin_id = $origin instanceof EntryContract ? $origin->id : $origin;
+            }
+
             return $this;
         }
 


### PR DESCRIPTION
When calling `$entry->origin(null)`, also set the `origin_id` on the model.

Otherwise, subsequent calls to `$entry->origin()` will fall back to reading the origin_id on the model, leaving you no way to truly null it out.

This is necessary when you delete an entry and choose to "detach" the localizations. All of the descendant entries should get the origin removed. Before this PR, when you tried to do that, the origin just sticks around. You end up with an error when trying to delete an entry instead of it actually getting deleted.

By solving this, the removal of the origin_id foreign key constraint onDelete cascade in #100 shouldn't be an issue.
