### PR TITLE
Change ID type on form_submissions to be a float

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "statamic/cms": "^5.0.1"
     },
     "require-dev": {
-        "doctrine/dbal": "^3.3",
+        "doctrine/dbal": "^3.5",
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^8.0 || ^9.0.2",
         "phpunit/phpunit": "^9.4 || ^10.0 || ^11.0"

--- a/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
+++ b/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
@@ -16,7 +16,8 @@ return new class extends Migration
     public function down()
     {
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            $table->id('id')->change();
+            $table->dropUnique('form_submissions_id_unique');
+            $table->string('id')->unique()->change();
         });
     }
 };

--- a/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
+++ b/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            $table->float('id', precision: 4)->index()->unique()->change();
+            $table->float('id', 10, 4)->index()->unique()->change();
         });
     }
 

--- a/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
+++ b/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
+            $table->float('id', precision: 4)->index()->unique()->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
+            $table->id('id')->change();
+        });
+    }
+};

--- a/src/Commands/ImportForms.php
+++ b/src/Commands/ImportForms.php
@@ -74,6 +74,7 @@ class ImportForms extends Command
 
                     app('statamic.eloquent.form_submissions.model')::firstOrNew(['created_at' => $timestamp])
                         ->fill([
+                            'id' => $submission->id(),
                             'form' => $form->handle(),
                             'data' => $submission->data(),
                             'updated_at' => $timestamp,

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -37,6 +37,7 @@ class Submission extends FileEntry
         return (! empty($model->id)) ? $model->fill([
             'data' => $this->data,
         ]) : $model->fill([
+            'id' => $this->id(),
             'data' => $this->data,
             'form' => $this->form->handle(),
             'created_at' => $timestamp,

--- a/src/Forms/SubmissionModel.php
+++ b/src/Forms/SubmissionModel.php
@@ -8,6 +8,8 @@ class SubmissionModel extends BaseModel
 {
     protected $guarded = [];
 
+    public $incrementing = false;
+
     protected $table = 'form_submissions';
 
     protected $casts = [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,6 +58,7 @@ class ServiceProvider extends AddonServiceProvider
         \Statamic\Eloquent\Updates\AddIdToAttributesInRevisionsTable::class,
         \Statamic\Eloquent\Updates\RelateFormSubmissionsByHandle::class,
         \Statamic\Eloquent\Updates\DropStatusOnEntries::class,
+        \Statamic\Eloquent\Updates\ChangeFormSubmissionsIdType::class,
     ];
 
     protected $listen = [
@@ -146,6 +147,7 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->publishes($formSubmissionMigrations = [
             __DIR__.'/../database/migrations/2024_03_07_100000_create_form_submissions_table.php' => database_path('migrations/2024_03_07_100000_create_form_submissions_table.php'),
+            __DIR__.'/../database/migrations/2024_05_15_100000_modify_form_submissions_id.php' => database_path('migrations/2024_05_15_100000_modify_form_submissions_id.php'),
         ], 'statamic-eloquent-form-submission-migrations');
 
         $this->publishes($assetContainerMigrations = [

--- a/src/Updates/ChangeFormSubmissionsIdType.php
+++ b/src/Updates/ChangeFormSubmissionsIdType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Statamic\UpdateScripts\UpdateScript;
+
+class ChangeFormSubmissionsIdType extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('4.1.0');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/2024_05_15_100000_modify_form_submissions_id.php';
+        $dest = database_path('migrations/2024_05_15_100000_modify_form_submissions_id.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -18,6 +18,7 @@ class FormSubmissionTest extends TestCase
         ]);
 
         $submission = SubmissionModel::create([
+            'id' => 1111111111.1111,
             'form' => $form->handle,
             'data' => [
                 'name' => 'John Doe',
@@ -37,6 +38,7 @@ class FormSubmissionTest extends TestCase
         ]);
 
         $submission = SubmissionModel::create([
+            'id' => 1111111111.1111,
             'form' => $form->handle,
             'data' => [
                 'name' => 'John Doe',
@@ -61,6 +63,7 @@ class FormSubmissionTest extends TestCase
         ]);
 
         $submission = SubmissionModel::create([
+            'id' => 1111111111.1111,
             'form' => $form->handle,
             'data' => [
                 'name' => 'John Doe',
@@ -68,6 +71,7 @@ class FormSubmissionTest extends TestCase
         ]);
 
         $submission = SubmissionModel::create([
+            'id' => 1111111111.2222,
             'form' => $form->handle,
             'data' => [
                 'name' => 'Billy Doe',


### PR DESCRIPTION
This PR updates the id type on form_submissions to be a float, rather than an int, so that out of the box it works on Postgres.

@andreas-eisenmann would you mind checking that this migration works in your situation?

Closes https://github.com/statamic/eloquent-driver/issues/286