### PR TITLE
Make AssetQueryBuilder for performance gains

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ We have provided imports from file based content for each repository, which can 
 - Revisions: `php please eloquent:import-revisions`
 - Taxonomies: `php please eloquent:import-taxonomies`
 
+If your assets are eloquent driver and you are managing your assets outside of Statamic, we have provided a sync assets command which will check your container for updates and add database entries for any missing files, while removing any that no longer exist.
+
+`php please eloquent:sync-assets`
+
+
 ## Exporting back to file based content
 
 We have provided exports from eloquent to file based content for each repository, which can be run as follows:

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -14,9 +14,12 @@ return new class extends Migration {
             $table->string('basename')->index();
             $table->string('filename')->index();
             $table->char('extension', 10)->index();
+            $table->string('path')->index();
             $table->jsonb('meta')->nullable();
             $table->jsonb('data')->nullable();
             $table->timestamps();
+
+            $table->index(['container', 'folder', 'basename']);
         });
     }
 

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -11,13 +11,14 @@ return new class extends Migration {
             $table->id();
             $table->string('container')->index();
             $table->string('folder')->index();
+            $table->string('basename')->index();
             $table->string('filename')->index();
+            $table->char('extension', 10)->index();
             $table->jsonb('meta')->nullable();
             $table->jsonb('data')->nullable();
             $table->timestamps();
         });
     }
