### PR TITLE
Allow 'hidden' blueprints to be un-hidden

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -114,6 +114,13 @@ class BlueprintRepository extends StacheRepository
         return [$namespace, $handle];
     }
 
+    public function getModel($blueprint)
+    {
+        return app('statamic.eloquent.blueprints.blueprint_model')::where('namespace', $blueprint->namespace() ?? null)
+            ->where('handle', $blueprint->handle())
+            ->first();
+    }
+
     public function updateModel($blueprint)
     {
         $model = app('statamic.eloquent.blueprints.blueprint_model')::firstOrNew([
@@ -121,15 +128,20 @@ class BlueprintRepository extends StacheRepository
             'namespace' => $blueprint->namespace() ?? null,
         ]);
 
-        $model->data = $this->addOrderToBlueprintSections($blueprint->contents());
+        $data = $this->addOrderToBlueprintSections($blueprint->contents());
+
+        if (! $blueprint->hidden()) {
+            unset($data['hide']);
+        }
+
+        $model->data = $data;
+
         $model->save();
     }
 
     public function deleteModel($blueprint)
     {
-        $model = app('statamic.eloquent.blueprints.blueprint_model')::where('namespace', $blueprint->namespace() ?? null)
-            ->where('handle', $blueprint->handle())
-            ->first();
+        $model = $this->getModel($blueprint);
 
         if ($model) {
             $model->delete();

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Data\Fields;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Statamic\Facades\Blueprint;
+use Tests\TestCase;
+
+class BlueprintTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->singleton(
+            'Statamic\Fields\BlueprintRepository',
+            'Statamic\Eloquent\Fields\BlueprintRepository'
+        );
+
+        $this->app->singleton(
+            'Statamic\Fields\FieldsetRepository',
+            'Statamic\Eloquent\Fields\FieldsetRepository'
+        );
+
+        $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
+            return \Statamic\Eloquent\Fields\BlueprintModel::class;
+        });
+
+        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
+            return \Statamic\Eloquent\Fields\FieldsetModel::class;
+        });
+    }
+
+    /** @test */
+    public function it_saves_and_removes_hidden_on_model()
+    {
+        $blueprint = Blueprint::make()
+            ->setHandle('test')
+            ->setHidden(true)
+            ->save();
+
+        $model = Blueprint::getModel($blueprint);
+
+        $this->assertTrue($model->data['hide']);
+
+        $blueprint->setHidden(false)->save();
+
+        $model = Blueprint::getModel($blueprint);
+
+        $this->assertFalse(isset($model->data['hide']));
+    }
+
+    /** @test */
+    public function it_deletes_the_model_when_the_blueprint_is_deleted()
+    {
+        $blueprint = Blueprint::make()
+            ->setHandle('test')
+            ->setHidden(true)
+            ->save();
+
+        $model = Blueprint::getModel($blueprint);
+
+        $this->assertNotNull($model);
+
+        $blueprint->delete();
+
+        $model = Blueprint::getModel($blueprint);
+
+        $this->assertNull($model);
+    }
+}


### PR DESCRIPTION
When toggling the blueprint visibility in the CP hidden it was getting stuck on 'hidden', and could not be reverted from that state. This is due to how the `contents` are being merged in and out of the database.

This change does a hard check on hidden before saving the model and removes it from the data being stored when not required. 

I also took the opportunity to begin test coverage for blueprints.

Fixes: https://github.com/statamic/eloquent-driver/issues/159