### PR TITLE
Fix failing tests in `EntryQueryBuilderTest`

### DIFF
--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -40,8 +40,6 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
     {
-        $this->freezeTime();
-
         $searchedEntry = $this->createDummyCollectionAndEntries();
         $columns = ['foo', 'collection'];
         $retrievedEntry = Entry::query()->find($searchedEntry->id(), $columns);

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -25,6 +25,8 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entry_is_found_within_all_created_entries_using_entry_facade_with_find_method()
     {
+        $this->freezeTime();
+
         $searchedEntry = $this->createDummyCollectionAndEntries();
         $retrievedEntry = Entry::query()->find($searchedEntry->id());
 
@@ -38,6 +40,8 @@ class EntryQueryBuilderTest extends TestCase
     /** @test **/
     public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
     {
+        $this->freezeTime();
+
         $searchedEntry = $this->createDummyCollectionAndEntries();
         $columns = ['foo', 'collection'];
         $retrievedEntry = Entry::query()->find($searchedEntry->id(), $columns);
@@ -45,7 +49,7 @@ class EntryQueryBuilderTest extends TestCase
         $retrievedEntry->model(null);
         $searchedEntry->model(null);
 
-        $this->assertSame(json_encode($searchedEntry), json_encode($retrievedEntry));
+        $this->assertSame(json_encode(['foo' => $searchedEntry->foo, 'collection' => $searchedEntry->collection()]), json_encode($retrievedEntry));
         $this->assertSame($retrievedEntry->selectedQueryColumns(), $columns);
     }
 


### PR DESCRIPTION
This pull request fixes two failing tests in the `EntryQueryBuilderTest`.

* `entry_is_found_within_all_created_entries_using_entry_facade_with_find_method` was failing due to the timestamps in the searched & retrieved entries not matching. Freezing time using Laravel's `$this->freezeTime()` helper fixed this.
* `entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param` was failing due to the retrieved entry only returning `foo` and `collection`, where the comparison was expecting the entire entry array. 

These fixes were "cherry picked" out of changes in #273.