### PR TITLE
Tokens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Alternatively, you can publish each repository's migrations individually:
 
 `php artisan vendor:publish --tag="statamic-eloquent-taxonomy-migrations"`
 
+`php artisan vendor:publish --tag="statamic-eloquent-token-migrations"`
+
 
 ## Configuration
 

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -82,4 +82,9 @@ return [
         'driver' => 'eloquent',
         'model' => \Statamic\Eloquent\Taxonomies\TermModel::class,
     ],
+
+    'tokens' => [
+        'driver' => 'eloquent',
+        'model' => \Statamic\Eloquent\Tokens\TokenModel::class,
+    ],
 ];

--- a/database/migrations/2024_03_07_100000_create_tokens_table.php
+++ b/database/migrations/2024_03_07_100000_create_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create($this->prefix('tokens'), function (Blueprint $table) {
+            $table->id();
+            $table->string('token')->unique();
+            $table->string('handler');
+            $table->jsonb('data');
+            $table->timestamp('expire_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix('tokens'));
+    }
+};

--- a/database/migrations/updates/create_tokens_table.php.stub
+++ b/database/migrations/updates/create_tokens_table.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create($this->prefix('tokens'), function (Blueprint $table) {
+            $table->id();
+            $table->string('token')->unique();
+            $table->string('handler');
+            $table->jsonb('data');
+            $table->timestamp('expire_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix('tokens'));
+    }
+};

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -35,9 +35,11 @@ use Statamic\Eloquent\Structures\NavTreeRepository;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
 use Statamic\Eloquent\Taxonomies\TermQueryBuilder;
 use Statamic\Eloquent\Taxonomies\TermRepository;
+use Statamic\Eloquent\Tokens\TokenRepository;
 use Statamic\Events\CollectionTreeSaved;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
+use Statamic\Tokens\TokenRepository as FileTokenRepository;
 
 class ServiceProvider extends AddonServiceProvider
 {
@@ -138,6 +140,10 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../database/migrations/2024_03_07_100000_create_revisions_table.php' => database_path('migrations/2024_03_07_100000_create_revisions_table.php'),
         ], 'statamic-eloquent-revision-migrations');
 
+        $this->publishes($tokenMigrations = [
+            __DIR__.'/../database/migrations/2024_03_07_100000_create_tokens_table.php' => database_path('migrations/2024_03_07_100000_create_tokens_table.php'),
+        ], 'statamic-eloquent-token-migrations');
+
         $this->publishes(
             array_merge(
                 $taxonomyMigrations,
@@ -147,7 +153,8 @@ class ServiceProvider extends AddonServiceProvider
                 $blueprintMigrations,
                 $formMigrations,
                 $assetMigrations,
-                $revisionMigrations
+                $revisionMigrations,
+                $tokenMigrations
             ),
             'migrations'
         );
@@ -177,6 +184,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerStructureTrees();
         $this->registerTaxonomies();
         $this->registerTerms();
+        $this->registerTokens();
     }
 
     private function registerAssetContainers()
@@ -433,6 +441,19 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         Statamic::repository(TermRepositoryContract::class, TermRepository::class);
+    }
+
+    public function registerTokens()
+    {
+        if (config('statamic.eloquent-driver.tokens.driver', 'file') != 'eloquent') {
+            return;
+        }
+
+        $this->app->bind('statamic.eloquent.tokens.model', function () {
+            return config('statamic.eloquent-driver.tokens.model');
+        });
+
+        Statamic::repository(FileTokenRepository::class, TokenRepository::class);
     }
 
     protected function addAboutCommandInfo()

--- a/src/Tokens/Token.php
+++ b/src/Tokens/Token.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Statamic\Eloquent\Tokens;
+
+use Illuminate\Database\Eloquent\Model;
+use Statamic\Contracts\Tokens\Token as Contract;
+use Statamic\Tokens\Token as FileToken;
+
+class Token extends FileToken
+{
+    protected $model;
+
+    public static function fromModel(Model $model)
+    {
+        return (new static($model->token, $model->handler, $model->data))
+            ->expireAt($model->expire_at)
+            ->model($model);
+    }
+
+    public function toModel()
+    {
+        return self::makeModelFromContract($this);
+    }
+
+    public static function makeModelFromContract(Contract $source)
+    {
+        $class = app('statamic.eloquent.tokens.model');
+
+        return $class::firstOrNew(['token' => $source->token()])->fill([
+            'handler'   => $source->handler(),
+            'data'      => $source->data(),
+            'expire_at' => $source->expiry(),
+        ]);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        return $this;
+    }
+
+    public function save()
+    {
+        $model = $this->toModel();
+        $model->save();
+
+        $this->model($model->fresh());
+    }
+
+    public function delete()
+    {
+        $this->model()->delete();
+    }
+}