-
 
     public function down()
     {

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -16,7 +16,6 @@ return new class extends Migration {
             $table->char('extension', 10)->index();
             $table->string('path')->index();
             $table->jsonb('meta')->nullable();
-            $table->jsonb('data')->nullable();
             $table->timestamps();
 
             $table->index(['container', 'folder', 'basename']);

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -9,7 +9,10 @@ return new class extends Migration {
     {
         Schema::create($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->id();
-            $table->string('handle')->index();
+            $table->string('container')->index();
+            $table->string('folder')->index();
+            $table->string('filename')->index();
+            $table->jsonb('meta')->nullable();
             $table->jsonb('data')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -35,8 +35,7 @@ return new class extends Migration {
                 $model->basename = $path->afterLast('/');
                 $model->extension = Str::of($model->basename)->afterLast('.');
                 $model->filename = Str::of($model->basename)->beforeLast('.');
-                $model->meta = Arr::except($model->data, ['data']);
-                $model->data = $model->data['data'] ?? [];
+                $model->meta = $model->data;
                 $model->save();
             });
 
@@ -54,7 +53,7 @@ return new class extends Migration {
         AssetModel::all()
             ->each(function ($model) {
                 $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->basename.'.yaml';
-                $model->data = array_merge(['data' => $model->data['data'] ?? []], $model->meta);
+                $model->data = $model->meta;
                 $model->saveQuietly();
             });
 

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Statamic\Eloquent\Assets\AssetModel;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->string('container')->after('handle')->index();
+            $table->string('folder')->after('container')->index();
+            $table->string('filename')->after('path')->index();
+            $table->jsonb('meta')->after('meta')->nullable();
+        });
+
+        AssetModel::all()
+            ->each(function ($model) {
+                $model->container = Str::before($model->handle, '::');
+                $model->folder = Str::of($model->handle)->after('::')->replace('/.meta/', '')->beforeLast('/');
+                $model->filename = Str::of($model->handle)->after('::')->afterLast('/');
+                $model->meta = Arr::except($model->data, ['data']);
+                $model->data = $model->data['data'] ?? [];
+                $model->saveQuietly();
+            });
+
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->dropColumn('handle');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->string('handle')->index();
+        });
+
+        AssetModel::all()
+            ->each(function ($model) {
+                $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->filename;
+                $model->data = array_merge(['data' => $model->data['data'] ?? []], $model->meta);
+                $model->saveQuietly();
+            });
+
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->dropColumn('meta');
+            $table->dropColumn('filename');
+            $table->dropColumn('folder');
+            $table->dropColumn('container');
+        });
+    }
+};

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -12,18 +12,20 @@ return new class extends Migration {
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->string('container')->after('handle')->index();
             $table->string('folder')->after('container')->index();
-            $table->string('filename')->after('folder')->index();
-            $table->jsonb('meta')->nullable();
+            $table->string('basename')->after('folder')->index();
+            $table->string('filename')->after('basename')->index();
+            $table->char('extension', 10)->after('filename')->index();
+            $table->jsonb('meta')->after('extension')->nullable();
         });
 
         AssetModel::all()
             ->each(function ($model) {
                 $model->container = Str::before($model->handle, '::');
                 $model->folder = Str::of($model->handle)->after('::')->replace('/.meta/', '')->beforeLast('/');
-                $model->filename = Str::of($model->handle)->after('::')->afterLast('/')->beforeLast('.yaml');
+                $model->basename = Str::of($model->handle)->after('::')->afterLast('/')->beforeLast('.yaml');
                 $model->meta = Arr::except($model->data, ['data']);
                 $model->data = $model->data['data'] ?? [];
-                $model->saveQuietly();
+                $model->save();
             });
 
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
@@ -39,14 +41,16 @@ return new class extends Migration {
 
         AssetModel::all()
             ->each(function ($model) {
-                $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->filename.'.yaml';
+                $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->basename.'.yaml';
                 $model->data = array_merge(['data' => $model->data['data'] ?? []], $model->meta);
                 $model->saveQuietly();
             });
 
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->dropColumn('meta');
+            $table->dropColumn('basename');
             $table->dropColumn('filename');
+            $table->dropColumn('extension');
             $table->dropColumn('folder');
             $table->dropColumn('container');
         });

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -12,15 +12,15 @@ return new class extends Migration {
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
             $table->string('container')->after('handle')->index();
             $table->string('folder')->after('container')->index();
-            $table->string('filename')->after('path')->index();
-            $table->jsonb('meta')->after('meta')->nullable();
+            $table->string('filename')->after('folder')->index();
+            $table->jsonb('meta')->nullable();
         });
 
         AssetModel::all()
             ->each(function ($model) {
                 $model->container = Str::before($model->handle, '::');
                 $model->folder = Str::of($model->handle)->after('::')->replace('/.meta/', '')->beforeLast('/');
-                $model->filename = Str::of($model->handle)->after('::')->afterLast('/');
+                $model->filename = Str::of($model->handle)->after('::')->afterLast('/')->beforeLast('.yaml');
                 $model->meta = Arr::except($model->data, ['data']);
                 $model->data = $model->data['data'] ?? [];
                 $model->saveQuietly();
@@ -39,7 +39,7 @@ return new class extends Migration {
 
         AssetModel::all()
             ->each(function ($model) {
-                $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->filename;
+                $model->handle = $model->container.'::'.$model->folder.'/.meta/'.$model->filename.'.yaml';
                 $model->data = array_merge(['data' => $model->data['data'] ?? []], $model->meta);
                 $model->saveQuietly();
             });

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -15,7 +15,8 @@ return new class extends Migration {
             $table->string('basename')->after('folder')->index();
             $table->string('filename')->after('basename')->index();
             $table->char('extension', 10)->after('filename')->index();
-            $table->jsonb('meta')->after('extension')->nullable();
+            $table->string('path')->after('extension')->index();
+            $table->jsonb('meta')->after('path')->nullable();
 
             $table->index(['container', 'folder', 'basename']);
         });
@@ -25,6 +26,9 @@ return new class extends Migration {
                 $model->container = Str::before($model->handle, '::');
                 $model->folder = Str::of($model->handle)->after('::')->replace('/.meta/', '')->beforeLast('/');
                 $model->basename = Str::of($model->handle)->after('::')->afterLast('/')->beforeLast('.yaml');
+                $model->path = Str::of($model->handle)->after('::')->replace('/.meta/', '');
+                $model->extension = Str::of($model->basename)->afterLast('.');
+                $model->filename = Str::of($model->basename)->beforeLast('.');
                 $model->meta = Arr::except($model->data, ['data']);
                 $model->data = $model->data['data'] ?? [];
                 $model->save();
@@ -52,6 +56,7 @@ return new class extends Migration {
             $table->dropIndex(['container', 'folder', 'basename']);
 
             $table->dropColumn('meta');
+            $table->dropColumn('path');
             $table->dropColumn('basename');
             $table->dropColumn('filename');
             $table->dropColumn('extension');

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -25,9 +25,13 @@ return new class extends Migration {
             ->each(function ($model) {
                 $path = Str::of($model->handle)->after('::')->replace('/.meta/', '');
 
+                if ($path->startsWith('.')) {
+                    $path = $path->replaceFirst('.', '');
+                }
+
                 $model->container = Str::before($model->handle, '::');
                 $model->path = $path;
-                $model->folder = $path->contains('/') ? $path->beforeLast('/') : '';
+                $model->folder = $path->contains('/') ? $path->beforeLast('/') : '/';
                 $model->basename = $path->afterLast('/')->beforeLast('.yaml');
                 $model->extension = Str::of($model->basename)->afterLast('.');
                 $model->filename = Str::of($model->basename)->beforeLast('.');

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -23,14 +23,14 @@ return new class extends Migration {
 
         AssetModel::all()
             ->each(function ($model) {
-                $path = Str::of($model->handle)->after('::')->replace('/.meta/', '');
+                $path = Str::of($model->handle)->after('::')->replace('/.meta', '');
 
                 if ($path->startsWith('.')) {
                     $path = $path->replaceFirst('.', '');
                 }
 
                 $model->container = Str::before($model->handle, '::');
-                $model->path = $path;
+                $model->path = $path->beforeLast('.yaml');
                 $model->folder = $path->contains('/') ? $path->beforeLast('/') : '/';
                 $model->basename = $path->afterLast('/')->beforeLast('.yaml');
                 $model->extension = Str::of($model->basename)->afterLast('.');

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -23,10 +23,12 @@ return new class extends Migration {
 
         AssetModel::all()
             ->each(function ($model) {
+                $path = Str::of($model->handle)->after('::')->replace('/.meta/', '');
+
                 $model->container = Str::before($model->handle, '::');
-                $model->folder = Str::of($model->handle)->after('::')->replace('/.meta/', '')->beforeLast('/');
-                $model->basename = Str::of($model->handle)->after('::')->afterLast('/')->beforeLast('.yaml');
-                $model->path = Str::of($model->handle)->after('::')->replace('/.meta/', '');
+                $model->path = $path;
+                $model->folder = $path->contains('/') ? $path->beforeLast('/') : '';
+                $model->basename = $path->afterLast('/')->beforeLast('.yaml');
                 $model->extension = Str::of($model->basename)->afterLast('.');
                 $model->filename = Str::of($model->basename)->beforeLast('.');
                 $model->meta = Arr::except($model->data, ['data']);

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -16,6 +16,8 @@ return new class extends Migration {
             $table->string('filename')->after('basename')->index();
             $table->char('extension', 10)->after('filename')->index();
             $table->jsonb('meta')->after('extension')->nullable();
+
+            $table->index(['container', 'folder', 'basename']);
         });
 
         AssetModel::all()
@@ -47,6 +49,8 @@ return new class extends Migration {
             });
 
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->dropIndex(['container', 'folder', 'basename']);
+
             $table->dropColumn('meta');
             $table->dropColumn('basename');
             $table->dropColumn('filename');

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -23,16 +23,16 @@ return new class extends Migration {
 
         AssetModel::all()
             ->each(function ($model) {
-                $path = Str::of($model->handle)->after('::')->replace('/.meta', '');
+                $path = Str::of($model->handle)->after('::')->replace('.meta/', '')->beforeLast('.yaml');
 
-                if ($path->startsWith('.')) {
-                    $path = $path->replaceFirst('.', '');
+                if ($path->startsWith('./')) {
+                    $path = $path->replaceFirst('./', '');
                 }
 
                 $model->container = Str::before($model->handle, '::');
-                $model->path = $path->beforeLast('.yaml');
+                $model->path = $path;
                 $model->folder = $path->contains('/') ? $path->beforeLast('/') : '/';
-                $model->basename = $path->afterLast('/')->beforeLast('.yaml');
+                $model->basename = $path->afterLast('/');
                 $model->extension = Str::of($model->basename)->afterLast('.');
                 $model->filename = Str::of($model->basename)->beforeLast('.');
                 $model->meta = Arr::except($model->data, ['data']);

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -110,6 +110,9 @@ class Asset extends FileAsset
         ])->fill([
             'data' => $meta['data'] ?? [],
             'meta' => Arr::except($meta, ['data']),
+            'filename' => $this->filename(),
+            'extension' => $this->extension(),
+            'path' => $this->path(),
         ]);
 
         // Set initial timestamps.

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -12,6 +12,7 @@ use Statamic\Support\Str;
 
 class Asset extends FileAsset
 {
+    protected $existsOnDisk = false;
     protected $removedData = [];
 
     public static function fromModel(Model $model)
@@ -65,7 +66,7 @@ class Asset extends FileAsset
 
     public function exists()
     {
-        return $this->metaExists();
+        return $this->existsOnDisk || $this->metaExists();
     }
 
     public function metaExists()
@@ -94,6 +95,8 @@ class Asset extends FileAsset
         if (! $this->disk()->exists($this->path())) {
             return ['data' => $this->data->all()];
         }
+
+        $this->existsOnDisk = true;
 
         return parent::generateMeta();
     }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Assets\Asset as FileAsset;
 use Statamic\Assets\AssetUploader as Uploader;
-use Statamic\Facades\Blink;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -58,7 +58,7 @@ class Asset extends FileAsset
 
     public function exists()
     {
-        return $this->metaExists(); // not ideal
+        return $this->metaExists();
     }
 
     public function metaExists()

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -166,8 +166,10 @@ class Asset extends FileAsset
             ])->first();
 
             if ($oldMetaModel) {
+                $meta = $oldMetaModel->meta;
                 $oldMetaModel->delete();
-                $this->writeMeta($oldMetaModel->data);
+
+                $this->writeMeta($meta);
             }
         }
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -19,7 +19,7 @@ class Asset extends FileAsset
     {
         return (new static())
             ->container($model->container)
-            ->path($model->folder.'/'.$model->filename)
+            ->path(Str::replace('//', '/', $model->folder.'/'.$model->basename))
             ->hydrateMeta($model->meta)
             ->data($model->data);
     }
@@ -68,7 +68,7 @@ class Asset extends FileAsset
             ->where([
                 'container' => $this->containerHandle(),
                 'folder' => $this->folder(),
-                'filename' => $this->filename(),
+                'basename' => $this->basename(),
             ])->count() > 0;
     }
 
@@ -106,7 +106,7 @@ class Asset extends FileAsset
         $model = app('statamic.eloquent.assets.model')::firstOrNew([
             'container' => $this->containerHandle(),
             'folder' => $this->folder(),
-            'filename' => $this->filename(),
+            'basename' => $this->basename(),
         ])->fill([
             'data' => $meta['data'] ?? [],
             'meta' => Arr::except($meta, ['data']),

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -47,10 +47,10 @@ class Asset extends FileAsset
         return $this->meta = Cache::rememberForever($this->metaCacheKey(), function () {
             $handle = $this->container()->handle().'::'.$this->metaPath();
             if ($model = app('statamic.eloquent.assets.model')::where([
-                    'container' => $this->containerHandle(),
-                    'folder' => $this->folder(),
-                    'basename' => $this->basename(),
-                ])->first()) {
+                'container' => $this->containerHandle(),
+                'folder' => $this->folder(),
+                'basename' => $this->basename(),
+            ])->first()) {
                 return $model->meta;
             }
 

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Statamic\Eloquent\Assets;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use League\Flysystem\DirectoryListing;
+use Statamic\Assets\AssetContainerContents as CoreAssetContainerContents;
+use Statamic\Statamic;
+use Statamic\Support\Str;
+
+class AssetContainerContents extends CoreAssetContainerContents
+{
+    protected $container;
+    protected $folders;
+
+    private function query()
+    {
+        return app('statamic.eloquent.assets.model')::query()
+            ->where('container', $this->container->handle());
+    }
+
+    public function all()
+    {
+        // for performance reasons we only return directories to
+        // avoid returning thousands of models
+        return $this->directories()->keyBy('path');
+    }
+
+    public function files()
+    {
+        return $this->query()
+            ->select(['path'])
+            ->get()
+            ->keyBy('path');
+    }
+
+    public function directories()
+    {
+        if ($this->folders && ! Statamic::isWorker()) {
+            return $this->folders;
+        }
+
+        $this->folders = Cache::remember($this->key(), $this->ttl(), function () {
+            return $this->container->disk()->getFolders('/', true)
+                ->map(fn ($dir) => ['path' => $dir]);
+        });
+
+        return $this->folders;
+    }
+
+    public function metaFilesIn($folder, $recursive)
+    {
+        return $this->query()
+            ->where(fn ($query) => $query
+                ->where('folder', $folder)
+                ->when($recursive, fn ($query) => $query->orWhere('folder', 'like', ($folder != '/' ? $folder : '').'/%'))
+            )
+            ->get()
+            ->keyBy('path');
+    }
+
+    public function filteredFilesIn($folder, $recursive)
+    {
+        return $this->metaFilesIn($folder, $recursive);
+    }
+
+    public function filteredDirectoriesIn($folder, $recursive)
+    {
+        $folder = $folder == '/' ? '' : $folder;
+
+        return $this->directories()->filter(function ($dir) use ($folder, $recursive) {
+            if ($folder && ! Str::startsWith($dir, $folder)) {
+                return false;
+            }
+
+            return ! $recursive ? Str::of($dir)->after($folder.'/')->contains('/') == false : true;
+        })->flip();
+    }
+
+    public function save()
+    {
+        Cache::put($this->key(), $this->folders, $this->ttl());
+    }
+
+    public function forget($path)
+    {
+        $this->directories();
+
+        $this->folders = $this->folders->reject(fn ($dir) => $dir['path'] == $path);
+
+        return $this;
+    }
+
+    public function add($path)
+    {
+        $this->directories();
+
+        // Add parent directories
+        if (($dir = dirname($path)) !== '.') {
+            $this->add($dir);
+        }
+
+        $this->folders->push(['path' => $path]);
+
+        return $this;
+    }
+
+    private function key()
+    {
+        return 'asset-folder-contents-'.$this->container->handle();
+    }
+
+    private function ttl()
+    {
+        return config('statamic.stache.watcher') ? 0 : null;
+    }
+}

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -2,9 +2,7 @@
 
 namespace Statamic\Eloquent\Assets;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
-use League\Flysystem\DirectoryListing;
 use Statamic\Assets\AssetContainerContents as CoreAssetContainerContents;
 use Statamic\Statamic;
 use Statamic\Support\Str;

--- a/src/Assets/AssetModel.php
+++ b/src/Assets/AssetModel.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Eloquent\Assets;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Eloquent\Database\BaseModel;
+use Statamic\Support\Str;
 
 class AssetModel extends BaseModel
 {
@@ -14,4 +16,12 @@ class AssetModel extends BaseModel
         'data' => 'json',
         'meta' => 'json',
     ];
+
+    public static function booted(): void
+    {
+        static::saving(function (Model $model) {
+            $model->extension = Str::afterLast($model->basename, '.');
+            $model->filename = Str::beforeLast($model->basename, '.');
+        });
+    }
 }

--- a/src/Assets/AssetModel.php
+++ b/src/Assets/AssetModel.php
@@ -12,5 +12,6 @@ class AssetModel extends BaseModel
 
     protected $casts = [
         'data' => 'json',
+        'meta' => 'json',
     ];
 }

--- a/src/Assets/AssetModel.php
+++ b/src/Assets/AssetModel.php
@@ -16,12 +16,4 @@ class AssetModel extends BaseModel
         'data' => 'json',
         'meta' => 'json',
     ];
-
-    public static function booted(): void
-    {
-        static::saving(function (Model $model) {
-            $model->extension = Str::afterLast($model->basename, '.');
-            $model->filename = Str::beforeLast($model->basename, '.');
-        });
-    }
 }

--- a/src/Assets/AssetModel.php
+++ b/src/Assets/AssetModel.php
@@ -2,9 +2,7 @@
 
 namespace Statamic\Eloquent\Assets;
 
-use Illuminate\Database\Eloquent\Model;
 use Statamic\Eloquent\Database\BaseModel;
-use Statamic\Support\Str;
 
 class AssetModel extends BaseModel
 {

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -21,7 +21,7 @@ class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         if (in_array($column, self::META_COLUMNS)) {
             $column = 'meta->'.$column;
         } elseif (! in_array($column, self::COLUMNS)) {
-            $column = 'data->'.$column;
+            $column = 'meta->data->'.$column;
         }
 
         return $column;

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Statamic\Eloquent\Assets;
+
+use Statamic\Assets\AssetCollection;
+use Statamic\Contracts\Assets\QueryBuilder;
+use Statamic\Query\EloquentQueryBuilder;
+
+class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
+{
+    const COLUMNS = [
+        'id', 'container', 'folder', 'filename', 'created_at', 'updated_at',
+    ];
+
+    const META_COLUMNS = [
+        'size', 'width', 'height', 'duration', 'mime_type', 'last_modified'
+    ];
+
+    protected function column($column) {
+        if (in_array($column, self::META_COLUMNS)) {
+            $column = 'meta->'. $column;
+        } elseif (!in_array($column, self::COLUMNS)) {
+            $column = 'data->'. $column;
+        }
+
+        return $column;
+    }
+
+    protected function transform($items, $columns = [])
+    {
+        return AssetCollection::make($items)->map(function ($model) use ($columns) {
+            return app('statamic.eloquent.assets.asset')::fromModel($model)
+                ->selectedQueryColumns($this->selectedQueryColumns ?? $columns);
+        });
+    }
+
+    public function with($relations, $callback = null)
+    {
+        return $this;
+    }
+}

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -13,14 +13,15 @@ class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     ];
 
     const META_COLUMNS = [
-        'size', 'width', 'height', 'duration', 'mime_type', 'last_modified'
+        'size', 'width', 'height', 'duration', 'mime_type', 'last_modified',
     ];
 
-    protected function column($column) {
+    protected function column($column)
+    {
         if (in_array($column, self::META_COLUMNS)) {
-            $column = 'meta->'. $column;
+            $column = 'meta->'.$column;
         } elseif (!in_array($column, self::COLUMNS)) {
-            $column = 'data->'. $column;
+            $column = 'data->'.$column;
         }
 
         return $column;

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -20,7 +20,7 @@ class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     {
         if (in_array($column, self::META_COLUMNS)) {
             $column = 'meta->'.$column;
-        } elseif (!in_array($column, self::COLUMNS)) {
+        } elseif (! in_array($column, self::COLUMNS)) {
             $column = 'data->'.$column;
         }
 

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -9,7 +9,7 @@ use Statamic\Query\EloquentQueryBuilder;
 class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {
     const COLUMNS = [
-        'id', 'container', 'folder', 'basename', 'filename', 'extension', 'created_at', 'updated_at',
+        'id', 'container', 'folder', 'basename', 'filename', 'extension', 'path', 'created_at', 'updated_at',
     ];
 
     const META_COLUMNS = [

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -9,7 +9,7 @@ use Statamic\Query\EloquentQueryBuilder;
 class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {
     const COLUMNS = [
-        'id', 'container', 'folder', 'filename', 'created_at', 'updated_at',
+        'id', 'container', 'folder', 'basename', 'filename', 'extension', 'created_at', 'updated_at',
     ];
 
     const META_COLUMNS = [

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -6,6 +6,7 @@ use Statamic\Assets\AssetRepository as BaseRepository;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\QueryBuilder as QueryBuilderContract;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Site;
 use Statamic\Support\Str;
 
 class AssetRepository extends BaseRepository

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -6,7 +6,6 @@ use Statamic\Assets\AssetRepository as BaseRepository;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\QueryBuilder as QueryBuilderContract;
 use Statamic\Facades\Blink;
-use Statamic\Facades\Stache;
 use Statamic\Support\Str;
 
 class AssetRepository extends BaseRepository

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -60,19 +60,18 @@ class AssetRepository extends BaseRepository
 
     public function delete($asset)
     {
-        $asset->container()->contents()->forget($asset->path())->save();
-
-        $model = $this->query()
+        $this->query()
             ->where([
                 'container' => $asset->container(),
                 'folder' => $asset->folder(),
                 'basename' => $asset->basename(),
             ])
-            ->first();
+            ->delete();
+    }
 
-        if ($model) {
-            $model->delete();
-        }
+    public function save($asset)
+    {
+        $asset->writeMeta($asset->generateMeta());
     }
 
     public static function bindings(): array

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -3,28 +3,83 @@
 namespace Statamic\Eloquent\Assets;
 
 use Statamic\Assets\AssetRepository as BaseRepository;
-use Statamic\Assets\QueryBuilder;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\QueryBuilder as QueryBuilderContract;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Stache;
+use Statamic\Support\Str;
 
 class AssetRepository extends BaseRepository
 {
+    public function findById($id): ?AssetContract
+    {
+        [$container, $path] = explode('::', $id);
+
+        $filename = Str::afterLast($path, '/');
+        $folder = Str::beforeLast($path, '/');
+
+        $blinkKey = "eloquent-asset-{$id}";
+        $item = Blink::once($blinkKey, function () use ($container, $filename, $folder) {
+            return $this->query()
+                ->where('container', $container)
+                ->where('folder', $folder)
+                ->where('filename', $filename)
+                ->first();
+        });
+
+        if (! $item) {
+            Blink::forget($blinkKey);
+
+            return null;
+        }
+
+        return $item;
+    }
+
+    public function findByUrl(string $url)
+    {
+        if (! $container = $this->resolveContainerFromUrl($url)) {
+            return null;
+        }
+
+        $siteUrl = rtrim(Site::current()->absoluteUrl(), '/');
+        $containerUrl = $container->url();
+
+        if (starts_with($containerUrl, '/')) {
+            $containerUrl = $siteUrl.$containerUrl;
+        }
+
+        if (starts_with($containerUrl, $siteUrl)) {
+            $url = $siteUrl.$url;
+        }
+
+        $path = str_after($url, $containerUrl);
+
+        return $this->findById("{$container}::{$path}");
+    }
+
     public function delete($asset)
     {
         $asset->container()->contents()->forget($asset->path())->save();
 
-        $handle = $asset->containerHandle().'::'.$asset->metaPath();
-        app('statamic.eloquent.assets.model')::where('handle', $handle)->first()?->delete();
+        $model = $this->query()
+            ->where([
+                'container' => $asset->container(),
+                'folder' => $asset->folder(),
+                'filename' => $asset->filename(),
+            ])
+            ->first();
 
-        Stache::store('assets::'.$asset->containerHandle())->delete($asset);
+        if ($model) {
+            $model->delete();
+        }
     }
 
     public static function bindings(): array
     {
         return [
             AssetContract::class        => app('statamic.eloquent.assets.asset'),
-            QueryBuilderContract::class => QueryBuilder::class,
+            QueryBuilderContract::class => AssetQueryBuilder::class,
         ];
     }
 }

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -16,14 +16,14 @@ class AssetRepository extends BaseRepository
         [$container, $path] = explode('::', $id);
 
         $filename = Str::afterLast($path, '/');
-        $folder = Str::beforeLast($path, '/');
+        $folder = str_contains($path, '/') ? Str::beforeLast($path, '/') : '/';
 
         $blinkKey = "eloquent-asset-{$id}";
         $item = Blink::once($blinkKey, function () use ($container, $filename, $folder) {
             return $this->query()
                 ->where('container', $container)
                 ->where('folder', $folder)
-                ->where('filename', $filename)
+                ->where('basename', $filename)
                 ->first();
         });
 
@@ -66,7 +66,7 @@ class AssetRepository extends BaseRepository
             ->where([
                 'container' => $asset->container(),
                 'folder' => $asset->folder(),
-                'filename' => $asset->filename(),
+                'basename' => $asset->basename(),
             ])
             ->first();
 

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Statamic\Eloquent\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Statamic\Console\RunsInPlease;
+use Statamic\Contracts\Assets\AssetContainer;
+use Statamic\Eloquent\Assets\AssetModel;
+use Statamic\Facades;
+
+class SyncAssets extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:eloquent:sync-assets {--container=all}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync assets in an asset container with your database';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        Facades\AssetContainer::all()
+            ->reject(fn ($container) => $this->option('container') != 'all' && $this->option('container') != $container->handle())
+            ->each(fn ($container) => $this->processContainer($container));
+
+        $this->info('Complete');
+    }
+
+    private function processContainer(AssetContainer $container)
+    {
+        $this->info("Container: {$container->handle()}");
+
+        $this->processFolder($container);
+    }
+
+    private function processFolder(AssetContainer $container, $folder = '')
+    {
+        $this->line("Processing folder: {$folder}");
+
+        // get raw listing of this folder, avoiding any of statamic's asset container caching
+        $files = collect($container->disk()->filesystem()->listContents($folder))
+            ->reject(fn ($item) => $item['type'] != 'file')
+            ->pluck('path');
+
+        // ensure we have an asset for any paths
+        $files->each(function ($file) use ($container) {
+            $this->info($file);
+
+            if (Str::startsWith($file, '.')) {
+                return;
+            }
+
+            $asset = Facades\Asset::make()
+                ->container($container->handle())
+                ->path($file)
+                ->saveQuietly();
+        });
+
+        // delete any assets we have a db entry for that no longer exist
+        AssetModel::query()
+            ->where('container', $container->handle())
+            ->where('folder', $folder)
+            ->chunk(100, function ($assets) use ($files) {
+                $assets->each(function ($asset) use ($files) {
+                    if (! $files->contains($asset->path)) {
+                        $this->error("Deleting {$asset->path}");
+
+                        $asset->delete();
+                    }
+                });
+            });
+
+        // process any sub-folders of this folder
+        $container->folders($folder)
+            ->each(function ($folder) use ($container) {
+                $this->processFolder($container, $folder);
+            });
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent;
 
 use Illuminate\Foundation\Console\AboutCommand;
+use Statamic\Assets\AssetContainerContents;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
 use Statamic\Contracts\Assets\AssetRepository as AssetRepositoryContract;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
@@ -16,6 +17,7 @@ use Statamic\Contracts\Structures\NavigationRepository as NavigationRepositoryCo
 use Statamic\Contracts\Structures\NavTreeRepository as NavTreeRepositoryContract;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
+use Statamic\Eloquent\Assets\AssetContainerContents as EloquentAssetContainerContents;
 use Statamic\Eloquent\Assets\AssetContainerRepository;
 use Statamic\Eloquent\Assets\AssetQueryBuilder;
 use Statamic\Eloquent\Assets\AssetRepository;
@@ -176,6 +178,10 @@ class ServiceProvider extends AddonServiceProvider
             return new AssetQueryBuilder(
                 $app['statamic.eloquent.assets.model']::query()
             );
+        });
+
+        $this->app->bind(AssetContainerContents::class, function ($app) {
+            return new EloquentAssetContainerContents();
         });
 
         Statamic::repository(AssetRepositoryContract::class, AssetRepository::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -44,6 +44,7 @@ class ServiceProvider extends AddonServiceProvider
     protected $migrationCount = 0;
 
     protected $updateScripts = [
+        \Statamic\Eloquent\Updates\AddMetaAndIndexesToAssetsTable::class,
         \Statamic\Eloquent\Updates\AddOrderToEntriesTable::class,
         \Statamic\Eloquent\Updates\AddBlueprintToEntriesTable::class,
         \Statamic\Eloquent\Updates\ChangeDefaultBlueprint::class,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -118,6 +118,7 @@ class ServiceProvider extends AddonServiceProvider
             Commands\ImportNavs::class,
             Commands\ImportRevisions::class,
             Commands\ImportTaxonomies::class,
+            Commands\SyncAssets::class,
         ]);
 
         $this->addAboutCommandInfo();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,7 @@ use Statamic\Contracts\Structures\NavTreeRepository as NavTreeRepositoryContract
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\TermRepository as TermRepositoryContract;
 use Statamic\Eloquent\Assets\AssetContainerRepository;
+use Statamic\Eloquent\Assets\AssetQueryBuilder;
 use Statamic\Eloquent\Assets\AssetRepository;
 use Statamic\Eloquent\Collections\CollectionRepository;
 use Statamic\Eloquent\Entries\EntryQueryBuilder;
@@ -168,6 +169,12 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->app->bind('statamic.eloquent.assets.asset', function () {
             return config('statamic.eloquent-driver.assets.asset', \Statamic\Eloquent\Assets\Asset::class);
+        });
+
+        $this->app->bind(AssetQueryBuilder::class, function ($app) {
+            return new AssetQueryBuilder(
+                $app['statamic.eloquent.assets.model']::query()
+            );
         });
 
         Statamic::repository(AssetRepositoryContract::class, AssetRepository::class);

--- a/src/Updates/AddMetaAndIndexesToAssetsTable.php
+++ b/src/Updates/AddMetaAndIndexesToAssetsTable.php
@@ -15,7 +15,7 @@ class AddMetaAndIndexesToAssetsTable extends UpdateScript
     public function update()
     {
         $source = __DIR__.'/../../database/migrations/updates/update_assets_table.php.stub';
-        $dest = database_path('migrations/'.date('Y_m_d_His').'update_assets_table.php');
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_update_assets_table.php');
 
         $this->files->copy($source, $dest);
 

--- a/src/Updates/AddMetaAndIndexesToAssetsTable.php
+++ b/src/Updates/AddMetaAndIndexesToAssetsTable.php
@@ -14,7 +14,7 @@ class AddMetaAndIndexesToAssetsTable extends UpdateScript
 
     public function update()
     {
-        $source = __DIR__.'/../../database/migrations/update_assets_table.php.stub';
+        $source = __DIR__.'/../../database/migrations/updates/update_assets_table.php.stub';
         $dest = database_path('migrations/'.date('Y_m_d_His').'update_assets_table.php');
 
         $this->files->copy($source, $dest);

--- a/src/Updates/AddMetaAndIndexesToAssetsTable.php
+++ b/src/Updates/AddMetaAndIndexesToAssetsTable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddMetaAndIndexesToAssetsTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return ! Schema::hasColumn(config('statamic.eloquent-driver.table_prefix', '').'assets_meta', 'meta');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/update_assets_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'update_assets_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -19,19 +19,31 @@ class AssetQueryBuilderTest extends TestCase
 
         Storage::fake('test', ['url' => '/assets']);
 
-        Storage::disk('test')->put('a.jpg', '');
-        Storage::disk('test')->put('b.txt', '');
-        Storage::disk('test')->put('c.txt', '');
-        Storage::disk('test')->put('d.jpg', '');
-        Storage::disk('test')->put('e.jpg', '');
-        Storage::disk('test')->put('f.jpg', '');
         $this->container = tap(AssetContainer::make('test')->disk('test'))->save();
+
+        Storage::disk('test')->put('a.jpg', '');
+        Asset::make()->container('test')->path('a.jpg')->save();
+
+        Storage::disk('test')->put('b.txt', '');
+        Asset::make()->container('test')->path('b.txt')->save();
+
+        Storage::disk('test')->put('c.txt', '');
+        Asset::make()->container('test')->path('c.txt')->save();
+
+        Storage::disk('test')->put('d.jpg', '');
+        Asset::make()->container('test')->path('d.jpg')->save();
+
+        Storage::disk('test')->put('e.jpg', '');
+        Asset::make()->container('test')->path('e.jpg')->save();
+
+        Storage::disk('test')->put('f.jpg', '');
+        Asset::make()->container('test')->path('f.jpg')->save();
     }
 
     /** @test */
     public function it_can_get_assets()
     {
-        $assets = $this->container->queryAssets()->get();
+        $assets = Asset::query()->get();
 
         $this->assertCount(6, $assets);
         $this->assertEquals(['a', 'b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
@@ -40,7 +52,7 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_or_where()
     {
-        $assets = $this->container->queryAssets()->where('filename', 'a')->orWhere('filename', 'c')->get();
+        $assets = Asset::query()->where('filename', 'a')->orWhere('filename', 'c')->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
@@ -49,7 +61,7 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_or_where_in()
     {
-        $assets = $this->container->queryAssets()
+        $assets = Asset::query()
             ->whereIn('filename', ['a', 'b'])
             ->orWhereIn('filename', ['a', 'd'])
             ->orWhereIn('extension', ['jpg'])
@@ -60,12 +72,12 @@ class AssetQueryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function assets_are_found_using_or_where_not_in()
+    public function assets_are_found_using_where_not_in()
     {
-        $assets = $this->container->queryAssets()
+        $assets = Asset::query()
             ->whereNotIn('filename', ['a', 'b'])
-            ->orWhereNotIn('filename', ['a', 'f'])
-            ->orWhereNotIn('extension', ['txt'])
+            ->whereNotIn('filename', ['a', 'f'])
+            ->whereNotIn('extension', ['txt'])
             ->get();
 
         $this->assertCount(2, $assets);
@@ -89,17 +101,17 @@ class AssetQueryBuilderTest extends TestCase
     {
         $this->createWhereDateTestAssets();
 
-        $assets = $this->container->queryAssets()->whereDate('test_date', '2021-11-15')->get();
+        $assets = Asset::query()->whereDate('test_date', '2021-11-15')->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereDate('test_date', 1637000264)->get();
+        $assets = Asset::query()->whereDate('test_date', 1637000264)->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereDate('test_date', '>=', '2021-11-15')->get();
+        $assets = Asset::query()->whereDate('test_date', '>=', '2021-11-15')->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
@@ -110,12 +122,12 @@ class AssetQueryBuilderTest extends TestCase
     {
         $this->createWhereDateTestAssets();
 
-        $assets = $this->container->queryAssets()->whereMonth('test_date', 11)->get();
+        $assets = Asset::query()->whereMonth('test_date', 11)->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['a', 'b', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereMonth('test_date', '<', 11)->get();
+        $assets = Asset::query()->whereMonth('test_date', '<', 11)->get();
 
         $this->assertCount(1, $assets);
         $this->assertEquals(['d'], $assets->map->filename()->all());
@@ -126,12 +138,12 @@ class AssetQueryBuilderTest extends TestCase
     {
         $this->createWhereDateTestAssets();
 
-        $assets = $this->container->queryAssets()->whereDay('test_date', 15)->get();
+        $assets = Asset::query()->whereDay('test_date', 15)->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereDay('test_date', '<', 15)->get();
+        $assets = Asset::query()->whereDay('test_date', '<', 15)->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['b', 'd'], $assets->map->filename()->all());
@@ -142,12 +154,12 @@ class AssetQueryBuilderTest extends TestCase
     {
         $this->createWhereDateTestAssets();
 
-        $assets = $this->container->queryAssets()->whereYear('test_date', 2021)->get();
+        $assets = Asset::query()->whereYear('test_date', 2021)->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['a', 'b', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereYear('test_date', '<', 2021)->get();
+        $assets = Asset::query()->whereYear('test_date', '<', 2021)->get();
 
         $this->assertCount(1, $assets);
         $this->assertEquals(['d'], $assets->map->filename()->all());
@@ -158,12 +170,12 @@ class AssetQueryBuilderTest extends TestCase
     {
         $this->createWhereDateTestAssets();
 
-        $assets = $this->container->queryAssets()->whereTime('test_date', '09:00')->get();
+        $assets = Asset::query()->whereTime('test_date', '09:00:00')->get();
 
         $this->assertCount(1, $assets);
         $this->assertEquals(['b'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereTime('test_date', '>', '09:00')->get();
+        $assets = Asset::query()->whereTime('test_date', '>', '09:00:00')->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'd'], $assets->map->filename()->all());
@@ -178,7 +190,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data([])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereNull('text')->get();
+        $assets = Asset::query()->whereNull('text')->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['c', 'e', 'f'], $assets->map->filename()->all());
@@ -194,7 +206,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data([])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereNotNull('text')->get();
+        $assets = Asset::query()->whereNotNull('text')->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['a', 'b', 'd'], $assets->map->filename()->all());
@@ -210,10 +222,10 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data([])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereNull('text')->orWhereNull('content')->get();
+        $assets = Asset::query()->whereNull('text')->orWhereNull('content')->get();
 
         $this->assertCount(5, $assets);
-        $this->assertEquals(['c', 'e', 'f', 'b', 'd'], $assets->map->filename()->all());
+        $this->assertEquals(['b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
     /** @test **/
@@ -226,16 +238,16 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data([])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereNotNull('content')->orWhereNotNull('text')->get();
+        $assets = Asset::query()->whereNotNull('content')->orWhereNotNull('text')->get();
 
         $this->assertCount(4, $assets);
-        $this->assertEquals(['a', 'c', 'b', 'd'], $assets->map->filename()->all());
+        $this->assertEquals(['a', 'b', 'c','d'], $assets->map->filename()->all());
     }
 
     /** @test **/
     public function assets_are_found_using_nested_where()
     {
-        $assets = $this->container->queryAssets()
+        $assets = Asset::query()
             ->where(function ($query) {
                 $query->where('filename', 'a');
             })
@@ -252,7 +264,7 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_nested_where_in()
     {
-        $assets = $this->container->queryAssets()
+        $assets = Asset::query()
             ->where(function ($query) {
                 $query->whereIn('filename', ['a', 'b']);
             })
@@ -277,7 +289,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['number_field' => 12])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereBetween('number_field', [9, 11])->get();
+        $assets = Asset::query()->whereBetween('number_field', [9, 11])->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['b', 'c', 'd'], $assets->map->filename()->all());
@@ -293,10 +305,10 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['number_field' => 12])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereNotBetween('number_field', [9, 11])->get();
+        $assets = Asset::query()->whereNotBetween('number_field', [9, 11])->get();
 
-        $this->assertCount(3, $assets);
-        $this->assertEquals(['a', 'e', 'f'], $assets->map->filename()->all());
+        $this->assertCount(2, $assets);
+        $this->assertEquals(['a', 'e'], $assets->map->filename()->all());
     }
 
     /** @test **/
@@ -309,7 +321,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['number_field' => 12])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->whereBetween('number_field', [9, 10])->orWhereBetween('number_field', [11, 12])->get();
+        $assets = Asset::query()->whereBetween('number_field', [9, 10])->orWhereBetween('number_field', [11, 12])->get();
 
         $this->assertCount(4, $assets);
         $this->assertEquals(['b', 'c', 'd', 'e'], $assets->map->filename()->all());
@@ -325,27 +337,31 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['text' => 'e', 'number_field' => 12])->save();
         Asset::find('test::f.jpg')->data([])->save();
 
-        $assets = $this->container->queryAssets()->where('text', 'e')->orWhereNotBetween('number_field', [10, 12])->get();
+        $assets = Asset::query()->where('text', 'e')->orWhereNotBetween('number_field', [10, 12])->get();
 
-        $this->assertCount(4, $assets);
-        $this->assertEquals(['e', 'a', 'b', 'f'], $assets->map->filename()->all());
+        $this->assertCount(3, $assets);
+        $this->assertEquals(['a', 'b', 'e'], $assets->map->filename()->all());
     }
 
     /** @test **/
     public function assets_are_found_using_where_json_contains()
     {
+        if ($this->isUsingSqlite()) {
+            $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
+        }
+
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
         Asset::find('test::d.jpg')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->save();
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonContains('test_taxonomy', ['taxonomy-1', 'taxonomy-5'])->get();
+        $assets = Asset::query()->whereJsonContains('test_taxonomy', ['taxonomy-1', 'taxonomy-5'])->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['a', 'c', 'e'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereJsonContains('test_taxonomy', 'taxonomy-1')->get();
+        $assets = Asset::query()->whereJsonContains('test_taxonomy', 'taxonomy-1')->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
@@ -354,6 +370,10 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_where_json_doesnt_contain()
     {
+        if ($this->isUsingSqlite()) {
+            $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
+        }
+
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
@@ -361,12 +381,12 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
         Asset::find('test::f.jpg')->data(['test_taxonomy' => ['taxonomy-1']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonDoesntContain('test_taxonomy', ['taxonomy-1'])->get();
+        $assets = Asset::query()->whereJsonDoesntContain('test_taxonomy', ['taxonomy-1'])->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['b', 'd', 'e'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->whereJsonDoesntContain('test_taxonomy', 'taxonomy-1')->get();
+        $assets = Asset::query()->whereJsonDoesntContain('test_taxonomy', 'taxonomy-1')->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['b', 'd', 'e'], $assets->map->filename()->all());
@@ -375,13 +395,17 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_or_where_json_contains()
     {
+        if ($this->isUsingSqlite()) {
+            $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
+        }
+
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
         Asset::find('test::d.jpg')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->save();
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonContains('test_taxonomy', ['taxonomy-1'])->orWhereJsonContains('test_taxonomy', ['taxonomy-5'])->get();
+        $assets = Asset::query()->whereJsonContains('test_taxonomy', ['taxonomy-1'])->orWhereJsonContains('test_taxonomy', ['taxonomy-5'])->get();
 
         $this->assertCount(3, $assets);
         $this->assertEquals(['a', 'c', 'e'], $assets->map->filename()->all());
@@ -390,6 +414,10 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_or_where_json_doesnt_contain()
     {
+        if ($this->isUsingSqlite()) {
+            $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
+        }
+
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
@@ -397,7 +425,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
         Asset::find('test::f.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonContains('test_taxonomy', ['taxonomy-1'])->orWhereJsonDoesntContain('test_taxonomy', ['taxonomy-5'])->get();
+        $assets = Asset::query()->whereJsonContains('test_taxonomy', ['taxonomy-1'])->orWhereJsonDoesntContain('test_taxonomy', ['taxonomy-5'])->get();
 
         $this->assertCount(4, $assets);
         $this->assertEquals(['a', 'c', 'b', 'd'], $assets->map->filename()->all());
@@ -406,13 +434,17 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_where_json_length()
     {
+        if ($this->isUsingSqlite()) {
+            $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
+        }
+
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
         Asset::find('test::d.jpg')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->save();
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonLength('test_taxonomy', 1)->get();
+        $assets = Asset::query()->whereJsonLength('test_taxonomy', 1)->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['b', 'e'], $assets->map->filename()->all());
@@ -421,7 +453,7 @@ class AssetQueryBuilderTest extends TestCase
     /** @test **/
     public function assets_are_found_using_array_of_wheres()
     {
-        $assets = $this->container->queryAssets()
+        $assets = Asset::query()
             ->where([
                 'filename' => 'a',
                 ['extension', 'jpg'],
@@ -443,12 +475,12 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['content' => 'string'])->save();
         Asset::find('test::f.jpg')->data(['content' => 123])->save();
 
-        $assets = $this->container->queryAssets()->where('content->value', 1)->get();
+        $assets = Asset::query()->where('content->value', 1)->get();
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->where('content->value', '!=', 1)->get();
+        $assets = Asset::query()->where('content->value', '!=', 1)->orWhereNull('content->value')->get();
 
         $this->assertCount(4, $assets);
         $this->assertEquals(['b', 'd', 'e', 'f'], $assets->map->filename()->all());
@@ -464,12 +496,12 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['foo' => 'Post 5', 'other_foo' => 'Not Post 5'])->save();
         Asset::find('test::f.jpg')->data(['foo' => 'Post 6', 'other_foo' => 'Not Post 6'])->save();
 
-        $entries = $this->container->queryAssets()->whereColumn('foo', 'other_foo')->get();
+        $entries = Asset::query()->whereColumn('foo', 'other_foo')->get();
 
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 3', 'Post 4'], $entries->map->foo->all());
 
-        $entries = $this->container->queryAssets()->whereColumn('foo', '!=', 'other_foo')->get();
+        $entries = Asset::query()->whereColumn('foo', '!=', 'other_foo')->get();
 
         $this->assertCount(4, $entries);
         $this->assertEquals(['Post 1', 'Post 2', 'Post 5', 'Post 6'], $entries->map->foo->all());
@@ -478,14 +510,14 @@ class AssetQueryBuilderTest extends TestCase
     /** @test */
     public function it_can_get_assets_using_when()
     {
-        $assets = $this->container->queryAssets()->when(true, function ($query) {
+        $assets = Asset::query()->when(true, function ($query) {
             $query->where('filename', 'a');
         })->get();
 
         $this->assertCount(1, $assets);
         $this->assertEquals(['a'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->when(false, function ($query) {
+        $assets = Asset::query()->when(false, function ($query) {
             $query->where('filename', 'a');
         })->get();
 
@@ -496,14 +528,14 @@ class AssetQueryBuilderTest extends TestCase
     /** @test */
     public function it_can_get_assets_using_unless()
     {
-        $assets = $this->container->queryAssets()->unless(true, function ($query) {
+        $assets = Asset::query()->unless(true, function ($query) {
             $query->where('filename', 'a');
         })->get();
 
         $this->assertCount(6, $assets);
         $this->assertEquals(['a', 'b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
 
-        $assets = $this->container->queryAssets()->unless(false, function ($query) {
+        $assets = Asset::query()->unless(false, function ($query) {
             $query->where('filename', 'a');
         })->get();
 
@@ -514,7 +546,7 @@ class AssetQueryBuilderTest extends TestCase
     /** @test */
     public function it_can_get_assets_using_tap()
     {
-        $assets = $this->container->queryAssets()->tap(function ($query) {
+        $assets = Asset::query()->tap(function ($query) {
             $query->where('filename', 'a');
         })->get();
 

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -241,7 +241,7 @@ class AssetQueryBuilderTest extends TestCase
         $assets = Asset::query()->whereNotNull('content')->orWhereNotNull('text')->get();
 
         $this->assertCount(4, $assets);
-        $this->assertEquals(['a', 'b', 'c','d'], $assets->map->filename()->all());
+        $this->assertEquals(['a', 'b', 'c', 'd'], $assets->map->filename()->all());
     }
 
     /** @test **/

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -466,7 +466,7 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entries_are_found_using_where_json_length()
     {
-        if (config('database.default') === 'sqlite') {
+        if ($this->isUsingSqlite()) {
             $this->markTestSkipped('SQLite doesn\'t support JSON contains queries');
         }
 


### PR DESCRIPTION
This PR brings an AssetQueryBuilder to eloquent driver, reducing the number of file systems calls made and removing the need for a stache cache of the path listing.

This is particularly useful for sites with a large number of assets in cloud storage, as asides from initially populating a folder cache and accessing assets individually, all queries, filtering and meta will be only accessed from the database.

Replaces https://github.com/statamic/eloquent-driver/pull/207
Closes https://github.com/statamic/eloquent-driver/issues/191