### PR TITLE
Fix issues with selecting fields in the content API

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -80,7 +80,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     {
         $items = EntryCollection::make($items)->map(function ($model) use ($columns) {
             return app('statamic.eloquent.entries.entry')::fromModel($model)
-                ->selectedQueryColumns($columns);
+                ->selectedQueryColumns($this->selectedQueryColumns ?? $columns);
         });
 
         return Entry::applySubstitutions($items);
@@ -125,16 +125,20 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             $query->limit = PHP_INT_MAX;
         }
 
+        $this->selectedQueryColumns = $columns;
+
         $this->addTaxonomyWheres();
 
-        return parent::get($columns);
+        return parent::get();
     }
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $this->addTaxonomyWheres();
 
-        return parent::paginate($perPage, $columns, $pageName, $page);
+        $this->selectedQueryColumns = $columns;
+
+        return parent::paginate($perPage, ['*'], $pageName, $page);
     }
 
     public function count()


### PR DESCRIPTION
I don't love this approach, but it seems like it might be the only thing that works. 
Switch to always getting all data from the database, then limiting whats returned by selectedQueryFields in the Entry class.

Fixes https://github.com/statamic/eloquent-driver/issues/26