### PR TITLE
Fix issues with directory listing not returning all folders

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -133,6 +133,8 @@ class Asset extends FileAsset
         }
 
         $model->save();
+
+        Blink::put('eloquent-asset-meta-exists-'.$this->id(), true);
     }
 
     public function metaPath()

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Assets\Asset as FileAsset;
 use Statamic\Assets\AssetUploader as Uploader;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -71,12 +72,14 @@ class Asset extends FileAsset
 
     public function metaExists()
     {
-        return app('statamic.eloquent.assets.model')::query()
+        return Blink::once('eloquent-asset-meta-exists-'.$this->id(), function () {
+            return app('statamic.eloquent.assets.model')::query()
             ->where([
                 'container' => $this->containerHandle(),
                 'folder' => $this->folder(),
                 'basename' => $this->basename(),
             ])->count() > 0;
+        });
     }
 
     private function metaValue($key)

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -67,13 +67,47 @@ class AssetContainerContents extends CoreAssetContainerContents
     {
         $folder = $folder == '/' ? '' : $folder;
 
-        return $this->directories()->filter(function ($dir) use ($folder, $recursive) {
-            if ($folder && ! Str::startsWith($dir, $folder)) {
-                return false;
-            }
+        return $this->directories()
+            ->filter(function ($dir) use ($folder, $recursive) {
+                if ($folder && ! Str::startsWith($dir['path'], $folder)) {
+                    return false;
+                }
 
-            return ! $recursive ? Str::of($dir)->after($folder.'/')->contains('/') == false : true;
-        })->flip();
+                if ($folder == $dir['path']) {
+                    return false;
+                }
+
+                return true;
+            })
+            ->map(function ($dir) {
+                $dirs = [];
+                $tmp = '';
+                foreach (explode('/', $dir['path']) as $dir) {
+                    $tmp .= '/'.$dir;
+                    $dirs[] = substr($tmp, 1);
+                }
+                return $dirs;
+            })
+            ->flatten()
+            ->unique()
+            ->filter(function ($dir) use ($folder, $recursive) {
+                if ($folder == $dir) {
+                    return false;
+                }
+
+                if ($recursive) {
+                    return true;
+                }
+
+                $dir = Str::of($dir);
+                if ($folder) {
+                    $dir = $dir->after($folder.'/');
+                }
+
+                return ! $dir->contains('/');
+            })
+            ->sort()
+            ->flip();
     }
 
     public function save()

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -107,7 +107,7 @@ class AssetContainerContents extends CoreAssetContainerContents
             ->flatten()
             ->unique()
             ->filter(function ($dir) use ($folder, $recursive) {
-                if ($folder == $dir) {
+                if ($folder == $dir || strlen($folder) > strlen($dir)) {
                     return false;
                 }
 

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -68,7 +68,7 @@ class AssetContainerContents extends CoreAssetContainerContents
         $folder = $folder == '/' ? '' : $folder;
 
         return $this->directories()
-            ->filter(function ($dir) use ($folder, $recursive) {
+            ->filter(function ($dir) use ($folder) {
                 if ($folder && ! Str::startsWith($dir['path'], $folder)) {
                     return false;
                 }
@@ -86,6 +86,7 @@ class AssetContainerContents extends CoreAssetContainerContents
                     $tmp .= '/'.$dir;
                     $dirs[] = substr($tmp, 1);
                 }
+
                 return $dirs;
             })
             ->flatten()

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -40,11 +40,26 @@ class AssetContainerContents extends CoreAssetContainerContents
         }
 
         $this->folders = Cache::remember($this->key(), $this->ttl(), function () {
-            return $this->container->disk()->getFolders('/', true)
+            return collect($this->directoryRecurse(''))
                 ->map(fn ($dir) => ['path' => $dir]);
         });
 
         return $this->folders;
+    }
+
+    private function directoryRecurse($directory)
+    {
+        $rootFolders = $this->container->disk()->getFolders($directory, false);
+
+        $folders = [];
+        foreach ($rootFolders as $folder) {
+            $folders[] = $folder;
+            if ($subfolders = $this->directoryRecurse($folder)) {
+                $folders = array_merge($folders, $subfolders);
+            }
+        }
+
+        return $folders;
     }
 
     public function metaFilesIn($folder, $recursive)

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -85,8 +85,8 @@ class SyncAssets extends Command
 
         // process any sub-folders of this folder
         $container->folders($folder)
-            ->each(function ($subfolder) use ($container) {
-                if ($folder != $subfolder) {
+            ->each(function ($subfolder) use ($container, $folder) {
+                if ($folder != $subfolder && (strlen($subfolder) > strlen($folder))) {
                     $this->processFolder($container, $subfolder);
                 }
             });

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -59,7 +59,7 @@ class SyncAssets extends Command
         $files->each(function ($file) use ($container) {
             $this->info($file);
 
-            if (Str::startsWith($file, '.')) {
+            if (Str::of($file)->afterLast('/')->startsWith('.')) {
                 return;
             }
 

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -85,8 +85,10 @@ class SyncAssets extends Command
 
         // process any sub-folders of this folder
         $container->folders($folder)
-            ->each(function ($folder) use ($container) {
-                $this->processFolder($container, $folder);
+            ->each(function ($subfolder) use ($container) {
+                if ($folder != $subfolder) {
+                    $this->processFolder($container, $subfolder);
+                }
             });
     }
 }

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -86,6 +86,10 @@ class SyncAssets extends Command
         // process any sub-folders of this folder
         $container->folders($folder)
             ->each(function ($subfolder) use ($container, $folder) {
+                if (str_contains($subfolder.'/', '.meta/')) {
+                    return;
+                }
+
                 if ($folder != $subfolder && (strlen($subfolder) > strlen($folder))) {
                     $this->processFolder($container, $subfolder);
                 }

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -57,11 +57,11 @@ class SyncAssets extends Command
 
         // ensure we have an asset for any paths
         $files->each(function ($file) use ($container) {
-            $this->info($file);
-
             if (Str::of($file)->afterLast('/')->startsWith('.')) {
                 return;
             }
+
+            $this->info($file);
 
             $asset = Facades\Asset::make()
                 ->container($container->handle())


### PR DESCRIPTION
This PR fixes an issue with the sync command and directory listing using the asset query builder. It also adds metaExists caching to the asset class to prevent multiple duplicate queries.

Closes https://github.com/statamic/eloquent-driver/issues/222
Closes https://github.com/statamic/eloquent-driver/issues/223