### PR TITLE
Make drivers opt-in, rather than opt-out

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -6,84 +6,84 @@ return [
     'table_prefix' => env('STATAMIC_ELOQUENT_PREFIX', ''),
 
     'asset_containers' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Assets\AssetContainerModel::class,
     ],
 
     'assets' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Assets\AssetModel::class,
         'asset' => \Statamic\Eloquent\Assets\Asset::class,
     ],
 
     'blueprints' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'blueprint_model' => \Statamic\Eloquent\Fields\BlueprintModel::class,
         'fieldset_model' => \Statamic\Eloquent\Fields\FieldsetModel::class,
     ],
 
     'collections' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Collections\CollectionModel::class,
         'update_entry_order_queue' => 'default',
         'update_entry_order_connection' => 'default',
     ],
 
     'collection_trees' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Structures\TreeModel::class,
         'tree' => \Statamic\Eloquent\Structures\CollectionTree::class,
     ],
 
     'entries' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
         'entry' => \Statamic\Eloquent\Entries\Entry::class,
     ],
 
     'forms' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model'  => \Statamic\Eloquent\Forms\FormModel::class,
     ],
 
     'form_submissions' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model'  => \Statamic\Eloquent\Forms\SubmissionModel::class,
     ],
 
     'global_sets' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Globals\GlobalSetModel::class,
     ],
 
     'global_set_variables' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Globals\VariablesModel::class,
     ],
 
     'navigations' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Structures\NavModel::class,
     ],
 
     'navigation_trees' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Structures\TreeModel::class,
         'tree' => \Statamic\Eloquent\Structures\NavTree::class,
     ],
 
     'revisions' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Revisions\RevisionModel::class,
     ],
 
     'taxonomies' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Taxonomies\TaxonomyModel::class,
     ],
 
     'terms' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Taxonomies\TermModel::class,
     ],
 ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,10 @@ abstract class TestCase extends AddonTestCase
         parent::resolveApplicationConfiguration($app);
 
         $app['config']->set('statamic.eloquent-driver', require (__DIR__.'/../config/eloquent-driver.php'));
+
+        collect(config('statamic.eloquent-driver'))
+            ->filter(fn ($config) => isset($config['driver']))
+            ->each(fn ($config, $key) => $app['config']->set("statamic.eloquent-driver.{$key}.driver", 'eloquent'));
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
Right now, when you install the Eloquent Driver, *everything* will become driven by Eloquent. However, in a lot of cases, you might only want to move one driver (eg. `assets`) to the database and keep the rest in flat-files. 

This PR changes the default `driver` of all the repositories and adds to the `TestCase` to ensure the repository is switched to `eloquent` when running the test suite.

This PR pairs with statamic/cms#9669, which will let you enable "parts" of the Eloquent Driver as needed. 