### PR TITLE
Ability to config queue connection for UpdateCollectionEntryOrder job

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -26,6 +26,7 @@ return [
         'driver' => 'eloquent',
         'model'  => \Statamic\Eloquent\Collections\CollectionModel::class,
         'update_entry_order_queue' => 'default',
+        'update_entry_order_connection' => 'default',
     ],
 
     'collection_trees' => [

--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -89,10 +89,10 @@ class CollectionRepository extends StacheRepository
 
                 $connection = config('statamic.eloquent-driver.collections.update_entry_order_connection', 'default');
 
-                if($connection != 'default') {
+                if ($connection != 'default') {
                     $dispatch->onConnection($connection);
                 }
-                
+
                 $dispatch->onQueue(config('statamic.eloquent-driver.collections.update_entry_order_queue', 'default'));
             });
     }

--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -85,8 +85,15 @@ class CollectionRepository extends StacheRepository
         $collection->queryEntries()
             ->get(['id'])
             ->each(function ($entry) {
-                UpdateCollectionEntryOrder::dispatch($entry->id())
-                    ->onQueue(config('statamic.eloquent-driver.collections.update_entry_order_queue', 'default'));
+                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id());
+
+                $connection = config('statamic.eloquent-driver.collections.update_entry_order_connection', 'default');
+
+                if($connection != 'default') {
+                    $dispatch->onConnection($connection);
+                }
+                
+                $dispatch->onQueue(config('statamic.eloquent-driver.collections.update_entry_order_queue', 'default'));
             });
     }
 }


### PR DESCRIPTION
Fixes #211 .

Had to add `onConnection` conditionally, as `onConnection('default')` is not a thing.

