### PR TITLE
Clear blink cache on asset save

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -229,6 +229,7 @@ class Asset extends FileAsset
     {
         $this->meta = null;
 
+        Blink::forget("eloquent-asset-{$this->id()}");
         Blink::forget($this->metaCacheKey());
         Cache::forget($this->metaCacheKey());
     }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent\Assets;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Assets\Asset as FileAsset;
 use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\Asset as AssetContract;
@@ -226,8 +227,9 @@ class Asset extends FileAsset
 
     private function clearCaches()
     {
-        Blink::forget($this->metaCacheKey());
+        $this->meta = null;
 
-        parent::clearCaches();
+        Blink::forget($this->metaCacheKey());
+        Cache::forget($this->metaCacheKey());
     }
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -223,4 +223,11 @@ class Asset extends FileAsset
             'data' => $this->data()->toArray(),
         ]);
     }
+
+    private function clearCaches()
+    {
+        Blink::forget($this->metaCacheKey());
+
+        parent::clearCaches();
+    }
 }


### PR DESCRIPTION
The blink meta cache currently persists after save, delete etc, which can cause issues with bulk importing assets or accessing them programatically.

This PR ensures the blink cache is cleared on save, re upload etc.