### PR TITLE
fixed typo in global variables migration file name

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,7 +71,7 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../database/migrations/create_taxonomies_table.php.stub'       => $this->migrationsPath('create_taxonomies_table.php'),
             __DIR__.'/../database/migrations/create_terms_table.php.stub'            => $this->migrationsPath('create_terms_table.php'),
             __DIR__.'/../database/migrations/create_globals_table.php.stub'          => $this->migrationsPath('create_globals_table.php'),
-            __DIR__.'/../database/migrations/create_global_varaibles_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
+            __DIR__.'/../database/migrations/create_global_variables_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
             __DIR__.'/../database/migrations/create_navigations_table.php.stub'      => $this->migrationsPath('create_navigations_table.php'),
             __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
             __DIR__.'/../database/migrations/create_collections_table.php.stub'      => $this->migrationsPath('create_collections_table.php'),


### PR DESCRIPTION
_php artisan vendor:publish --provider="Statamic\Eloquent\ServiceProvider" --tag=migrations_ was returning _ERROR  Can't locate path: <vendor/statamic/eloquent-driver/src/../database/migrations/create_global_varaibles_table.php.stub>_  before the typo fix