### PR TITLE
Allow blueprints and field sets to be split repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .php_cs.cache
 .nova/*
 .phpunit.cache
+.idea

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -42,7 +42,7 @@ return [
     ],
 
     'fieldsets' => [
-        'driver' => 'eloquent',
+        'driver' => 'file',
         'model' => \Statamic\Eloquent\Fields\FieldsetModel::class,
     ],
 

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -18,8 +18,7 @@ return [
 
     'blueprints' => [
         'driver' => 'file',
-        'blueprint_model' => \Statamic\Eloquent\Fields\BlueprintModel::class,
-        'fieldset_model' => \Statamic\Eloquent\Fields\FieldsetModel::class,
+        'model' => \Statamic\Eloquent\Fields\BlueprintModel::class,
         'namespaces' => 'all',
     ],
 
@@ -40,6 +39,11 @@ return [
         'driver' => 'file',
         'model' => \Statamic\Eloquent\Entries\EntryModel::class,
         'entry' => \Statamic\Eloquent\Entries\Entry::class,
+    ],
+
+    'fieldsets' => [
+        'driver' => 'eloquent',
+        'model' => \Statamic\Eloquent\Fields\FieldsetModel::class,
     ],
 
     'forms' => [

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -96,6 +96,10 @@ class BlueprintRepository extends StacheRepository
 
     protected function filesIn($namespace)
     {
+        if (! $this->isEloquentDrivenNamespace($namespace)) {
+            return parent::filesIn($namespace);
+        }
+
         return Blink::store(self::BLINK_NAMESPACE_PATHS)->once($namespace ?? 'none', function () use ($namespace) {
             $namespace = str_replace('/', '.', $namespace);
 

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -25,7 +25,7 @@ class BlueprintRepository extends StacheRepository
                 return parent::find($blueprint);
             }
 
-            $blueprintModel = ($namespace ? $this->filesIn($namespace) : app('statamic.eloquent.blueprints.blueprint_model')::whereNull('namespace'))
+            $blueprintModel = ($namespace ? $this->filesIn($namespace) : app('statamic.eloquent.blueprints.model')::whereNull('namespace'))
                 ->where('handle', $handle)
                 ->first();
 
@@ -103,7 +103,7 @@ class BlueprintRepository extends StacheRepository
         return Blink::store(self::BLINK_NAMESPACE_PATHS)->once($namespace ?? 'none', function () use ($namespace) {
             $namespace = str_replace('/', '.', $namespace);
 
-            if (count($blueprintModels = app('statamic.eloquent.blueprints.blueprint_model')::where('namespace', $namespace)->get()) == 0) {
+            if (count($blueprintModels = app('statamic.eloquent.blueprints.model')::where('namespace', $namespace)->get()) == 0) {
                 return collect();
             }
 
@@ -142,14 +142,14 @@ class BlueprintRepository extends StacheRepository
 
     public function getModel($blueprint)
     {
-        return app('statamic.eloquent.blueprints.blueprint_model')::where('namespace', $blueprint->namespace() ?? null)
+        return app('statamic.eloquent.blueprints.model')::where('namespace', $blueprint->namespace() ?? null)
             ->where('handle', $blueprint->handle())
             ->first();
     }
 
     public function updateModel($blueprint)
     {
-        $model = app('statamic.eloquent.blueprints.blueprint_model')::firstOrNew([
+        $model = app('statamic.eloquent.blueprints.model')::firstOrNew([
             'handle' => $blueprint->handle(),
             'namespace' => $blueprint->namespace() ?? null,
         ]);

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -32,7 +32,7 @@ class BlueprintRepository extends StacheRepository
             if (! $blueprintModel) {
                 throw_if(
                     $namespace === null && $handle === 'default',
-                    Exception::class,
+                    \Exception::class,
                     'Default Blueprint is required but not found. '
                 );
 

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -12,7 +12,7 @@ class FieldsetRepository extends StacheRepository
     public function all(): Collection
     {
         return Blink::once('eloquent-fieldsets', function () {
-            if (count($models = app('statamic.eloquent.blueprints.fieldset_model')::get() ?? collect()) === 0) {
+            if (count($models = app('statamic.eloquent.fieldsets.model')::get() ?? collect()) === 0) {
                 return collect();
             }
 
@@ -47,7 +47,7 @@ class FieldsetRepository extends StacheRepository
 
     public function updateModel($fieldset)
     {
-        $model = app('statamic.eloquent.blueprints.fieldset_model')::firstOrNew([
+        $model = app('statamic.eloquent.fieldsets.model')::firstOrNew([
             'handle' => $fieldset->handle(),
         ]);
 
@@ -59,7 +59,7 @@ class FieldsetRepository extends StacheRepository
 
     public function deleteModel($fieldset)
     {
-        $model = app('statamic.eloquent.blueprints.fieldset_model')::where('handle', $fieldset->handle())->first();
+        $model = app('statamic.eloquent.fieldsets.model')::where('handle', $fieldset->handle())->first();
 
         if ($model) {
             $model->delete();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -352,7 +352,12 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         $this->app->bind('statamic.eloquent.fieldsets.model', function () {
-            return config('statamic.eloquent-driver.fieldsets.model');
+            return config('statamic.eloquent-driver.fieldsets.model', config('statamic.eloquent-driver.blueprints.fieldset_model'));
+        });
+
+        // @deprecated
+        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
+            return config('statamic.eloquent-driver.fieldsets.model', config('statamic.eloquent-driver.blueprints.fieldset_model'));
         });
 
         $this->app->singleton(

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -143,7 +143,7 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->publishes($fieldsetMigrations = [
             __DIR__.'/../database/migrations/2024_03_07_100000_create_fieldsets_table.php' => database_path('migrations/2024_03_07_100000_create_fieldsets_table.php'),
-        ], 'statamic-eloquent-fieldsets-migrations');
+        ], 'statamic-eloquent-fieldset-migrations');
 
         $this->publishes($formMigrations = [
             __DIR__.'/../database/migrations/2024_03_07_100000_create_forms_table.php' => database_path('migrations/2024_03_07_100000_create_forms_table.php'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent;
 
 use Illuminate\Foundation\Console\AboutCommand;
+use JetBrains\PhpStorm\Deprecated;
 use Statamic\Assets\AssetContainerContents;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
 use Statamic\Contracts\Assets\AssetRepository as AssetRepositoryContract;
@@ -268,7 +269,12 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
+        $this->app->bind('statamic.eloquent.blueprints.model', function () {
+            return config('statamic.eloquent-driver.blueprints.model', config('statamic.eloquent-driver.blueprints.blueprint_model'));
+        });
+
+        // @deprecated
+        $this->app->bind('statamic.eloquent.blueprints.blueprints_model', function () {
             return config('statamic.eloquent-driver.blueprints.model', config('statamic.eloquent-driver.blueprints.blueprint_model'));
         });
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -203,6 +203,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerCollections();
         $this->registerCollectionTrees();
         $this->registerEntries();
+        $this->registerFieldsets();
         $this->registerForms();
         $this->registerFormSubmissions();
         $this->registerGlobals();
@@ -268,22 +269,13 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
-            return config('statamic.eloquent-driver.blueprints.blueprint_model');
-        });
-
-        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
-            return config('statamic.eloquent-driver.blueprints.fieldset_model');
+            return config('statamic.eloquent-driver.blueprints.model', config('statamic.eloquent-driver.blueprints.blueprint_model'));
         });
 
         $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () {
             return (new \Statamic\Eloquent\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'));
         });
-
-        $this->app->singleton(
-            'Statamic\Fields\FieldsetRepository',
-            'Statamic\Eloquent\Fields\FieldsetRepository'
-        );
     }
 
     private function registerCollections()
@@ -343,6 +335,24 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
+    }
+
+    private function registerFieldsets()
+    {
+        $usingOldConfigKeys = config()->has('statamic.eloquent-driver.blueprints.fieldset_model');
+
+        if (config($usingOldConfigKeys ? 'statamic.eloquent-driver.blueprints.driver' : 'statamic.eloquent-driver.fieldsets.driver', 'file') != 'eloquent') {
+            return;
+        }
+
+        $this->app->bind('statamic.eloquent.fieldsets.model', function () {
+            return config('statamic.eloquent-driver.fieldsets.model');
+        });
+
+        $this->app->singleton(
+            'Statamic\Fields\FieldsetRepository',
+            'Statamic\Eloquent\Fields\FieldsetRepository'
+        );
     }
 
     private function registerForms()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -139,8 +139,11 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->publishes($blueprintMigrations = [
             __DIR__.'/../database/migrations/2024_03_07_100000_create_blueprints_table.php' => database_path('migrations/2024_03_07_100000_create_blueprints_table.php'),
-            __DIR__.'/../database/migrations/2024_03_07_100000_create_fieldsets_table.php' => database_path('migrations/2024_03_07_100000_create_fieldsets_table.php'),
         ], 'statamic-eloquent-blueprint-migrations');
+
+        $this->publishes($fieldsetMigrations = [
+            __DIR__.'/../database/migrations/2024_03_07_100000_create_fieldsets_table.php' => database_path('migrations/2024_03_07_100000_create_fieldsets_table.php'),
+        ], 'statamic-eloquent-fieldsets-migrations');
 
         $this->publishes($formMigrations = [
             __DIR__.'/../database/migrations/2024_03_07_100000_create_forms_table.php' => database_path('migrations/2024_03_07_100000_create_forms_table.php'),
@@ -177,6 +180,7 @@ class ServiceProvider extends AddonServiceProvider
                 $navigationTreeMigrations,
                 $collectionMigrations,
                 $blueprintMigrations,
+                $fieldsetMigrations,
                 $formMigrations,
                 $formSubmissionMigrations,
                 $assetContainerMigrations,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Statamic\Eloquent;
 
 use Illuminate\Foundation\Console\AboutCommand;
-use JetBrains\PhpStorm\Deprecated;
 use Statamic\Assets\AssetContainerContents;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
 use Statamic\Contracts\Assets\AssetRepository as AssetRepositoryContract;

--- a/tests/Commands/ImportBlueprintsTest.php
+++ b/tests/Commands/ImportBlueprintsTest.php
@@ -7,6 +7,7 @@ use Statamic\Eloquent\Fields\BlueprintModel;
 use Statamic\Eloquent\Fields\FieldsetModel;
 use Statamic\Facades\Blueprint as BlueprintFacade;
 use Statamic\Facades\Fieldset as FieldsetFacade;
+use Statamic\Facades\File;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\BlueprintRepository;
 use Statamic\Fields\Fieldset;
@@ -37,6 +38,10 @@ class ImportBlueprintsTest extends TestCase
 
         // Statamic will automatically generate a default blueprint. For the purpose of this test, we'll delete it.
         BlueprintModel::all()->each->delete();
+
+        // Ensure there is no stray yaml hanging out which might cause count errors.
+        File::withAbsolutePaths()->getFilesByTypeRecursively(resource_path('blueprints'), 'yaml')->each(fn ($file) => unlink($file));
+        File::withAbsolutePaths()->getFilesByTypeRecursively(resource_path('fieldsets'), 'yaml')->each(fn ($file) => unlink($file));
     }
 
     /** @test */
