### PR TITLE
Fix querying statuses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "v5.0.0-alpha.6"
+        "statamic/cms": "dev-where-status-trait"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "dev-where-status-trait"
+        "statamic/cms": "dev-master"
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -164,6 +164,24 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         return $this;
     }
 
+    public function where($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        if ($column === 'status') {
+            trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
+        }
+
+        return parent::where($column, $operator, $value, $boolean);
+    }
+
+    public function whereIn($column, $values, $boolean = 'and')
+    {
+        if ($column === 'status') {
+            trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
+        }
+
+        return parent::whereIn($column, $values, $boolean);
+    }
+
     public function whereStatus(string $status)
     {
         if (! in_array($status, self::STATUSES)) {

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -198,11 +198,9 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         $ids = $wheres->where('column', 'id')->flatMap(fn ($where) => $where['values'] ?? [$where['value']]);
 
         // If no IDs were queried, fall back to all collections.
-        if ($ids->isEmpty()) {
-            return $this->whereIn('collection', Collection::handles());
-        }
-
-        $this->whereIn('collection', app(static::class)->whereIn('id', $ids)->pluck('collection')->unique()->values());
+        $ids->isEmpty()
+            ? $this->whereIn('collection', Collection::handles())
+            : $this->whereIn('collection', app(static::class)->whereIn('id', $ids)->pluck('collection')->unique()->values());
     }
 
     private function getCollectionsForStatusQuery(): \Illuminate\Support\Collection

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -184,7 +184,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         return parent::whereIn($column, $values, $boolean);
     }
 
-    private function ensureCollectionsAreQueriedForStatusQuery()
+    private function ensureCollectionsAreQueriedForStatusQuery(): void
     {
         $wheres = collect($this->builder->getQuery()->wheres);
 
@@ -205,7 +205,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         $this->whereIn('collection', app(static::class)->whereIn('id', $ids)->pluck('collection')->unique()->values());
     }
 
