### PR TITLE
Refactor makeModelFromContract on assets and containers

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -129,7 +129,7 @@ class Asset extends FileAsset
     {
         $meta['data'] = Arr::removeNullValues($meta['data']);
 
-        self::makeModelFromContract($this, $meta);
+        self::makeModelFromContract($this, $meta)?->save();
 
         Blink::put('eloquent-asset-meta-exists-'.$this->id(), true);
     }
@@ -165,8 +165,6 @@ class Asset extends FileAsset
             $model->created_at = $meta['last_modified'];
             $model->updated_at = $meta['last_modified'];
         }
-
-        $model->save();
 
         return $model;
     }

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -60,23 +60,7 @@ class AssetContainer extends FileEntry
 
     public function toModel()
     {
-        $class = app('statamic.eloquent.assets.container_model');
-
-        return $class::firstOrNew(['handle' => $this->handle()])->fill([
-            'title'    => $this->title(),
-            'disk'     => $this->diskHandle() ?? config('filesystems.default'),
-            'settings' => [
-                'allow_uploads'     => $this->allowUploads(),
-                'allow_downloading' => $this->allowDownloading(),
-                'allow_moving'      => $this->allowMoving(),
-                'allow_renaming'    => $this->allowRenaming(),
-                'create_folders'    => $this->createFolders(),
-                'search_index'      => $this->searchIndex(),
-                'source_preset'     => $this->sourcePreset,
-                'warm_presets'      => $this->warmPresets,
-                'validation_rules'  => $this->validationRules(),
-            ],
-        ]);
+        return self::makeModelFromContract($this);
     }
 
     public static function makeModelFromContract(AssetContainerContract $source)
@@ -102,8 +86,6 @@ class AssetContainer extends FileEntry
             $model->created_at = $source->fileLastModified();
             $model->updated_at = $source->fileLastModified();
         }
-
-        $model->save();
 
         return $model;
     }

--- a/src/Commands/ImportAssets.php
+++ b/src/Commands/ImportAssets.php
@@ -70,7 +70,7 @@ class ImportAssets extends Command
         }
 
         $this->withProgressBar(AssetContainerFacade::all(), function ($container) {
-            AssetContainer::makeModelFromContract($container);
+            AssetContainer::makeModelFromContract($container)?->save();
         });
 
         $this->components->info('Assets containers imported sucessfully');
@@ -83,7 +83,7 @@ class ImportAssets extends Command
         }
 
         $this->withProgressBar(AssetFacade::all(), function ($asset) {
-            EloquentAsset::makeModelFromContract($asset);
+            EloquentAsset::makeModelFromContract($asset)?->save();
         });
 
         $this->components->info('Assets imported sucessfully');


### PR DESCRIPTION
When working on https://github.com/statamic/eloquent-driver/pull/296 I noticed there was a duplication of code in AssetContainer which we should avoid. 

I also took the chance to update the makeModelFromContract methods in assets and containers to not save the model, as it should only make the instance, after which you can decide if you want to save it or not.