### PR TITLE
Add config for asset class to make it easier to to customize

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -9,6 +9,7 @@ return [
         'driver'          => 'eloquent',
         'container_model' => \Statamic\Eloquent\Assets\AssetContainerModel::class,
         'model'           => \Statamic\Eloquent\Assets\AssetModel::class,
+        'asset'           => \Statamic\Eloquent\Assets\Asset::class,
     ],
 
     'blueprints' => [

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -23,7 +23,7 @@ class AssetRepository extends BaseRepository
     public static function bindings(): array
     {
         return [
-            AssetContract::class        => Asset::class,
+            AssetContract::class        => app('statamic.eloquent.assets.asset'),
             QueryBuilderContract::class => QueryBuilder::class,
         ];
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -121,9 +121,6 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        Statamic::repository(AssetContainerRepositoryContract::class, AssetContainerRepository::class);
-        Statamic::repository(AssetRepositoryContract::class, AssetRepository::class);
-
         $this->app->bind('statamic.eloquent.assets.container_model', function () {
             return config('statamic.eloquent-driver.assets.container_model');
         });
@@ -131,6 +128,13 @@ class ServiceProvider extends AddonServiceProvider
         $this->app->bind('statamic.eloquent.assets.model', function () {
             return config('statamic.eloquent-driver.assets.model');
         });
+
+        $this->app->bind('statamic.eloquent.assets.asset', function () {
+            return config('statamic.eloquent-driver.assets.asset');
+        });
+
+        Statamic::repository(AssetContainerRepositoryContract::class, AssetContainerRepository::class);
+        Statamic::repository(AssetRepositoryContract::class, AssetRepository::class);
     }
 
     private function registerBlueprints()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -130,7 +130,7 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         $this->app->bind('statamic.eloquent.assets.asset', function () {
-            return config('statamic.eloquent-driver.assets.asset');
+            return config('statamic.eloquent-driver.assets.asset', \Statamic\Eloquent\Assets\Asset::class);
         });
 
         Statamic::repository(AssetContainerRepositoryContract::class, AssetContainerRepository::class);


### PR DESCRIPTION
This PR adds a config option and app binding for the asset class, allowing a different class to be used while using the same asset repository.

Fixes #131 