### PR TITLE
Bug fix when saving collection tree for first time in split repos

### DIFF
--- a/src/Structures/CollectionTreeRepository.php
+++ b/src/Structures/CollectionTreeRepository.php
@@ -20,13 +20,15 @@ class CollectionTreeRepository extends StacheRepository
         });
     }
 
-    public function save($entry)
+    public function save($tree)
     {
-        $model = $entry->toModel();
+        $model = app('statamic.eloquent.collections.tree')::makeModelFromContract($tree);
         $model->save();
 
         Blink::forget("eloquent-collection-tree-{$model->handle}-{$model->locale}");
 
-        $entry->model($model->fresh());
+        if ($tree instanceof CollectionTree) {
+            $tree->model($model->fresh());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/statamic/eloquent-driver/issues/198

When saving a collection for the first time in split config mode (file for collection config, eloquent for data), it will return a [stache tree as the collection structure is designed to do this](https://github.com/statamic/cms/blob/e66df876e11cd8e757eed4fd0691380870e6d99b/src/Structures/CollectionStructure.php#L59C1-L60C1).

The work around is to not assume we get passed an eloquent collection tree.