### PR TITLE
Fix migration path for global variables update

### DIFF
--- a/src/Updates/SplitGlobalsFromVariables.php
+++ b/src/Updates/SplitGlobalsFromVariables.php
@@ -16,8 +16,8 @@ class SplitGlobalsFromVariables extends UpdateScript
 
     public function update()
     {
-        $source = __DIR__.'/../../database/migrations/create_global_variables_table.php.stub';
-        $dest = database_path('migrations/'.date('Y_m_d_His').'_create_global_variables_table.php');
+        $source = __DIR__.'/../../database/migrations/2024_03_07_100000_create_global_variables_table.php';
+        $dest = database_path('migrations/2024_03_07_100000_create_global_variables_table.php');
 
         $this->files->copy($source, $dest);
 


### PR DESCRIPTION
This PR fixes the path to the global variables update which was missed as part of https://github.com/statamic/eloquent-driver/pull/253/files

Closes https://github.com/statamic/eloquent-driver/issues/280