### PR TITLE
`fromModel` should accept any Eloquent model rather than forcing a specific model

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Assets;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Assets\AssetContainer as FileEntry;
-use Statamic\Eloquent\Assets\AssetContainerModel as Model;
 use Statamic\Events\AssetContainerDeleted;
 use Statamic\Events\AssetContainerSaved;
 

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Collections;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Entries\Collection as Contract;
-use Statamic\Eloquent\Collections\CollectionModel as Model;
 use Statamic\Eloquent\Structures\CollectionStructure;
 use Statamic\Entries\Collection as FileEntry;
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Statamic\Contracts\Entries\Entry as EntryContract;
-use Statamic\Eloquent\Entries\EntryModel as Model;
 use Statamic\Entries\Entry as FileEntry;
 use Statamic\Facades\Entry as EntryFacade;
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Forms;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Forms\Form as Contract;
-use Statamic\Eloquent\Forms\FormModel as Model;
 use Statamic\Events\FormDeleted;
 use Statamic\Events\FormSaved;
 use Statamic\Forms\Form as FileEntry;

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Forms;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
-use Statamic\Eloquent\Forms\SubmissionModel as Model;
 use Statamic\Events\SubmissionCreated;
 use Statamic\Events\SubmissionDeleted;
 use Statamic\Events\SubmissionSaved;

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Eloquent\Revisions;
 
-use Statamic\Eloquent\Revisions\RevisionModel as Model;
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Events\RevisionDeleted;
 use Statamic\Events\RevisionSaved;
 use Statamic\Revisions\Revision as FileEntry;

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Eloquent\Structures\TreeModel as Model;
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Structures\CollectionTree as FileEntry;
 
 class CollectionTree extends FileEntry

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Structures;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Structures\Nav as Contract;
-use Statamic\Eloquent\Structures\NavModel as Model;
 use Statamic\Structures\Nav as FileEntry;
 
 class Nav extends FileEntry

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Eloquent\Structures;
 
-use Statamic\Eloquent\Structures\TreeModel as Model;
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Structures\NavTree as FileEntry;
 
 class NavTree extends FileEntry

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
-use Statamic\Eloquent\Taxonomies\TaxonomyModel as Model;
 use Statamic\Taxonomies\Taxonomy as FileEntry;
 
 class Taxonomy extends FileEntry

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Statamic\Contracts\Taxonomies\Term as Contract;
-use Statamic\Eloquent\Taxonomies\TermModel as Model;
 use Statamic\Taxonomies\Term as FileEntry;
 
 class Term extends FileEntry


### PR DESCRIPTION
Seeing as we let models be bound in the config file, the fromModel methods should not force a certain model class. Otherwise this means developers are forced to extend our models, which they may have good reasons not to.