--- a/src/Tokens/TokenModel.php
+++ b/src/Tokens/TokenModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Eloquent\Tokens;
+
+use Statamic\Eloquent\Database\BaseModel;
+
+class TokenModel extends BaseModel
+{
+    protected $guarded = [];
+
+    protected $table = 'tokens';
+
+    protected $casts = [
+        'data' => 'json',
+        'expire_at' => 'datetime',
+    ];
+}

--- a/src/Tokens/TokenRepository.php
+++ b/src/Tokens/TokenRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Statamic\Eloquent\Tokens;
+
+use Statamic\Contracts\Tokens\Token as TokenContract;
+use Statamic\Tokens\TokenRepository as StatamicTokenRepository;
+
+class TokenRepository extends StatamicTokenRepository
+{
+    public function make(?string $token, string $handler, array $data = []): Token
+    {
+        return new Token($token, $handler, $data);
+    }
+
+    public function find($token)
+    {
+        $model = app('statamic.eloquent.tokens.model')::whereToken($token)->first();
+
+        if (! $model) {
+            return;
+        }
+
+        return Token::fromModel($model);
+    }
+
+    public function save($entry)
+    {
+        $model = $entry->toModel();
+        $model->save();
+
+        $entry->model($model->fresh());
+    }
+
+    public function delete($entry)
+    {
+        $entry->model()->delete();
+    }
+
+    public function collectGarbage()
+    {
+        app('statamic.eloquent.tokens.model')::where('expire_at', '<', now())->delete();
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            TokenContract::class => Token::class,
+        ];
+    }
+}

--- a/src/Updates/CreateTokensTable.php
+++ b/src/Updates/CreateTokensTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Statamic\UpdateScripts\UpdateScript;
+
+class CreateTokensTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.5.0');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/updates/create_tokens_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_create_tokens_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/Repositories/TokenRepositoryTest.php
+++ b/tests/Repositories/TokenRepositoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Repositories;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Statamic\Contracts\Tokens\Token;
+use Statamic\Eloquent\Tokens\TokenRepository;
+use Tests\TestCase;
+
+class TokenRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = new TokenRepository();
+
+        $this->repo->make('abc', 'ExampleHandler', ['foo' => 'bar'])->save();
+    }
+
+    /** @test */
+    public function it_gets_a_token()
+    {
+        tap($this->repo->find('abc'), function ($token) {
+            $this->assertInstanceOf(Token::class, $token);
+            $this->assertEquals('abc', $token->token());
+            $this->assertEquals('ExampleHandler', $token->handler());
+            $this->assertEquals(['foo' => 'bar'], $token->data()->all());
+            $this->assertInstanceOf(Carbon::class, $token->expiry());
+        });
+
+        $this->assertNull($this->repo->find('unknown'));
+    }
+
+    /** @test */
+    public function it_saves_a_token_to_the_database()
+    {
+        $token = $this->repo->make('new', 'ExampleHandler', ['foo' => 'bar']);
+
+        $this->assertNull($this->repo->find('new'));
+
+        $this->repo->save($token);
+
+        $this->assertNotNull($item = $this->repo->find('new'));
+        $this->assertEquals(['foo' => 'bar'], $item->data()->all());
+    }
+}


### PR DESCRIPTION
Adds token support so live preview tokens are stored in the database.

There are a couple of things that are out of the ordinary:

- There's no `TokenRepository` contract, so we're just binding to the file repository class instead.
- The file token `make` method doesn't use the service container, so we have to override it.
- Calling `app(Token::class)::fromModel($model)` doesn't work due to the constructor arguments, so this just calls `Token::fromModel($model)` directly.

These probably require PRs to core if we want them to work like everything else.

Let me know if anything needs changing.