### PR TITLE
Add bindings for eloquent collection and nav trees

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.16"
+        "statamic/cms": "^4.21"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/src/Structures/CollectionTreeRepository.php
+++ b/src/Structures/CollectionTreeRepository.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Eloquent\Structures;
 
+use Statamic\Contracts\Structures\CollectionTree as CollectionTreeContract;
 use Statamic\Contracts\Structures\Tree as TreeContract;
+use Statamic\Eloquent\Structures\CollectionTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\CollectionTreeRepository as StacheRepository;
 
@@ -28,5 +30,12 @@ class CollectionTreeRepository extends StacheRepository
         Blink::forget("eloquent-collection-tree-{$model->handle}-{$model->locale}");
 
         $entry->model($model->fresh());
+    }
+
+    public static function bindings()
+    {
+        return [
+            CollectionTreeContract::class => CollectionTree::class,
+        ];
     }
 }

--- a/src/Structures/CollectionTreeRepository.php
+++ b/src/Structures/CollectionTreeRepository.php
@@ -4,7 +4,6 @@ namespace Statamic\Eloquent\Structures;
 
 use Statamic\Contracts\Structures\CollectionTree as CollectionTreeContract;
 use Statamic\Contracts\Structures\Tree as TreeContract;
-use Statamic\Eloquent\Structures\CollectionTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\CollectionTreeRepository as StacheRepository;
 

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -4,7 +4,6 @@ namespace Statamic\Eloquent\Structures;
 
 use Statamic\Contracts\Structures\NavTree as NavTreeContract;
 use Statamic\Contracts\Structures\Tree as TreeContract;
-use Statamic\Eloquent\Structures\NavTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\NavTreeRepository as StacheRepository;
 

--- a/src/Structures/NavTreeRepository.php
+++ b/src/Structures/NavTreeRepository.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Eloquent\Structures;
 
+use Statamic\Contracts\Structures\NavTree as NavTreeContract;
 use Statamic\Contracts\Structures\Tree as TreeContract;
+use Statamic\Eloquent\Structures\NavTree;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\NavTreeRepository as StacheRepository;
 
@@ -43,5 +45,12 @@ class NavTreeRepository extends StacheRepository
         }
 
         $entry->model()->delete();
+    }
+
+    public static function bindings()
+    {
+        return [
+            NavTreeContract::class => NavTree::class,
+        ];
     }
 }


### PR DESCRIPTION
This PR binds our collection and nav trees so when new instances are created by any repository (stache or eloquent) we get the instance we expect.

Requires: https://github.com/statamic/cms/pull/8658
Replaces: https://github.com/statamic/eloquent-driver/pull/199