@@ -60,6 +65,153 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(0, FieldsetModel::all());
 
         $this->artisan('statamic:eloquent:import-blueprints')
+            ->expectsQuestion('Do you want to import blueprints?', true)
+            ->expectsOutputToContain('Blueprints imported successfully.')
+            ->expectsQuestion('Do you want to import fieldsets?', true)
+            ->expectsOutputToContain('Fieldsets imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, BlueprintModel::all());
+        $this->assertCount(1, FieldsetModel::all());
+    }
+
+    /** @test */
+    public function it_imports_blueprints_with_console_question()
+    {
+        BlueprintFacade::make('user')->setContents([
+            'fields' => [
+                ['handle' => 'name', 'field' => ['type' => 'text']],
+                ['handle' => 'email', 'field' => ['type' => 'text'], 'validate' => 'required'],
+            ],
+        ])->save();
+
+        FieldsetFacade::make('test')->setContents([
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'text']],
+                ['handle' => 'bar', 'field' => ['type' => 'textarea', 'validate' => 'required']],
+            ],
+        ])->save();
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+
+        $this->artisan('statamic:eloquent:import-blueprints')
+            ->expectsQuestion('Do you want to import blueprints?', true)
+            ->expectsOutputToContain('Blueprints imported successfully.')
+            ->expectsQuestion('Do you want to import fieldsets?', false)
+            ->assertExitCode(0);
+
+        $this->assertCount(1, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+    }
+
+    /** @test */
+    public function it_imports_fieldsets_with_console_question()
+    {
+        BlueprintFacade::make('user')->setContents([
+            'fields' => [
+                ['handle' => 'name', 'field' => ['type' => 'text']],
+                ['handle' => 'email', 'field' => ['type' => 'text'], 'validate' => 'required'],
+            ],
+        ])->save();
+
+        FieldsetFacade::make('test')->setContents([
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'text']],
+                ['handle' => 'bar', 'field' => ['type' => 'textarea', 'validate' => 'required']],
+            ],
+        ])->save();
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+
+        $this->artisan('statamic:eloquent:import-blueprints')
+            ->expectsQuestion('Do you want to import blueprints?', false)
+            ->expectsQuestion('Do you want to import fieldsets?', true)
+            ->expectsOutputToContain('Fieldsets imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(1, FieldsetModel::all());
+    }
+
+    /** @test */
+    public function it_imports_blueprints_with_only_blueprints_argument()
+    {
+        BlueprintFacade::make('user')->setContents([
+            'fields' => [
+                ['handle' => 'name', 'field' => ['type' => 'text']],
+                ['handle' => 'email', 'field' => ['type' => 'text'], 'validate' => 'required'],
+            ],
+        ])->save();
+
+        FieldsetFacade::make('test')->setContents([
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'text']],
+                ['handle' => 'bar', 'field' => ['type' => 'textarea', 'validate' => 'required']],
+            ],
+        ])->save();
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+
+        $this->artisan('statamic:eloquent:import-blueprints', ['--only-blueprints' => true])
+            ->expectsOutputToContain('Blueprints imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+    }
+
+    /** @test */
+    public function it_imports_fieldsets_with_only_fieldsets_argument()
+    {
+        BlueprintFacade::make('user')->setContents([
+            'fields' => [
+                ['handle' => 'name', 'field' => ['type' => 'text']],
+                ['handle' => 'email', 'field' => ['type' => 'text'], 'validate' => 'required'],
+            ],
+        ])->save();
+
+        FieldsetFacade::make('test')->setContents([
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'text']],
+                ['handle' => 'bar', 'field' => ['type' => 'textarea', 'validate' => 'required']],
+            ],
+        ])->save();
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+
+        $this->artisan('statamic:eloquent:import-blueprints', ['--only-fieldsets' => true])
+            ->expectsOutputToContain('Fieldsets imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(1, FieldsetModel::all());
+    }
+
+    /** @test */
+    public function it_imports_blueprints_and_fieldsets_with_force_argument()
+    {
+        BlueprintFacade::make('user')->setContents([
+            'fields' => [
+                ['handle' => 'name', 'field' => ['type' => 'text']],
+                ['handle' => 'email', 'field' => ['type' => 'text'], 'validate' => 'required'],
+            ],
+        ])->save();
+
+        FieldsetFacade::make('test')->setContents([
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'text']],
+                ['handle' => 'bar', 'field' => ['type' => 'textarea', 'validate' => 'required']],
+            ],
+        ])->save();
+
+        $this->assertCount(0, BlueprintModel::all());
+        $this->assertCount(0, FieldsetModel::all());
+
+        $this->artisan('statamic:eloquent:import-blueprints', ['--force' => true])
             ->expectsOutputToContain('Blueprints imported successfully.')
             ->expectsOutputToContain('Fieldsets imported successfully.')
             ->assertExitCode(0);


### PR DESCRIPTION
This PR allows blueprints and field sets to be run in split repository mode, ie the blueprints could be eloquent driven and field sets file driven, or vice versa.

It also fixes some of the code introduced in https://github.com/statamic/eloquent-driver/pull/300 to handle methods that were missed initially.