### PR TITLE
Drop foreign key on form_id

### DIFF
--- a/database/migrations/updates/relate_form_submissions_by_handle.php.stub
+++ b/database/migrations/updates/relate_form_submissions_by_handle.php.stub
@@ -24,6 +24,7 @@ return new class extends Migration {
             });
 
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
+            $table->dropForeign(['form_id']);
             $table->dropColumn('form_id');
         });
     }


### PR DESCRIPTION
As reported on discord there is an error in the form migration, we needed to drop the foreign key first.

This PR ensures that is done.