### PR TITLE
Allow publishing migrations separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ If you're planning to use existing content, we can use the existing UUIDs. This 
 - Run `php artisan vendor:publish --tag="statamic-eloquent-entries-table-with-string-ids"`.
 - Run `php artisan migrate`.
 
+### Publishing migrations seperately
+
+Alternatively, you can publish each repository's migrations individually:
+
+`php artisan vendor:publish --tag="statamic-eloquent-asset-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-blueprint-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-collection-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-form-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-global-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-navigation-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-revision-migrations"`
+
+`php artisan vendor:publish --tag="statamic-eloquent-taxonomy-migrations"`
+
+
 ## Configuration
 
 The configuration file (`statamic.eloquent-driver`) allows you to choose which repositories you want to be driven by eloquent. By default, all are selected, but if you want to opt out simply change `driver` from `eloquent` to `file` for that repository.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -93,6 +93,44 @@ class ServiceProvider extends AddonServiceProvider
         ], 'migrations');
 
         $this->publishes([
+            __DIR__.'/../database/migrations/create_taxonomies_table.php.stub' => $this->migrationsPath('create_taxonomies_table.php'),
+            __DIR__.'/../database/migrations/create_terms_table.php.stub' => $this->migrationsPath('create_terms_table.php'),
+        ], 'statamic-eloquent-taxonomy-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_globals_table.php.stub' => $this->migrationsPath('create_globals_table.php'),
+            __DIR__.'/../database/migrations/create_global_variables_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
+        ], 'statamic-eloquent-global-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_navigations_table.php.stub' => $this->migrationsPath('create_navigations_table.php'),
+            __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
+        ], 'statamic-eloquent-navigation-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_collections_table.php.stub' => $this->migrationsPath('create_collections_table.php'),
+        ], 'statamic-eloquent-collection-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_blueprints_table.php.stub' => $this->migrationsPath('create_blueprints_table.php'),
+            __DIR__.'/../database/migrations/create_fieldsets_table.php.stub' => $this->migrationsPath('create_fieldsets_table.php'),
+        ], 'statamic-eloquent-blueprint-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_forms_table.php.stub' => $this->migrationsPath('create_forms_table.php'),
+            __DIR__.'/../database/migrations/create_form_submissions_table.php.stub' => $this->migrationsPath('create_form_submissions_table.php'),
+        ], 'statamic-eloquent-form-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_asset_containers_table.php.stub' => $this->migrationsPath('create_asset_containers_table.php'),
+            __DIR__.'/../database/migrations/create_asset_table.php.stub' => $this->migrationsPath('create_asset_table.php'),
+        ], 'statamic-eloquent-asset-migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_revisions_table.php.stub' => $this->migrationsPath('create_revisions_table.php'),
+        ], 'statamic-eloquent-revision-migrations');
+
+        $this->publishes([
             __DIR__.'/../database/migrations/create_entries_table.php.stub' => $this->migrationsPath('create_entries_table'),
         ], 'statamic-eloquent-entries-table');
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -122,7 +122,7 @@ class ServiceProvider extends AddonServiceProvider
                 $blueprintMigrations,
                 $formMigrations,
                 $assetMigrations,
-                $revisionMigrations,
+                $revisionMigrations
             ),
             'migrations'
         );

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -75,60 +75,57 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->publishes([$config => config_path('statamic/eloquent-driver.php')], 'statamic-eloquent-config');
 
