### PR TITLE
Support mixed repository blueprints

### DIFF
--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -20,6 +20,7 @@ return [
         'driver' => 'file',
         'blueprint_model' => \Statamic\Eloquent\Fields\BlueprintModel::class,
         'fieldset_model' => \Statamic\Eloquent\Fields\FieldsetModel::class,
+        'namespaces' => 'all',
     ],
 
     'collections' => [

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -21,7 +21,7 @@ class BlueprintRepository extends StacheRepository
                 return null;
             }
 
-            if ($this->isEloquentDrivenNamespace($namespace)) {
+            if (! $this->isEloquentDrivenNamespace($namespace)) {
                 return parent::find($blueprint);
             }
 
@@ -47,7 +47,7 @@ class BlueprintRepository extends StacheRepository
     {
         $this->clearBlinkCaches();
 
-        if ($this->isEloquentDrivenNamespace($blueprint->namespace())) {
+        if (! $this->isEloquentDrivenNamespace($blueprint->namespace())) {
             return parent::save($blueprint);
         }
 
@@ -58,7 +58,7 @@ class BlueprintRepository extends StacheRepository
     {
         $this->clearBlinkCaches();
 
-        if ($this->isEloquentDrivenNamespace($blueprint->namespace())) {
+        if (! $this->isEloquentDrivenNamespace($blueprint->namespace())) {
             return parent::delete($blueprint);
         }
 
@@ -74,7 +74,7 @@ class BlueprintRepository extends StacheRepository
 
     public function in(string $namespace)
     {
-        if ($this->isEloquentDrivenNamespace($namespace)) {
+        if (! $this->isEloquentDrivenNamespace($namespace)) {
             return parent::in($namespace);
         }
 
@@ -219,8 +219,12 @@ class BlueprintRepository extends StacheRepository
         return $contents;
     }
 
-    private function isEloquentDrivenNamespace(string $namespace)
+    private function isEloquentDrivenNamespace(?string $namespace)
     {
+        if (! $namespace) {
+            return true;
+        }
+
         $eloquentNamespaces = config('statamic.eloquent-driver.namespaces', 'all');
 
         if ($eloquentNamespaces !== 'all') {

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -225,7 +225,7 @@ class BlueprintRepository extends StacheRepository
             return true;
         }
 
-        $eloquentNamespaces = config('statamic.eloquent-driver.namespaces', 'all');
+        $eloquentNamespaces = config('statamic.eloquent-driver.blueprints.namespaces', 'all');
 
         if ($eloquentNamespaces !== 'all') {
             if (! in_array($namespace, Arr::wrap($eloquentNamespaces))) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -275,10 +275,10 @@ class ServiceProvider extends AddonServiceProvider
             return config('statamic.eloquent-driver.blueprints.fieldset_model');
         });
 
-        $this->app->singleton(
-            'Statamic\Fields\BlueprintRepository',
-            'Statamic\Eloquent\Fields\BlueprintRepository'
-        );
+        $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () {
+            return (new \Statamic\Eloquent\Fields\BlueprintRepository)
+                ->setDirectory(resource_path('blueprints'));
+        });
 
         $this->app->singleton(
             'Statamic\Fields\FieldsetRepository',

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Fields;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Statamic\Eloquent\Fields\BlueprintModel;
 use Statamic\Facades\Blueprint;
 use Tests\TestCase;
 
@@ -69,5 +70,21 @@ class BlueprintTest extends TestCase
         $model = Blueprint::getModel($blueprint);
 
         $this->assertNull($model);
+    }
+
+    /** @test */
+    public function it_uses_file_based_namespaces()
+    {
+        config()->set('statamic.eloquent-driver.blueprints.namespaces', ['collections']);
+
+        $this->assertCount(1, BlueprintModel::all());
+
+        $blueprint = Blueprint::make()
+            ->setNamespace('forms')
+            ->setHandle('test')
+            ->setHidden(true)
+            ->save();
+
+        $this->assertCount(1, BlueprintModel::all()); // we check theres no new  database entries, ie its been handled by files
     }
 }

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -15,10 +15,10 @@ class BlueprintTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->singleton(
-            'Statamic\Fields\BlueprintRepository',
-            'Statamic\Eloquent\Fields\BlueprintRepository'
-        );
+        $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () {
+            return (new \Statamic\Eloquent\Fields\BlueprintRepository)
+                ->setDirectory(resource_path('blueprints'));
+        });
 
         $this->app->singleton(
             'Statamic\Fields\FieldsetRepository',


### PR DESCRIPTION
This PR adds a config to choose which blueprint namespaces are eloquent driven and which are not. For example, you may want form blueprints in the database but others to be file based.

Closes https://github.com/statamic/eloquent-driver/issues/204