### PR TITLE
Check if a asset extension could be found

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -127,6 +127,11 @@ class Asset extends FileAsset
             $meta = $source->meta();
         }
 
+        // Make shure that a extension could be found, as the extension field is required.
+        if (! $extension = $source->extension()) {
+            return null;
+        }
+
         $model = app('statamic.eloquent.assets.model')::firstOrNew([
             'container' => $source->containerHandle(),
             'folder' => $source->folder(),
@@ -134,7 +139,7 @@ class Asset extends FileAsset
         ])->fill([
             'meta' => $meta,
             'filename' => $source->filename(),
-            'extension' => $source->extension(),
+            'extension' => $extension,
             'path' => $source->path(),
         ]);
 


### PR DESCRIPTION
It may be, that I had corrupt assets in my import.

To not abort the import script, I added a check, if the extension could be found.
In case it returns null, the import aborts.

```
Integrity constraint violation: 1048 Column 'extension' cannot be null
```

To improve the check, some kind of notice, that a certain image could not be imported may be nice.
Anyways, I thought I'll drop this little change to see, if this is something that should be implemented.
