### PR TITLE
Restructure global variables to use its own table

### DIFF
--- a/database/migrations/create_global_variables_table.php.stub
+++ b/database/migrations/create_global_variables_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create($this->prefix('global_set_variables'), function (Blueprint $table) {
+            $table->id();
+            $table->string('handle')->index();
+            $table->string('locale')->nullable();
+            $table->string('origin')->nullable();
+            $table->jsonb('data');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix('global_set_variables'));
+    }
+};

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -11,7 +11,7 @@ return new class extends Migration {
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
-            $table->jsonb('localizations');
+            $table->jsonb('settings');
             $table->timestamps();
         });
     }

--- a/database/migrations/updates/update_globals_table.php.stub
+++ b/database/migrations/updates/update_globals_table.php.stub
@@ -20,15 +20,15 @@ return new class extends Migration {
                 foreach ($localizations as $localization) {
                     VariablesModel::create([
                         'handle' => $model->handle,
-                        'locale' => $localization['locale'],
-                        'data' => $localization['data'],
-                        'origin' => $localization['origin'],
+                        'locale' => $localization->locale,
+                        'data' => $localization->data,
+                        'origin' => $localization->origin,
                     ]);
                 }
             });
 
         Schema::table($this->prefix('global_sets'), function (Blueprint $table) {
-            $table->dropColumn('localizations'));
+            $table->dropColumn('localizations');
         });
     }
 
@@ -40,17 +40,17 @@ return new class extends Migration {
         });
 
         GlobalSetModel::all()
-            ->each(function ($model)) {
-                $model->localizations = VariablesModel::where('handle' => $model->handle)
+            ->each(function ($model) {
+                $model->localizations = VariablesModel::where('handle', $model->handle)
                     ->get()
                     ->mapWithKeys(function ($variable, $key) {
                         return [
-                            $variable->locale => [
+                            $variable->locale = [
                                 'locale' => $variable->locale,
                                 'data' => $variable->data,
                                 'origin' => $variable->origin,
-                            ];
-                        ]
+                            ],
+                        ];
                     });
 
                 $model->save();

--- a/database/migrations/updates/update_globals_table.php.stub
+++ b/database/migrations/updates/update_globals_table.php.stub
@@ -36,6 +36,24 @@ return new class extends Migration {
     {
         Schema::table($this->prefix('global_sets'), function (Blueprint $table) {
             $table->dropColumn('settings');
+            $table->jsonb('localizations')->after('title')->nullable();
         });
+
+        GlobalSetModel::all()
+            ->each(function ($model)) {
+                $model->localizations = VariablesModel::where('handle' => $model->handle)
+                    ->get()
+                    ->mapWithKeys(function ($variable, $key) {
+                        return [
+                            $variable->locale => [
+                                'locale' => $variable->locale,
+                                'data' => $variable->data,
+                                'origin' => $variable->origin,
+                            ];
+                        ]
+                    });
+
+                $model->save();
+            });
     }
 };

--- a/database/migrations/updates/update_globals_table.php.stub
+++ b/database/migrations/updates/update_globals_table.php.stub
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+use Statamic\Eloquent\Globals\GlobalSetModel;
+use Statamic\Eloquent\Globals\VariablesModel;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table($this->prefix('global_sets'), function (Blueprint $table) {
+            $table->jsonb('settings')->after('title')->nullable();
+        });
+
+        GlobalSetModel::all()
+            ->each(function ($model) {
+                $localizations = json_decode($model->localizations);
+
+                foreach ($localizations as $localization) {
+                    VariablesModel::create([
+                        'handle' => $model->handle,
+                        'locale' => $localization['locale'],
+                        'data' => $localization['data'],
+                        'origin' => $localization['origin'],
+                    ]);
+                }
+            });
+
+        Schema::table($this->prefix('global_sets'), function (Blueprint $table) {
+            $table->dropColumn('localizations'));
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('global_sets'), function (Blueprint $table) {
+            $table->dropColumn('settings');
+        });
+    }
+};

--- a/src/Commands/ImportGlobals.php
+++ b/src/Commands/ImportGlobals.php
@@ -56,7 +56,9 @@ class ImportGlobals extends Command
 
         $this->withProgressBar($sets, function ($set) {
             $lastModified = $set->fileLastModified();
-            $set->toModel()->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])->save();
+
+            $set = GlobalSet::makeModelFromContract($set)->fill(['created_at' => $lastModified, 'updated_at' => $lastModified]);
+            $set->save();
         });
 
         $this->newLine();

--- a/src/Commands/ImportGlobals.php
+++ b/src/Commands/ImportGlobals.php
@@ -7,6 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
 use Statamic\Contracts\Globals\GlobalSet as GlobalSetContract;
 use Statamic\Eloquent\Globals\GlobalSet;
