### PR TITLE
Add "Tokens" driver to `artisan about` command output

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -520,6 +520,7 @@ class ServiceProvider extends AddonServiceProvider
             'Revisions' => config('statamic.eloquent-driver.revisions.driver', 'file'),
             'Taxonomies' => config('statamic.eloquent-driver.taxonomies.driver', 'file'),
             'Terms' => config('statamic.eloquent-driver.terms.driver', 'file'),
+            'Tokens' => config('statamic.eloquent-driver.tokens.driver', 'file'),
         ])->map(fn ($value) => $this->applyAboutCommandFormatting($value))->all());
     }
 


### PR DESCRIPTION
This pull request adds the recently introduced "Tokens" repository to the list of outputted drivers in the `php artisan about` / `php please support:details` commands.

![CleanShot 2024-05-28 at 17 45 35](https://github.com/statamic/eloquent-driver/assets/19637309/a2e91f53-520b-48b9-9be8-536ecb2e5c02)

The "Tokens" repository was added in #277.