### PR TITLE
Remove custom collection methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.0.0"
+        "statamic/cms": "^4.6.0"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -100,14 +100,4 @@ class Collection extends FileEntry
             ->showSlugs($this->structureContents['slugs'] ?? false)
             ->maxDepth($this->structureContents['max_depth'] ?? null);
     }
-
-    public function customSortField()
-    {
-        return $this->sortField;
-    }
-
-    public function customSortDirection()
-    {
-        return $this->sortDirection;
-    }
 }


### PR DESCRIPTION
Closes #161

This bumps the minimum version of Statamic to where the methods are available, so we don't need the overrides anymore.

This requires 4.6.0 to be tagged.