+use Statamic\Eloquent\Globals\Variables;
 use Statamic\Facades\GlobalSet as GlobalSetFacade;
 use Statamic\Stache\Repositories\GlobalRepository;
 use Statamic\Statamic;
@@ -57,8 +58,12 @@ class ImportGlobals extends Command
         $this->withProgressBar($sets, function ($set) {
             $lastModified = $set->fileLastModified();
 
-            $set = GlobalSet::makeModelFromContract($set)->fill(['created_at' => $lastModified, 'updated_at' => $lastModified]);
-            $set->save();
+            $setModel = GlobalSet::makeModelFromContract($set)->fill(['created_at' => $lastModified, 'updated_at' => $lastModified]);
+            $setModel->save();
+
+            $set->localizations()->each(function ($locale) {
+                Variables::makeModelFromContract($locale)->save();
+            });
         });
 
         $this->newLine();

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -48,6 +48,10 @@ class GlobalRepository extends StacheRepository
         $model = $entry->toModel();
         $model->save();
 
+        $entry->localizations()->each(function ($locale) {
+            $locale->toModel()->save();
+        });
+
         $entry->model($model->fresh());
 
         Blink::forget("eloquent-globalsets-{$model->handle}");

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -49,7 +49,7 @@ class GlobalRepository extends StacheRepository
         $model->save();
 
         $entry->localizations()->each(function ($locale) {
-            $locale->toModel()->save();
+            $locale->save();
         });
 
         $entry->model($model->fresh());

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -5,7 +5,6 @@ namespace Statamic\Eloquent\Globals;
 use Statamic\Contracts\Globals\GlobalSet as Contract;
 use Statamic\Contracts\Globals\Variables as VariablesContract;
 use Statamic\Eloquent\Globals\GlobalSetModel as Model;
-use Statamic\Eloquent\Globals\VariablesModel;
 use Statamic\Globals\GlobalSet as FileEntry;
 
 class GlobalSet extends FileEntry

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -21,7 +21,7 @@ class GlobalSet extends FileEntry
 
         $variablesModel = app('statamic.eloquent.global_sets.variables_model');
 
