### PR TITLE
Ensure computed values are stored in the database so they can be queried

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -41,7 +41,8 @@ class Entry extends FileEntry
     {
         $class = app('statamic.eloquent.entries.model');
 
-        $data = $this->data();
+        $data = $this->data()
+            ->merge(method_exists($this, 'computedData') ? $this->computedData() : []);
 
         $attributes = [
             'origin_id'  => $this->origin()?->id(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -49,7 +49,7 @@ class Entry extends FileEntry
         $class = app('statamic.eloquent.entries.model');
 
         $data = $source->data()
-            ->merge(method_exists($this, 'computedData') ? $this->computedData() : []);
+            ->merge(method_exists($source, 'computedData') ? $source->computedData() : []);
 
         $date = $source->hasDate() ? $source->date() : null;
 

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -7,10 +7,9 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
+use Statamic\Facades;
 use Statamic\Facades\Collection as CollectionFacade;
 use Statamic\Facades\Entry as EntryFacade;
-use Statamic\Facades;
-
 use Tests\TestCase;
 
 class EntryTest extends TestCase
@@ -125,7 +124,7 @@ class EntryTest extends TestCase
 
         $this->assertEquals(100, $freshEntry->shares);
     }
-  
+
     /** @test */
     public function it_propagates_entry_if_configured()
     {

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -7,6 +7,7 @@ use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Facades\Collection as CollectionFacade;
+use Statamic\Facades\Entry as EntryFacade;
 use Tests\TestCase;
 
 class EntryTest extends TestCase
@@ -86,5 +87,39 @@ class EntryTest extends TestCase
         $entry->save();
 
         $this->assertEquals(150, $entry->model()->data['shares']);
+    }
+
+    /** @test */
+    public function it_defers_to_the_live_computed_value_instead_of_the_stored_value()
+    {
+        $collection = Collection::make('blog')->title('blog')->routes([
+            'en' => '/blog/{slug}',
+        ])->save();
+
+        CollectionFacade::computed('blog', 'shares', function ($entry, $value) {
+            return ! isset($value) ? 150 : 100;
+        });
+
+        $model = new EntryModel([
+            'slug' => 'the-slug',
+            'data' => [
+                'foo' => 'bar',
+            ],
+        ]);
+
+        $entry = (new Entry())
+            ->collection('blog')
+            ->slug('the-slug')
+            ->data([
+                'foo' => 'bar',
+            ]);
+
+        $entry->save();
+
+        $this->assertEquals(150, $entry->model()->data['shares']);
+
+        $freshEntry = EntryFacade::query()->where('slug', 'the-slug')->first();
+
+        $this->assertEquals(100, $freshEntry->shares);
     }
 }


### PR DESCRIPTION
Add computed values to the data being stored to `entries`, so its available to the query builder.

Fixes: https://github.com/statamic/eloquent-driver/issues/149