-        $this->publishes([
-            __DIR__.'/../database/migrations/create_taxonomies_table.php.stub' => $this->migrationsPath('create_taxonomies_table.php'),
-            __DIR__.'/../database/migrations/create_terms_table.php.stub' => $this->migrationsPath('create_terms_table.php'),
-            __DIR__.'/../database/migrations/create_globals_table.php.stub' => $this->migrationsPath('create_globals_table.php'),
-            __DIR__.'/../database/migrations/create_global_variables_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
-            __DIR__.'/../database/migrations/create_navigations_table.php.stub' => $this->migrationsPath('create_navigations_table.php'),
-            __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
-            __DIR__.'/../database/migrations/create_collections_table.php.stub' => $this->migrationsPath('create_collections_table.php'),
-            __DIR__.'/../database/migrations/create_blueprints_table.php.stub' => $this->migrationsPath('create_blueprints_table.php'),
-            __DIR__.'/../database/migrations/create_fieldsets_table.php.stub' => $this->migrationsPath('create_fieldsets_table.php'),
-            __DIR__.'/../database/migrations/create_forms_table.php.stub' => $this->migrationsPath('create_forms_table.php'),
-            __DIR__.'/../database/migrations/create_form_submissions_table.php.stub' => $this->migrationsPath('create_form_submissions_table.php'),
-            __DIR__.'/../database/migrations/create_asset_containers_table.php.stub' => $this->migrationsPath('create_asset_containers_table.php'),
-            __DIR__.'/../database/migrations/create_asset_table.php.stub' => $this->migrationsPath('create_asset_table.php'),
-            __DIR__.'/../database/migrations/create_revisions_table.php.stub' => $this->migrationsPath('create_revisions_table.php'),
-        ], 'migrations');
-
-        $this->publishes([
+        $this->publishes($taxonomyMigrations = [
             __DIR__.'/../database/migrations/create_taxonomies_table.php.stub' => $this->migrationsPath('create_taxonomies_table.php'),
             __DIR__.'/../database/migrations/create_terms_table.php.stub' => $this->migrationsPath('create_terms_table.php'),
         ], 'statamic-eloquent-taxonomy-migrations');
 
-        $this->publishes([
+        $this->publishes($globalMigrations = [
             __DIR__.'/../database/migrations/create_globals_table.php.stub' => $this->migrationsPath('create_globals_table.php'),
             __DIR__.'/../database/migrations/create_global_variables_table.php.stub' => $this->migrationsPath('create_global_variables_table.php'),
         ], 'statamic-eloquent-global-migrations');
 
-        $this->publishes([
+        $this->publishes($navigationMigrations = [
             __DIR__.'/../database/migrations/create_navigations_table.php.stub' => $this->migrationsPath('create_navigations_table.php'),
             __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
         ], 'statamic-eloquent-navigation-migrations');
 
-        $this->publishes([
+        $this->publishes($collectionMigrations = [
             __DIR__.'/../database/migrations/create_collections_table.php.stub' => $this->migrationsPath('create_collections_table.php'),
         ], 'statamic-eloquent-collection-migrations');
 
-        $this->publishes([
+        $this->publishes($blueprintMigrations = [
             __DIR__.'/../database/migrations/create_blueprints_table.php.stub' => $this->migrationsPath('create_blueprints_table.php'),
             __DIR__.'/../database/migrations/create_fieldsets_table.php.stub' => $this->migrationsPath('create_fieldsets_table.php'),
         ], 'statamic-eloquent-blueprint-migrations');
 
-        $this->publishes([
+        $this->publishes($formMigrations = [
             __DIR__.'/../database/migrations/create_forms_table.php.stub' => $this->migrationsPath('create_forms_table.php'),
             __DIR__.'/../database/migrations/create_form_submissions_table.php.stub' => $this->migrationsPath('create_form_submissions_table.php'),
         ], 'statamic-eloquent-form-migrations');
 
-        $this->publishes([
+        $this->publishes($assetMigrations = [
             __DIR__.'/../database/migrations/create_asset_containers_table.php.stub' => $this->migrationsPath('create_asset_containers_table.php'),
             __DIR__.'/../database/migrations/create_asset_table.php.stub' => $this->migrationsPath('create_asset_table.php'),
         ], 'statamic-eloquent-asset-migrations');
 
-        $this->publishes([
+        $this->publishes($revisionMigrations = [
             __DIR__.'/../database/migrations/create_revisions_table.php.stub' => $this->migrationsPath('create_revisions_table.php'),
         ], 'statamic-eloquent-revision-migrations');
+
+        $this->publishes(
+            array_merge(
+                $taxonomyMigrations,
+                $globalMigrations,
+                $navigationMigrations,
+                $collectionMigrations,
+                $blueprintMigrations,
+                $formMigrations,
+                $assetMigrations,
+                $revisionMigrations,
+            ),
+            'migrations'
+        );
 
         $this->publishes([
             __DIR__.'/../database/migrations/create_entries_table.php.stub' => $this->migrationsPath('create_entries_table'),

--- a/src/Updates/AddBlueprintToEntriesTable.php
+++ b/src/Updates/AddBlueprintToEntriesTable.php
@@ -9,7 +9,9 @@ class AddBlueprintToEntriesTable extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return ! Schema::hasColumn(config('statamic.eloquent-driver.table_prefix', '').'entries', 'blueprint');
+        $entriesTable = config('statamic.eloquent-driver.table_prefix', '').'entries';
+
+        return Schema::hasTable($entriesTable) && ! Schema::hasColumn($entriesTable, 'blueprint');
     }
 
     public function update()

--- a/src/Updates/AddMetaAndIndexesToAssetsTable.php
+++ b/src/Updates/AddMetaAndIndexesToAssetsTable.php
@@ -9,7 +9,9 @@ class AddMetaAndIndexesToAssetsTable extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return ! Schema::hasColumn(config('statamic.eloquent-driver.table_prefix', '').'assets_meta', 'meta');
+        $assetsTable = config('statamic.eloquent-driver.table_prefix', '').'assets_meta';
+
+        return Schema::hasTable($assetsTable) && ! Schema::hasColumn($assetsTable, 'meta');
     }
 
     public function update()

--- a/src/Updates/SplitGlobalsFromVariables.php
+++ b/src/Updates/SplitGlobalsFromVariables.php
@@ -9,7 +9,9 @@ class SplitGlobalsFromVariables extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return ! Schema::hasColumn(config('statamic.eloquent-driver.table_prefix', '').'global_sets', 'settings');
+        $globalsTable = config('statamic.eloquent-driver.table_prefix', '').'global_sets';
+
+        return Schema::hasTable($globalsTable) && ! Schema::hasColumn($globalsTable, 'settings');
     }
 
     public function update()


### PR DESCRIPTION
I'm building a new `php please install:eloquent-driver` command into Statamic Core, which will make the process of moving "things" to the Eloquent Driver much easier.

The command will install the package & let you configure which repositories you want to move over. 

As part of these changes, I didn't want to force users to publish *all* of the Eloquent Driver's migrations, even if they're only planning on switching one of two of the repositories.

This PR makes that possible by splitting the migrations into separate publish tags, grouped by repository. 