-        $localizations = $variablesModel::query()->where('handle', $model->handle)->all()
+        $localizations = $variablesModel::query()->where('handle', $model->handle)->all();
         foreach ($localizations as $localization) {
             $global->addLocalization(app(VariablesContract::class)::fromModel($localization));
         }

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -37,7 +37,7 @@ class GlobalSet extends FileEntry
         $class = app('statamic.eloquent.global_sets.model');
 
         $source->localizations()->each(function ($value) {
-            Variables::makeModelFromContract($value)->save();
+            Variables::makeModelFromContract($value);
         });
 
         return $class::firstOrNew(['handle' => $source->handle()])->fill([

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -20,7 +20,7 @@ class GlobalSet extends FileEntry
 
         $variablesModel = app('statamic.eloquent.global_sets.variables_model');
 
-        $localizations = $variablesModel::query()->where('handle', $model->handle)->all();
+        $localizations = $variablesModel::query()->where('handle', $model->handle)->get();
         foreach ($localizations as $localization) {
             $global->addLocalization(app(VariablesContract::class)::fromModel($localization));
         }

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -2,8 +2,10 @@
 
 namespace Statamic\Eloquent\Globals;
 
+use Statamic\Contracts\Globals\GlobalSet as Contract;
 use Statamic\Contracts\Globals\Variables as VariablesContract;
 use Statamic\Eloquent\Globals\GlobalSetModel as Model;
+use Statamic\Eloquent\Globals\Variables;
 use Statamic\Globals\GlobalSet as FileEntry;
 
 class GlobalSet extends FileEntry
@@ -20,7 +22,7 @@ class GlobalSet extends FileEntry
         $variablesModel = app('statamic.eloquent.global_sets.variables_model');
 
         foreach ($model->localizations as $localization) {
-            $global->addLocalization(app(VariablesContract::class)::fromModel($variablesModel::make($localization)));
+            $global->addLocalization(app(VariablesContract::class)::fromModel($localization));
         }
 
         return $global;
@@ -28,13 +30,20 @@ class GlobalSet extends FileEntry
 
     public function toModel()
     {
+        return self::makeModelFromContract($this);
+    }
+
+    public static function makeModelFromContract(Contract $source)
+    {
         $class = app('statamic.eloquent.global_sets.model');
 
-        $localizations = $this->localizations()->map(fn ($value) => $value->toModel()->toArray());
+        $source->localizations()->each(function ($value) {
+            Variables::makeModelFromContract($value)->save();
+        });
 
-        return $class::firstOrNew(['handle' => $this->handle()])->fill([
-            'title'         => $this->title(),
-            'localizations' => $localizations,
+        return $class::firstOrNew(['handle' => $source->handle()])->fill([
+            'title' => $source->title(),
+            'settings'  => [], // future proofing
         ]);
     }
 

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -5,6 +5,7 @@ namespace Statamic\Eloquent\Globals;
 use Statamic\Contracts\Globals\GlobalSet as Contract;
 use Statamic\Contracts\Globals\Variables as VariablesContract;
 use Statamic\Eloquent\Globals\GlobalSetModel as Model;
+use Statamic\Eloquent\Globals\VariablesModel;
 use Statamic\Globals\GlobalSet as FileEntry;
 
 class GlobalSet extends FileEntry
@@ -20,7 +21,8 @@ class GlobalSet extends FileEntry
 
         $variablesModel = app('statamic.eloquent.global_sets.variables_model');
 
-        foreach ($model->localizations as $localization) {
+        $localizations = $variablesModel::query()->where('handle', $model->handle)->all()
+        foreach ($localizations as $localization) {
             $global->addLocalization(app(VariablesContract::class)::fromModel($localization));
         }
 

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -5,7 +5,6 @@ namespace Statamic\Eloquent\Globals;
 use Statamic\Contracts\Globals\GlobalSet as Contract;
 use Statamic\Contracts\Globals\Variables as VariablesContract;
 use Statamic\Eloquent\Globals\GlobalSetModel as Model;
-use Statamic\Eloquent\Globals\Variables;
 use Statamic\Globals\GlobalSet as FileEntry;
 
 class GlobalSet extends FileEntry

--- a/src/Globals/GlobalSetModel.php
+++ b/src/Globals/GlobalSetModel.php
@@ -19,9 +19,4 @@ class GlobalSetModel extends BaseModel
     {
         return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
     }
-
-    public function localizations()
-    {
-        return $this->hasMany(VariablesModel::class, 'handle', 'handle');
-    }
 }

--- a/src/Globals/GlobalSetModel.php
+++ b/src/Globals/GlobalSetModel.php
@@ -12,11 +12,16 @@ class GlobalSetModel extends BaseModel
     protected $table = 'global_sets';
 
     protected $casts = [
-        'localizations' => 'json',
+        'settings' => 'json',
     ];
 
     public function getAttribute($key)
     {
         return Arr::get($this->getAttributeValue('data'), $key, parent::getAttribute($key));
+    }
+
+    public function localizations()
+    {
+        return $this->hasMany(VariablesModel::class, 'handle', 'handle');
     }
 }

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -45,4 +45,11 @@ class Variables extends FileEntry
     {
         return $this->globalSet()->in($origin);
     }
+
+    public function save()
+    {
+        $this->toModel()->save();
+
+        return $this;
+    }
 }

--- a/src/Globals/VariablesModel.php
+++ b/src/Globals/VariablesModel.php
@@ -11,7 +11,9 @@ class VariablesModel extends BaseModel
 
     protected $table = 'global_set_variables';
 
-    protected $casts = [];
+    protected $casts = [
+        'data' => 'array',
+    ];
 
     public function getAttribute($key)
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -68,6 +68,7 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../database/migrations/create_taxonomies_table.php.stub'       => $this->migrationsPath('create_taxonomies_table.php'),
             __DIR__.'/../database/migrations/create_terms_table.php.stub'            => $this->migrationsPath('create_terms_table.php'),
             __DIR__.'/../database/migrations/create_globals_table.php.stub'          => $this->migrationsPath('create_globals_table.php'),
+            __DIR__.'/../database/migrations/create_global_varaibles_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
             __DIR__.'/../database/migrations/create_navigations_table.php.stub'      => $this->migrationsPath('create_navigations_table.php'),
             __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
             __DIR__.'/../database/migrations/create_collections_table.php.stub'      => $this->migrationsPath('create_collections_table.php'),

--- a/src/Updates/SplitGlobalsFromVariables.php
+++ b/src/Updates/SplitGlobalsFromVariables.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class SplitGlobalsFromVariables extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return ! Schema::hasColumn(config('statamic.eloquent-driver.table_prefix', '').'global_sets', 'settings');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/create_global_variables_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_create_global_variables_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $source = __DIR__.'/../../database/migrations/updates/update_globals_table.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_update_globals_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         __DIR__.'/../database/migrations/create_taxonomies_table.php.stub',
         __DIR__.'/../database/migrations/create_terms_table.php.stub',
         __DIR__.'/../database/migrations/create_globals_table.php.stub',
+        __DIR__.'/../database/migrations/create_global_variables_table.php.stub',
         __DIR__.'/../database/migrations/create_navigations_table.php.stub',
         __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub',
         __DIR__.'/../database/migrations/create_collections_table.php.stub',


### PR DESCRIPTION
Following on from the conversation in https://github.com/statamic/eloquent-driver/issues/128, it makes sense to split globals and variables into separate tables, enabling splitting of configuration from data.

Ideally we would be able to offer a config for letting you opt into eloquent globals and variables separately, but from what I can see this is not possible in core as things stand. Scope for future development.

Closes: https://github.com/statamic/eloquent-driver/issues/128