### PR TITLE
Fix bug in updateEntryUris and updateEntryOrder

### DIFF
--- a/src/Collections/CollectionRepository.php
+++ b/src/Collections/CollectionRepository.php
@@ -13,7 +13,7 @@ class CollectionRepository extends StacheRepository
     public function updateEntryUris($collection, $ids = null)
     {
         $query = $collection->queryEntries()
-            ->when($ids, fn () => $query->whereIn('id', $ids))
+            ->when($ids, fn ($query) => $query->whereIn('id', $ids))
             ->get()
             ->each(function ($entry) {
                 app('statamic.eloquent.entries.model')::find($entry->id())->update(['uri' => $entry->uri()]);
@@ -80,7 +80,7 @@ class CollectionRepository extends StacheRepository
     public function updateEntryOrder(CollectionContract $collection, $ids = null)
     {
         $query = $collection->queryEntries()
-            ->when($ids, fn () => $query->whereIn('id', $ids))
+            ->when($ids, fn ($query) => $query->whereIn('id', $ids))
             ->get(['id'])
             ->each(function ($entry) {
                 $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id());


### PR DESCRIPTION
As reported here: https://github.com/statamic/eloquent-driver/pull/301#issuecomment-2175683899