### PR TITLE
Use model `created_at` for form submission date()

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -22,7 +22,7 @@ class Submission extends FileEntry
     {
         return (new static())
             ->id($model->id)
-            ->date($model->data['date'] ?? Carbon::now())
+            ->date($model->data['date'] ?? $model->created_at ?? Carbon::now())
             ->data(Arr::except($model->data, 'date'))
             ->model($model);
     }

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -22,7 +22,7 @@ class Submission extends FileEntry
     {
         return (new static())
             ->id($model->id)
-            ->date($model->data['date'] ?? $model->created_at ?? Carbon::now())
+            ->date($model->created_at ?? Carbon::now())
             ->data(Arr::except($model->data, 'date'))
             ->model($model);
     }

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Forms;
 use Carbon\Carbon;
 use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Eloquent\Forms\SubmissionModel;
+use Statamic\Facades;
 use Tests\TestCase;
 
 class FormSubmissionTest extends TestCase
@@ -79,5 +80,24 @@ class FormSubmissionTest extends TestCase
         ]);
 
         $this->assertCount(2, SubmissionModel::all());
+    }
+
+    /** @test */
+    public function it_should_not_save_date_in_data()
+    {
+        $form = tap(Facades\Form::make('test')->title('Test'))
+            ->save();
+
+        $submission = tap($form->makeSubmission([
+            'name' => 'John Doe'
+        ]))->save();
+
+        $this->assertInstanceOf(Carbon::class, $submission->date());
+        $this->assertArrayNotHasKey('date', $submission->model()->data);
+
+        $fresh = \Statamic\Eloquent\Forms\Submission::fromModel($submission->model()->fresh());
+
+        $this->assertInstanceOf(Carbon::class, $fresh->date());
+        $this->assertSame($fresh->date()->format('u'), $submission->date()->format('u'));
     }
 }

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -83,7 +83,7 @@ class FormSubmissionTest extends TestCase
         $this->assertCount(2, SubmissionModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_not_save_date_in_data()
     {
         $form = tap(Facades\Form::make('test')->title('Test'))

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -89,7 +89,7 @@ class FormSubmissionTest extends TestCase
             ->save();
 
         $submission = tap($form->makeSubmission([
-            'name' => 'John Doe'
+            'name' => 'John Doe',
         ]))->save();
 
         $this->assertInstanceOf(Carbon::class, $submission->date());


### PR DESCRIPTION
As we no longer store the `date` in the model's data, we need to instead use the `created_at` value from the model for the submission date.