### PR TITLE
add license to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "statamic/eloquent-driver",
     "description": "Allows you to store Statamic data in a database.",
+    "license": "MIT",
     "autoload": {
         "psr-4": {
             "Statamic\\Eloquent\\": "src"


### PR DESCRIPTION
Hi! We check the licences of our packages in our CI and get a warning¹ because no licence is detected. 😅 

Note that this change would also require a release to reach [Packagist](https://packagist.org/packages/statamic/eloquent-driver).

---

¹ `There is no license information available for the latest version (v3.0.5) of this package.`