### PR TITLE
make use of $ids in updateEntryOrder method

### DIFF
--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -82,8 +82,11 @@ class CollectionRepository extends StacheRepository
 
     public function updateEntryOrder(CollectionContract $collection, $ids = null)
     {
-        $collection->queryEntries()
-            ->get(['id'])
+        $query = $collection->queryEntries();
+        if ($ids) {
+            $query->whereIn('id', $ids);
+        }
+        $query->get(['id'])
             ->each(function ($entry) {
                 $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id());
 

--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -12,15 +12,12 @@ class CollectionRepository extends StacheRepository
 {
     public function updateEntryUris($collection, $ids = null)
     {
-        $query = $collection->queryEntries();
-
-        if ($ids) {
-            $query->whereIn('id', $ids);
-        }
-
-        $query->get()->each(function ($entry) {
-            app('statamic.eloquent.entries.model')::find($entry->id())->update(['uri' => $entry->uri()]);
-        });
+        $query = $collection->queryEntries()
+            ->when($ids, fn () => $query->whereIn('id', $ids))
+            ->get()
+            ->each(function ($entry) {
+                app('statamic.eloquent.entries.model')::find($entry->id())->update(['uri' => $entry->uri()]);
+            });
     }
 
     public function all(): IlluminateCollection
@@ -82,11 +79,9 @@ class CollectionRepository extends StacheRepository
 
     public function updateEntryOrder(CollectionContract $collection, $ids = null)
     {
-        $query = $collection->queryEntries();
-        if ($ids) {
-            $query->whereIn('id', $ids);
-        }
-        $query->get(['id'])
+        $query = $collection->queryEntries()
+            ->when($ids, fn () => $query->whereIn('id', $ids))
+            ->get(['id'])
             ->each(function ($entry) {
                 $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id());
 


### PR DESCRIPTION
This PR optimises the collection query in the `updateEntryOrder` method by making use of `ids` which are redundant in the current method.

On some of our sites this caused a large number of jobs to be dispatched to the queue when entries were reordered in collection trees. This fix has resolved our issue when applied via composer patch.

The fix is akin to logic already in use in the `updateEntryUris` method