### PR TITLE
Apply syncOriginal for dirty state tracking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,5 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ryanmitchell/cms"
-        }
-    ]
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "dev-feature/is-dirty-is-clean"
+        "statamic/cms": "^4.51"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.48"
+        "statamic/cms": "dev-feature/is-dirty-is-clean"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",
@@ -42,5 +42,11 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ryanmitchell/cms"
+        }
+    ]
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Statamic\Assets\Asset as FileAsset;
 use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\Asset as AssetContract;
+use Statamic\Data\HasDirtyState;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
@@ -14,6 +15,18 @@ use Statamic\Support\Str;
 
 class Asset extends FileAsset
 {
+    use HasDirtyState {
+        syncOriginal as traitSyncOriginal;
+    }
+
+    public function syncOriginal()
+    {
+        // FileAsset overrides the trait method in order to add the "pending
+        // data" logic. We don't need it here since everything comes from
+        // the model so we'll just use the original trait method again.
+        return $this->traitSyncOriginal();
+    }
+
     protected $existsOnDisk = false;
     protected $removedData = [];
 
@@ -22,7 +35,8 @@ class Asset extends FileAsset
         return (new static())
             ->container($model->container)
             ->path(Str::replace('//', '/', $model->folder.'/'.$model->basename))
-            ->hydrateMeta($model->meta);
+            ->hydrateMeta($model->meta)
+            ->syncOriginal();
     }
 
     public function meta($key = null)

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -36,7 +36,7 @@ class Entry extends FileEntry
             }
         }
 
-        return $entry;
+        return $entry->syncOriginal();
     }
 
     public function toModel()

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -35,14 +35,13 @@ class Term extends FileEntry
             unset($data['collection']);
         }
 
-        $term->syncOriginal();
         $term->data($data);
 
         if (config('statamic.system.track_last_update')) {
             $term->set('updated_at', $model->updated_at ?? $model->created_at);
         }
 
-        return $term;
+        return $term->syncOriginal();
     }
 
     public function toModel()

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -39,7 +39,7 @@ class EntryQueryBuilderTest extends TestCase
     public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
     {
         $searchedEntry = $this->createDummyCollectionAndEntries();
-        $columns = ['title'];
+        $columns = ['foo', 'collection'];
         $retrievedEntry = Entry::query()->find($searchedEntry->id(), $columns);
 
         $retrievedEntry->model(null);

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -19,7 +19,10 @@ class EntryTest extends TestCase
     /** @test */
     public function it_loads_from_entry_model()
     {
+        Collection::make('blog')->title('blog')->save();
+
         $model = new EntryModel([
+            'collection' => 'blog',
             'slug' => 'the-slug',
             'data' => [
                 'foo' => 'bar',


### PR DESCRIPTION
This goes along with statamic/cms#5502 to allow `isDirty` etc to work correctly when using the Eloquent driver.

- [x] Entries
- [x] Terms
- [x] Assets
- [x] Trees
- [x] Composer requirement
- [x] Tests