-    private function getCollectionsForStatusQuery()
+    private function getCollectionsForStatusQuery(): \Illuminate\Support\Collection
     {
         // Since we have to add nested queries for each collection, we only want to add clauses for the
         // applicable collections. By this point, there should be where clauses on the collection column.

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -856,27 +856,27 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::collection('calendar')->slug('calendar-past')->published(true)->date(now()->subDay())->create();
         EntryFactory::collection('calendar')->slug('calendar-past-draft')->published(false)->date(now()->subDay())->create();
 
-        $this->assertEquals($expected, Entry::query()->whereStatus($status)->get()->map->slug()->all());
+        $this->assertEquals($expected, Entry::query()->whereStatus($status)->get()->map->slug()->sort()->all());
     }
 
     public static function filterByStatusProvider()
     {
         return [
             'draft' => ['draft', [
-                'page-draft',
                 'blog-future-draft',
                 'blog-past-draft',
-                'event-future-draft',
-                'event-past-draft',
                 'calendar-future-draft',
                 'calendar-past-draft',
+                'event-future-draft',
+                'event-past-draft',
+                'page-draft',
             ]],
             'published' => ['published', [
-                'page',
                 'blog-past',
-                'event-future',
                 'calendar-future',
                 'calendar-past',
+                'event-future',
+                'page',
             ]],
             'scheduled' => ['scheduled', [
                 'blog-future',

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -794,4 +794,96 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(3, $entries);
         $this->assertEquals(['Post 2', 'Post 1', 'Post 3'], $entries->map->title->all());
     }
+
+    /** @test */
+    public function filtering_using_where_status_column_writes_deprecation_log()
+    {
+        $this->withoutDeprecationHandling();
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('Filtering by status is deprecated. Use whereStatus() instead.');
+
+        $this->createDummyCollectionAndEntries();
+
+        Entry::query()->where('collection', 'posts')->where('status', 'published')->get();
+    }
+
+    /** @test */
+    public function filtering_using_whereIn_status_column_writes_deprecation_log()
+    {
+        $this->withoutDeprecationHandling();
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('Filtering by status is deprecated. Use whereStatus() instead.');
+
+        $this->createDummyCollectionAndEntries();
+
+        Entry::query()->where('collection', 'posts')->whereIn('status', ['published'])->get();
+    }
+
+    /** @test */
+    public function filtering_by_unexpected_status_throws_exception()
+    {
+        $this->expectExceptionMessage('Invalid status [foo]');
+
+        Entry::query()->whereStatus('foo')->get();
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider filterByStatusProvider
+     */
+    public function it_filters_by_status($status, $expected)
+    {
+        Collection::make('pages')->dated(false)->save();
+        EntryFactory::collection('pages')->slug('page')->published(true)->create();
+        EntryFactory::collection('pages')->slug('page-draft')->published(false)->create();
+
+        Collection::make('blog')->dated(true)->futureDateBehavior('private')->pastDateBehavior('public')->save();
+        EntryFactory::collection('blog')->slug('blog-future')->published(true)->date(now()->addDay())->create();
+        EntryFactory::collection('blog')->slug('blog-future-draft')->published(false)->date(now()->addDay())->create();
+        EntryFactory::collection('blog')->slug('blog-past')->published(true)->date(now()->subDay())->create();
+        EntryFactory::collection('blog')->slug('blog-past-draft')->published(false)->date(now()->subDay())->create();
+
+        Collection::make('events')->dated(true)->futureDateBehavior('public')->pastDateBehavior('private')->save();
+        EntryFactory::collection('events')->slug('event-future')->published(true)->date(now()->addDay())->create();
+        EntryFactory::collection('events')->slug('event-future-draft')->published(false)->date(now()->addDay())->create();
+        EntryFactory::collection('events')->slug('event-past')->published(true)->date(now()->subDay())->create();
+        EntryFactory::collection('events')->slug('event-past-draft')->published(false)->date(now()->subDay())->create();
+
+        Collection::make('calendar')->dated(true)->futureDateBehavior('public')->pastDateBehavior('public')->save();
+        EntryFactory::collection('calendar')->slug('calendar-future')->published(true)->date(now()->addDay())->create();
+        EntryFactory::collection('calendar')->slug('calendar-future-draft')->published(false)->date(now()->addDay())->create();
+        EntryFactory::collection('calendar')->slug('calendar-past')->published(true)->date(now()->subDay())->create();
+        EntryFactory::collection('calendar')->slug('calendar-past-draft')->published(false)->date(now()->subDay())->create();
+
+        $this->assertEquals($expected, Entry::query()->whereStatus($status)->get()->map->slug()->all());
+    }
+
+    public static function filterByStatusProvider()
+    {
+        return [
+            'draft' => ['draft', [
+                'page-draft',
+                'blog-future-draft',
+                'blog-past-draft',
+                'event-future-draft',
+                'event-past-draft',
+                'calendar-future-draft',
+                'calendar-past-draft',
+            ]],
+            'published' => ['published', [
+                'page',
+                'blog-past',
+                'event-future',
+                'calendar-future',
+                'calendar-past',
+            ]],
+            'scheduled' => ['scheduled', [
+                'blog-future',
+            ]],
+            'expired' => ['expired', [
+                'event-past',
+            ]],
+        ];
+    }
 }

--- a/tests/Factories/EntryFactory.php
+++ b/tests/Factories/EntryFactory.php
@@ -89,9 +89,12 @@ class EntryFactory
 
     public function make()
     {
+        $collection = $this->createCollection();
+
         $entry = Entry::make()
             ->locale($this->locale)
-            ->collection($this->createCollection())
+            ->collection($collection)
+            ->blueprint($collection->entryBlueprint())
             ->slug($this->slug)
             ->data($this->data)
             ->origin($this->origin)


### PR DESCRIPTION
This pull request fixes an issue I ran into this morning when using the REST API alongside the Eloquent Driver.

Essentially, when the REST API queries to get entries, it filters for entries where `status` `is` `published`. However, when using the Eloquent Driver, no entries were being returned. 

I've fixed this issue by copying over the recent changes around entry statuses to the Eloquent Driver (related: #9317). 

The implementation is *mostly* the same as it is in Core. However, the main difference is the fact the Eloquent Driver's query builder doesn't maintain a `$collections` property to track the queried collection, instead we're just using `$this->wheres()`

## To Do

* [x] Get the tests passing