### PR TITLE
Entry import: follow makeModelFromContract() approach used in other imports

### DIFF
--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -7,6 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
+use Statamic\Eloquent\Entries\Entry as EloquentEntry;
 use Statamic\Facades\Entry;
 use Statamic\Stache\Repositories\CollectionRepository;
 use Statamic\Stache\Repositories\EntryRepository;
@@ -67,7 +68,9 @@ class ImportEntries extends Command
 
         $this->withProgressBar($entriesWithoutOrigin, function ($entry) {
             $lastModified = $entry->fileLastModified();
-            $entry->toModel()->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])->save();
+            $entry = EloquentEntry::makeModelFromContract($entry)
+                ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
+                ->save();
         });
 
         if ($entriesWithOrigin->count() > 0) {
@@ -76,7 +79,9 @@ class ImportEntries extends Command
 
             $this->withProgressBar($entriesWithOrigin, function ($entry) {
                 $lastModified = $entry->fileLastModified();
-                $entry->toModel()->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])->save();
+                EloquentEntry::makeModelFromContract($entry)
+                    ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
+                    ->save();
             });
         }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -38,29 +38,34 @@ class Entry extends FileEntry
 
     public function toModel()
     {
+        return self::makeModelFromContract($this);
+    }
+
+    public static function makeModelFromContract(EntryContract $source)
+    {
         $class = app('statamic.eloquent.entries.model');
 
-        $data = $this->data();
+        $data = $source->data();
 
-        if ($this->blueprint && $this->collection()->entryBlueprints()->count() > 1) {
-            $data['blueprint'] = $this->blueprint;
+        if ($source->blueprint && $source->collection()->entryBlueprints()->count() > 1) {
+            $data['blueprint'] = $source->blueprint;
         }
 
         $attributes = [
-            'origin_id'  => $this->origin()?->id(),
-            'site'       => $this->locale(),
-            'slug'       => $this->slug(),
-            'uri'        => $this->uri(),
-            'date'       => $this->hasDate() ? $this->date() : null,
-            'collection' => $this->collectionHandle(),
+            'origin_id'  => $source->origin()?->id(),
+            'site'       => $source->locale(),
+            'slug'       => $source->slug(),
+            'uri'        => $source->uri(),
+            'date'       => $source->hasDate() ? $source->date() : null,
+            'collection' => $source->collectionHandle(),
             'data'       => $data->except(EntryQueryBuilder::COLUMNS),
-            'published'  => $this->published(),
-            'status'     => $this->status(),
-            'updated_at' => $this->lastModified(),
-            'order'      => $this->order(),
+            'published'  => $source->published(),
+            'status'     => $source->status(),
+            'updated_at' => $source->lastModified(),
+            'order'      => $source->order(),
         ];
 
-        if ($id = $this->id()) {
+        if ($id = $source->id()) {
             $attributes['id'] = $id;
         }
 


### PR DESCRIPTION
Importing entries has been broken, not totally sure when we lost sync with core, but something has changed that stopped us getting a Eloquent entry class and instead a Stache entry class.

Luckily we have an approach that worked with the other repositories, so let's move entries to using that same approach.