### PR TITLE
Add a block to `php please support:details` to show repository config

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -380,21 +380,21 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        AboutCommand::add('Statamic Eloquent Driver', [
-            'Asset Containers' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.asset_containers.driver', 'file')),
-            'Assets' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.assets.driver', 'file')),
-            'Blueprints' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.blueprints.driver', 'file')),
-            'Collections' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.collections.driver', 'file')),
-            'Collection Trees' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.collection_trees.driver', 'file')),
-            'Entries' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.entries.driver', 'file')),
-            'Forms' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.forms.driver', 'file')),
-            'Global Sets' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.global_sets.driver', 'file')),
-            'Navigations' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.navigations.driver', 'file')),
-            'Navigation Trees' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.navigation_trees.driver', 'file')),
-            'Revisions' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.revisions.driver', 'file')),
-            'Taxonomies' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.taxonomies.driver', 'file')),
-            'Terms' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.terms.driver', 'file')),
-        ]);
+        AboutCommand::add('Statamic Eloquent Driver', collect([
+            'Asset Containers' => config('statamic.eloquent-driver.asset_containers.driver', 'file'),
+            'Assets' => config('statamic.eloquent-driver.assets.driver', 'file'),
+            'Blueprints' => config('statamic.eloquent-driver.blueprints.driver', 'file'),
+            'Collections' => config('statamic.eloquent-driver.collections.driver', 'file'),
+            'Collection Trees' => config('statamic.eloquent-driver.collection_trees.driver', 'file'),
+            'Entries' => config('statamic.eloquent-driver.entries.driver', 'file'),
+            'Forms' => config('statamic.eloquent-driver.forms.driver', 'file'),
+            'Global Sets' => config('statamic.eloquent-driver.global_sets.driver', 'file'),
+            'Navigations' => config('statamic.eloquent-driver.navigations.driver', 'file'),
+            'Navigation Trees' => config('statamic.eloquent-driver.navigation_trees.driver', 'file'),
+            'Revisions' => config('statamic.eloquent-driver.revisions.driver', 'file'),
+            'Taxonomies' => config('statamic.eloquent-driver.taxonomies.driver', 'file'),
+            'Terms' => config('statamic.eloquent-driver.terms.driver', 'file'),
+        ])->map(fn ($value) => $this->applyAboutCommandFormatting($value))->all());
     }
 
     private function applyAboutCommandFormatting($config)

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Eloquent;
 
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Console\AboutCommand;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
 use Statamic\Contracts\Assets\AssetRepository as AssetRepositoryContract;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
@@ -112,6 +114,8 @@ class ServiceProvider extends AddonServiceProvider
             Commands\ImportRevisions::class,
             Commands\ImportTaxonomies::class,
         ]);
+
+        $this->addAboutCommandInfo();
     }
 
     public function register()
@@ -369,5 +373,37 @@ class ServiceProvider extends AddonServiceProvider
     protected function migrationsPath($filename)
     {
         return database_path('migrations/'.date('Y_m_d_His', time() + (++$this->migrationCount + 60))."_{$filename}.php");
+    }
+
+    protected function addAboutCommandInfo()
+    {
+        if (! class_exists(AboutCommand::class)) {
+            return;
+        }
+
+        AboutCommand::add('Statamic Eloquent Driver', [
+            'Asset Containers' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.asset_containers.driver', 'file')),
+            'Assets' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.assets.driver', 'file')),
+            'Blueprints' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.blueprints.driver', 'file')),
+            'Collections' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.collections.driver', 'file')),
+            'Collection Trees' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.collection_trees.driver', 'file')),
+            'Entries' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.entries.driver', 'file')),
+            'Forms' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.forms.driver', 'file')),
+            'Global Sets' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.global_sets.driver', 'file')),
+            'Navigations' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.navigations.driver', 'file')),
+            'Navigation Trees' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.navigation_trees.driver', 'file')),
+            'Revisions' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.revisions.driver', 'file')),
+            'Taxonomies' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.taxonomies.driver', 'file')),
+            'Terms' => $this->applyAboutCommandFormatting(config('statamic.eloquent-driver.terms.driver', 'file')),
+        ]);
+    }
+
+    private function applyAboutCommandFormatting($config)
+    {
+        if ($config == 'eloquent') {
+            return ' <fg=yellow;options=bold>'.$config.'</>';
+        }
+
+        return $config;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Eloquent;
 
-use Illuminate\Console\Command;
 use Illuminate\Foundation\Console\AboutCommand;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
 use Statamic\Contracts\Assets\AssetRepository as AssetRepositoryContract;


### PR DESCRIPTION
This PR adds a "Statamic Eloquent Driver" block to `php please support:details` showing the repository configuration, so it does not need to be requested when supporting issues.

Example of how it looks:
<img width="365" alt="Screenshot 2023-07-26 at 08 59 03" src="https://github.com/statamic/eloquent-driver/assets/51899/c29e171e-1d4b-4ebf-bdb8-482e7f7ad880">
