### PR TITLE
Use double instead of float for MySQL compatability

### DIFF
--- a/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
+++ b/database/migrations/2024_05_15_100000_modify_form_submissions_id.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            $table->float('id', 10, 4)->index()->unique()->change();
+            $table->double('id', 14, 4)->index()->unique()->change();
         });
     }
 


### PR DESCRIPTION
Change the form id migration to use double as float isn't consistent in MySQL