### PR TITLE
Don't double-save descendants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.14"
+        "statamic/cms": "^4.16"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.6.0"
+        "statamic/cms": "^4.14"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -58,8 +58,6 @@ class EntryRepository extends StacheRepository
 
         Blink::put("eloquent-entry-{$entry->id()}", $entry);
         Blink::put("eloquent-entry-{$entry->uri()}", $entry);
-
-        $entry->descendants()->each->save();
     }
 
     public function delete($entry)

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -198,7 +198,7 @@ class EntryTest extends TestCase
         $blueprint->ensureField('too', ['type' => 'test', 'localizable' => true]);
         $entry->merge(['too' => 'tar']);
 
-        Facades\Entry::save($entry);
+        $entry->save();
 
         $this->assertNotNull($entry->descendants()->get('fr')->model()->data['too'] ?? null);
         $this->assertNotNull($entry->descendants()->get('de')->model()->data['too'] ?? null);
@@ -243,7 +243,7 @@ class EntryTest extends TestCase
         $blueprint->ensureField('too', ['type' => 'test', 'localizable' => true]);
         $entry->date('2024-01-01');
 
-        Facades\Entry::save($entry);
+        $entry->save();
 
         $this->assertEquals($entry->descendants()->get('fr')->model()->date, '2024-01-01 00:00:00');
     }


### PR DESCRIPTION
In statamic/cms#8505 descendants will be saved. There is no longer a need to do it from the Eloquent repository side. It would only cause them to be saved twice.

I'm bumping the requirement of cms to the version where that PR would be available.

This is not currently an issue, but will be once that PR is released. It's only minor - the entries would be double saved, and EntrySaved events dispatched multiple times. Database `update` queries wouldn't even run since the model would have no changes the second time.