### PR TITLE
Fix offset being specified without limit and without pagination on EntryQueryBuilder

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -62,6 +62,11 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 
     public function get($columns = ['*'])
     {
+        $query = $this->builder->getQuery();
+        if ($query->offset && ! $query->limit) {
+            $query->limit = PHP_INT_MAX;
+        }
+
         $this->addTaxonomyWheres();
 
         return parent::get($columns);

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -690,6 +690,21 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     /** @test */
+    public function entries_are_found_using_offset_but_no_limit()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $entries = Entry::query()->get();
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['Post 1', 'Post 2', 'Post 3'], $entries->map->title->all());
+
+        $entries = Entry::query()->offset(1)->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
+    }
+
+    /** @test */
     public function entries_can_be_retrieved_on_join_table_conditions()
     {
         Collection::make('posts')->save();


### PR DESCRIPTION
This PR checks for the presence of offset without limit on entry queries, which throws an error on some database engines (looking at you MySQL). 

Laravel have chosen to not provide a work around in their query builder, but we should as the Stache allows this and we want to be compatible.

Closes #175 