### PR TITLE
Move to PHPUnit attributes

### DIFF
--- a/tests/Commands/ImportAssetsTest.php
+++ b/tests/Commands/ImportAssetsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Commands;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Assets\AssetContainerRepository as AssetContainerRepositoryContract;
@@ -45,7 +46,7 @@ class ImportAssetsTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_asset_containers_and_assets()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
@@ -72,7 +73,7 @@ class ImportAssetsTest extends TestCase
         $this->assertDatabaseHas('assets_meta', ['container' => 'test', 'path' => 'subdirectory/other.txt']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_asset_containers_and_assets_with_force_argument()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
@@ -97,7 +98,7 @@ class ImportAssetsTest extends TestCase
         $this->assertDatabaseHas('assets_meta', ['container' => 'test', 'path' => 'subdirectory/other.txt']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_asset_containers_with_only_asset_containers_argument()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
@@ -122,7 +123,7 @@ class ImportAssetsTest extends TestCase
         $this->assertDatabaseMissing('assets_meta', ['container' => 'test', 'path' => 'subdirectory/other.txt']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_asset_containers_with_console_question()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
@@ -149,7 +150,7 @@ class ImportAssetsTest extends TestCase
         $this->assertDatabaseMissing('assets_meta', ['container' => 'test', 'path' => 'subdirectory/other.txt']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_assets_with_only_assets_argument()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
@@ -174,7 +175,7 @@ class ImportAssetsTest extends TestCase
         $this->assertDatabaseHas('assets_meta', ['container' => 'test', 'path' => 'subdirectory/other.txt']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_assets_with_console_question()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();

--- a/tests/Commands/ImportBlueprintsTest.php
+++ b/tests/Commands/ImportBlueprintsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Fields\BlueprintModel;
 use Statamic\Eloquent\Fields\FieldsetModel;
 use Statamic\Facades\Blueprint as BlueprintFacade;
@@ -44,7 +45,7 @@ class ImportBlueprintsTest extends TestCase
         File::withAbsolutePaths()->getFilesByTypeRecursively(resource_path('fieldsets'), 'yaml')->each(fn ($file) => unlink($file));
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_blueprints_and_fieldsets()
     {
         BlueprintFacade::make('user')->setContents([
@@ -75,7 +76,7 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(1, FieldsetModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_blueprints_with_console_question()
     {
         BlueprintFacade::make('user')->setContents([
@@ -105,7 +106,7 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(0, FieldsetModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_fieldsets_with_console_question()
     {
         BlueprintFacade::make('user')->setContents([
@@ -135,7 +136,7 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(1, FieldsetModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_blueprints_with_only_blueprints_argument()
     {
         BlueprintFacade::make('user')->setContents([
@@ -163,7 +164,7 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(0, FieldsetModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_fieldsets_with_only_fieldsets_argument()
     {
         BlueprintFacade::make('user')->setContents([
@@ -191,7 +192,7 @@ class ImportBlueprintsTest extends TestCase
         $this->assertCount(1, FieldsetModel::all());
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_blueprints_and_fieldsets_with_force_argument()
     {
         BlueprintFacade::make('user')->setContents([

--- a/tests/Commands/ImportCollectionsTest.php
+++ b/tests/Commands/ImportCollectionsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\Entry as EntryContract;
@@ -37,7 +38,7 @@ class ImportCollectionsTest extends TestCase
         app()->bind(EntryContract::class, \Statamic\Entries\Entry::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collections_and_collection_trees()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -67,7 +68,7 @@ class ImportCollectionsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'pages', 'type' => 'collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collections_and_collection_trees_with_force_argument()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -95,7 +96,7 @@ class ImportCollectionsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'pages', 'type' => 'collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collections_with_console_question()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -125,7 +126,7 @@ class ImportCollectionsTest extends TestCase
         $this->assertDatabaseMissing('trees', ['handle' => 'pages', 'type' => 'collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collections_with_only_collections_argument()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -153,7 +154,7 @@ class ImportCollectionsTest extends TestCase
         $this->assertDatabaseMissing('trees', ['handle' => 'pages', 'type' => 'collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collection_trees_with_console_question()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -183,7 +184,7 @@ class ImportCollectionsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'pages', 'type' => 'collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_collection_trees_with_only_collections_argument()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();

--- a/tests/Commands/ImportEntriesTest.php
+++ b/tests/Commands/ImportEntriesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\Entry as EntryContract;
@@ -38,7 +39,7 @@ class ImportEntriesTest extends TestCase
         app()->bind(EntryContract::class, \Statamic\Entries\Entry::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_entries()
     {
         $collection = tap(Collection::make('pages')->title('Pages'))->save();
@@ -55,7 +56,7 @@ class ImportEntriesTest extends TestCase
         $this->assertDatabaseHas('entries', ['collection' => 'pages', 'slug' => 'foo', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_localized_entries()
     {
         Site::setSites([

--- a/tests/Commands/ImportFormsTest.php
+++ b/tests/Commands/ImportFormsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Contracts\Forms\FormRepository as FormRepositoryContract;
 use Statamic\Contracts\Forms\Submission as SubmissionContract;
@@ -31,7 +32,7 @@ class ImportFormsTest extends TestCase
         app()->bind(\Statamic\Eloquent\Forms\SubmissionQueryBuilder::class, \Statamic\Stache\Query\SubmissionQueryBuilder::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_forms_and_submissions()
     {
         $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
@@ -57,7 +58,7 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_forms_and_submissions_with_force_argument()
     {
         $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
@@ -81,7 +82,7 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_forms_with_only_forms_argument()
     {
         $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
@@ -105,7 +106,7 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseMissing('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_forms_with_console_question()
     {
         $form = tap(\Statamic\Facades\Form::make('contact')->title('Contact')->store(true))->save();
@@ -131,7 +132,7 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseMissing('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_submissions_with_only_form_submissions_argument()
     {
         $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
@@ -155,7 +156,7 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_form_submissions_with_console_question()
     {
         $form = tap(\Statamic\Facades\Form::make('contact')->title('Contact')->store(true))->save();

--- a/tests/Commands/ImportGlobalsTest.php
+++ b/tests/Commands/ImportGlobalsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Globals\GlobalRepository as GlobalRepositoryContract;
 use Statamic\Contracts\Globals\GlobalSet as GlobalSetContract;
 use Statamic\Contracts\Globals\GlobalVariablesRepository as GlobalVariablesRepositoryContract;
@@ -30,7 +31,7 @@ class ImportGlobalsTest extends TestCase
         app()->bind(GlobalVariablesRepositoryContract::class, \Statamic\Stache\Repositories\GlobalVariablesRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_global_sets_and_variables()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();
@@ -53,7 +54,7 @@ class ImportGlobalsTest extends TestCase
         $this->assertDatabaseHas('global_set_variables', ['handle' => 'footer', 'locale' => 'en', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_global_sets_and_variables_with_force_argument()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();
@@ -74,7 +75,7 @@ class ImportGlobalsTest extends TestCase
         $this->assertDatabaseHas('global_set_variables', ['handle' => 'footer', 'locale' => 'en', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_global_sets_with_console_question()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();
@@ -97,7 +98,7 @@ class ImportGlobalsTest extends TestCase
         $this->assertDatabaseMissing('global_set_variables', ['handle' => 'footer', 'locale' => 'en', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_global_sets_with_only_global_sets_argument()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();
@@ -118,7 +119,7 @@ class ImportGlobalsTest extends TestCase
         $this->assertDatabaseMissing('global_set_variables', ['handle' => 'footer', 'locale' => 'en', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_variables_with_console_question()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();
@@ -141,7 +142,7 @@ class ImportGlobalsTest extends TestCase
         $this->assertDatabaseHas('global_set_variables', ['handle' => 'footer', 'locale' => 'en', 'data' => '{"foo":"bar"}']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_only_variables_with_only_global_variables_argument()
     {
         $globalSet = tap(GlobalSet::make('footer')->title('Footer'))->save();

--- a/tests/Commands/ImportNavsTest.php
+++ b/tests/Commands/ImportNavsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Structures\Nav as NavContract;
 use Statamic\Contracts\Structures\NavigationRepository as NavigationRepositoryContract;
 use Statamic\Contracts\Structures\NavTree as NavTreeContract;
@@ -30,7 +31,7 @@ class ImportNavsTest extends TestCase
         app()->bind(NavTreeRepositoryContract::class, \Statamic\Stache\Repositories\NavTreeRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_navs_and_nav_trees()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();
@@ -55,7 +56,7 @@ class ImportNavsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'footer', 'type' => 'navigation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_navs_and_nav_trees_with_force_argument()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();
@@ -78,7 +79,7 @@ class ImportNavsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'footer', 'type' => 'navigation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_navs_with_console_question()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();
@@ -103,7 +104,7 @@ class ImportNavsTest extends TestCase
         $this->assertDatabaseMissing('trees', ['handle' => 'footer', 'type' => 'navigation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_navs_with_only_navs_argument()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();
@@ -126,7 +127,7 @@ class ImportNavsTest extends TestCase
         $this->assertDatabaseMissing('trees', ['handle' => 'footer', 'type' => 'navigation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_nav_trees_with_console_question()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();
@@ -151,7 +152,7 @@ class ImportNavsTest extends TestCase
         $this->assertDatabaseHas('trees', ['handle' => 'footer', 'type' => 'navigation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_nav_trees_with_only_nav_trees_argument()
     {
         $nav = tap(Nav::make('footer')->title('Footer'))->save();

--- a/tests/Commands/ImportRevisionsTest.php
+++ b/tests/Commands/ImportRevisionsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Commands;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Revisions\Revision as RevisionContract;
 use Statamic\Contracts\Revisions\RevisionRepository as RevisionRepositoryContract;
 use Statamic\Eloquent\Revisions\RevisionModel;
@@ -39,7 +40,7 @@ class ImportRevisionsTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_import_revisions_when_feature_is_disabled()
     {
         config(['statamic.revisions.enabled' => false]);
@@ -48,7 +49,7 @@ class ImportRevisionsTest extends TestCase
             ->expectsOutputToContain('This import can only be run when revisions are enabled.');
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_revisions()
     {
         Revision::make()

--- a/tests/Commands/ImportTaxonomiesTest.php
+++ b/tests/Commands/ImportTaxonomiesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
@@ -31,7 +32,7 @@ class ImportTaxonomiesTest extends TestCase
         app()->bind(TermRepositoryContract::class, \Statamic\Stache\Repositories\TermRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_taxonomies_and_terms()
     {
         Taxonomy::make('tags')->save();
@@ -58,7 +59,7 @@ class ImportTaxonomiesTest extends TestCase
         $this->assertDatabaseHas('taxonomy_terms', ['slug' => 'charlie']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_taxonomies_and_terms_with_force_argument()
     {
         Taxonomy::make('tags')->save();
@@ -83,7 +84,7 @@ class ImportTaxonomiesTest extends TestCase
         $this->assertDatabaseHas('taxonomy_terms', ['slug' => 'charlie']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_taxonomies_with_console_question()
     {
         Taxonomy::make('tags')->save();
@@ -110,7 +111,7 @@ class ImportTaxonomiesTest extends TestCase
         $this->assertDatabaseMissing('taxonomy_terms', ['slug' => 'charlie']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_taxonomies_with_only_taxonomies_argument()
     {
         Taxonomy::make('tags')->save();
@@ -135,7 +136,7 @@ class ImportTaxonomiesTest extends TestCase
         $this->assertDatabaseMissing('taxonomy_terms', ['slug' => 'charlie']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_terms_with_console_question()
     {
         Taxonomy::make('tags')->save();
@@ -162,7 +163,7 @@ class ImportTaxonomiesTest extends TestCase
         $this->assertDatabaseHas('taxonomy_terms', ['slug' => 'charlie']);
     }
 
-    /** @test */
+    #[Test]
     public function it_imports_terms_with_only_terms_argument()
     {
         Taxonomy::make('tags')->save();

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Data\Assets;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Blueprint;
@@ -40,7 +41,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::make()->container('test')->path('f.jpg')->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_assets()
     {
         $assets = Asset::query()->get();
@@ -49,7 +50,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where()
     {
         $assets = Asset::query()->where('filename', 'a')->orWhere('filename', 'c')->get();
@@ -58,7 +59,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_in()
     {
         $assets = Asset::query()
@@ -71,7 +72,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_not_in()
     {
         $assets = Asset::query()
@@ -96,7 +97,7 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::e.jpg')->data(['test_date' => null])->save();
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_date()
     {
         $this->createWhereDateTestAssets();
@@ -117,7 +118,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_month()
     {
         $this->createWhereDateTestAssets();
@@ -133,7 +134,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['d'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_day()
     {
         $this->createWhereDateTestAssets();
@@ -149,7 +150,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'd'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_year()
     {
         $this->createWhereDateTestAssets();
@@ -165,7 +166,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['d'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_time()
     {
         $this->createWhereDateTestAssets();
@@ -196,7 +197,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['c', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_not_null()
     {
         Asset::find('test::a.jpg')->data(['text' => 'Text 1'])->save();
@@ -212,7 +213,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_null()
     {
         Asset::find('test::a.jpg')->data(['text' => 'Text 1', 'content' => 'Content 1'])->save();
@@ -228,7 +229,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_not_null()
     {
         Asset::find('test::a.jpg')->data(['text' => 'Text 1', 'content' => 'Content 1'])->save();
@@ -244,7 +245,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 'd'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_nested_where()
     {
         $assets = Asset::query()
@@ -261,7 +262,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c', 'd', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_nested_where_in()
     {
         $assets = Asset::query()
@@ -279,7 +280,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd', 'c', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_between()
     {
         Asset::find('test::a.jpg')->data(['number_field' => 8])->save();
@@ -295,7 +296,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'c', 'd'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_not_between()
     {
         Asset::find('test::a.jpg')->data(['number_field' => 8])->save();
@@ -311,7 +312,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_between()
     {
         Asset::find('test::a.jpg')->data(['number_field' => 8])->save();
@@ -327,7 +328,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'c', 'd', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_not_between()
     {
         Asset::find('test::a.jpg')->data(['text' => 'a', 'number_field' => 8])->save();
@@ -343,7 +344,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -367,7 +368,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -392,7 +393,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'd', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -411,7 +412,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_or_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -431,7 +432,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c', 'b', 'd'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_json_length()
     {
         if ($this->isUsingSqlite()) {
@@ -450,7 +451,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'e'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_array_of_wheres()
     {
         $assets = Asset::query()
@@ -464,7 +465,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function results_are_found_using_where_with_json_value()
     {
         Asset::find('test::a.jpg')->data(['text' => 'Text 1', 'content' => ['value' => 1]])->save();
@@ -486,7 +487,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['b', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function assets_are_found_using_where_column()
     {
         Asset::find('test::a.jpg')->data(['foo' => 'Post 1', 'other_foo' => 'Not Post 1'])->save();
@@ -507,7 +508,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 5', 'Post 6'], $entries->map->foo->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_assets_using_when()
     {
         $assets = Asset::query()->when(true, function ($query) {
@@ -525,7 +526,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 'd', 'e', 'f'], $assets->map->filename()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_assets_using_unless()
     {
         $assets = Asset::query()->unless(true, function ($query) {
@@ -543,7 +544,7 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertEquals(['a'], $assets->map->filename()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_assets_using_tap()
     {
         $assets = Asset::query()->tap(function ($query) {

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Data\Entries;
 
 use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -21,7 +23,7 @@ class EntryQueryBuilderTest extends TestCase
         return $entry;
     }
 
-    /** @test **/
+    #[Test]
     public function entry_is_found_within_all_created_entries_using_entry_facade_with_find_method()
     {
         $this->freezeTime();
@@ -36,7 +38,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertSame(json_encode($searchedEntry), json_encode($retrievedEntry));
     }
 
-    /** @test **/
+    #[Test]
     public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
     {
         $searchedEntry = $this->createDummyCollectionAndEntries();
@@ -50,7 +52,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertSame($retrievedEntry->selectedQueryColumns(), $columns);
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where()
     {
         $this->createDummyCollectionAndEntries();
@@ -61,7 +63,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_in()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
@@ -76,7 +78,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 4', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_not_in()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
@@ -91,7 +93,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_date()
     {
         $this->createWhereDateTestEntries();
@@ -112,7 +114,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_month()
     {
         $this->createWhereDateTestEntries();
@@ -128,7 +130,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_day()
     {
         $this->createWhereDateTestEntries();
@@ -144,7 +146,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_year()
     {
         $this->createWhereDateTestEntries();
@@ -160,7 +162,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_time()
     {
         $this->createWhereDateTestEntries();
@@ -202,7 +204,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 3', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_not_null()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1'])->create();
@@ -217,7 +219,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_null()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1', 'content' => 'Content 1'])->create();
@@ -232,7 +234,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_not_null()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1', 'content' => 'Content 1'])->create();
@@ -247,7 +249,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 3', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_column()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'other_title' => 'Not Post 1'])->create();
@@ -267,7 +269,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_nested_where()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
@@ -291,7 +293,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['1', '3', '4', '6'], $entries->map->id()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_nested_where_in()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
@@ -318,7 +320,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['1', '2', '4', '6', '7', '9'], $entries->map->id()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_between()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'number_field' => 8])->create();
@@ -333,7 +335,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_not_between()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'number_field' => 8])->create();
@@ -348,7 +350,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_between()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'number_field' => 8])->create();
@@ -363,7 +365,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_not_between()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'number_field' => 8])->create();
@@ -378,7 +380,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -402,7 +404,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -426,7 +428,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 4', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -445,7 +447,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_or_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -464,7 +466,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3', 'Post 2', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_json_length()
     {
         if ($this->isUsingSqlite()) {
@@ -483,7 +485,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 5'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_array_of_wheres()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'content' => 'Test'])->create();
@@ -504,7 +506,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['3', '5'], $entries->map->id()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_with_json_value()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'content' => ['value' => 1]])->create();
@@ -527,7 +529,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_when()
     {
         $this->createDummyCollectionAndEntries();
@@ -547,7 +549,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 2', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_unless()
     {
         $this->createDummyCollectionAndEntries();
@@ -567,7 +569,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_tap()
     {
         $this->createDummyCollectionAndEntries();
@@ -580,7 +582,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_entries_by_id()
     {
         Collection::make('posts')->routes('/posts/{slug}')->save();
@@ -601,7 +603,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertSame($found, $substitute);
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_entries_by_uri()
     {
         Collection::make('posts')->routes('/posts/{slug}')->save();
@@ -624,7 +626,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertSame($found, $substitute);
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_entries_by_uri_and_site()
     {
         $this->setSites([
@@ -675,7 +677,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertSame($found, $substituteFr);
     }
 
-    /** @test */
+    #[Test]
     public function entries_are_found_using_offset()
     {
         $this->createDummyCollectionAndEntries();
@@ -690,7 +692,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function entries_are_found_using_offset_but_no_limit()
     {
         $this->createDummyCollectionAndEntries();
@@ -705,7 +707,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function entries_can_be_retrieved_on_join_table_conditions()
     {
         Collection::make('posts')->save();
@@ -743,7 +745,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
     }
 
-    /** @test */
+    #[Test]
     public function entries_can_be_ordered_by_an_integer_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['integer' => ['type' => 'integer']]);
@@ -760,7 +762,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 3', 'Post 1', 'Post 2'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function entries_can_be_ordered_by_an_float_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['float' => ['type' => 'float']]);
@@ -777,7 +779,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 3', 'Post 1', 'Post 2'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function entries_can_be_ordered_by_an_date_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => true]]);
@@ -794,7 +796,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 1', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test */
+    #[Test]
     public function filtering_using_where_status_column_writes_deprecation_log()
     {
         $this->withoutDeprecationHandling();
@@ -806,7 +808,7 @@ class EntryQueryBuilderTest extends TestCase
         Entry::query()->where('collection', 'posts')->where('status', 'published')->get();
     }
 
-    /** @test */
+    #[Test]
     public function filtering_using_whereIn_status_column_writes_deprecation_log()
     {
         $this->withoutDeprecationHandling();
@@ -818,7 +820,7 @@ class EntryQueryBuilderTest extends TestCase
         Entry::query()->where('collection', 'posts')->whereIn('status', ['published'])->get();
     }
 
-    /** @test */
+    #[Test]
     public function filtering_by_unexpected_status_throws_exception()
     {
         $this->expectExceptionMessage('Invalid status [foo]');
@@ -826,11 +828,8 @@ class EntryQueryBuilderTest extends TestCase
         Entry::query()->whereStatus('foo')->get();
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider filterByStatusProvider
-     */
+    #[Test]
+    #[DataProvider('filterByStatusProvider')]
     public function it_filters_by_status($status, $expected)
     {
         Collection::make('pages')->dated(false)->save();

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Fields;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Fields\BlueprintModel;
 use Statamic\Facades\Blueprint;
 use Tests\TestCase;
@@ -34,7 +35,7 @@ class BlueprintTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_and_removes_hidden_on_model()
     {
         $blueprint = Blueprint::make()
@@ -53,7 +54,7 @@ class BlueprintTest extends TestCase
         $this->assertFalse(isset($model->data['hide']));
     }
 
-    /** @test */
+    #[Test]
     public function it_deletes_the_model_when_the_blueprint_is_deleted()
     {
         $blueprint = Blueprint::make()
@@ -72,7 +73,7 @@ class BlueprintTest extends TestCase
         $this->assertNull($model);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_file_based_namespaces()
     {
         config()->set('statamic.eloquent-driver.blueprints.namespaces', ['collections']);

--- a/tests/Data/Globals/GlobalSetTest.php
+++ b/tests/Data/Globals/GlobalSetTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Data\Globals;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Globals\GlobalSet;
 use Tests\TestCase;
 
 class GlobalSetTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_file_contents_for_saving_with_a_single_site()
     {
         config()->set('statamic.system.multisite', false);
@@ -37,7 +38,7 @@ EOT;
         $this->assertEquals($expected, $set->fileContents());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_file_contents_for_saving_with_multiple_sites()
     {
         config()->set('statamic.system.multisite', true);

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -6,6 +6,8 @@ use BadMethodCallException;
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Contracts\Support\Arrayable;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Globals\Variables;
 use Statamic\Facades;
 use Statamic\Facades\Blueprint;
@@ -17,7 +19,7 @@ use Tests\TestCase;
 
 class VariablesTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_file_contents_for_saving()
     {
         $entry = (new Variables())->data([
@@ -37,7 +39,7 @@ EOT;
         $this->assertEquals($expected, $entry->fileContents());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_file_contents_for_saving_a_localized_set()
     {
         $global = GlobalSet::make('test');
@@ -98,7 +100,7 @@ EOT;
         $this->assertEquals($expected, $c->fileContents());
     }
 
-    /** @test */
+    #[Test]
     public function if_the_value_is_explicitly_set_to_null_then_it_should_not_fall_back()
     {
         $global = GlobalSet::make('test');
@@ -194,7 +196,7 @@ EOT;
         $this->assertEquals(null, $e->value('four'));
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_data_values_using_magic_properties()
     {
         $variables = new Variables();
@@ -206,7 +208,7 @@ EOT;
         $this->assertEquals('bar', $variables->get('foo'));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_evaluated_augmented_value_using_magic_property()
     {
         (new class() extends Fieldtype
@@ -232,11 +234,8 @@ EOT;
         $this->assertEquals('delta (augmented)', $variables['charlie']);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider queryBuilderProvider
-     **/
+    #[Test]
+    #[DataProvider('queryBuilderProvider')]
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
         $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
@@ -272,7 +271,7 @@ EOT;
         ];
     }
 
-    /** @test */
+    #[Test]
     public function calling_unknown_method_throws_exception()
     {
         $this->expectException(BadMethodCallException::class);
@@ -281,7 +280,7 @@ EOT;
         GlobalSet::make('settings')->makeLocalization('en')->thisFieldDoesntExist();
     }
 
-    /** @test */
+    #[Test]
     public function it_converts_to_an_array()
     {
         $fieldtype = new class() extends Fieldtype
@@ -327,7 +326,7 @@ EOT;
         ], $array['baz'], 'Value objects are not resolved recursively');
     }
 
-    /** @test */
+    #[Test]
     public function only_requested_relationship_fields_are_included_in_to_array()
     {
         $regularFieldtype = new class() extends Fieldtype

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Taxonomies;
 
 use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
@@ -13,7 +14,7 @@ use Tests\TestCase;
 
 class TermQueryBuilderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_terms()
     {
         Taxonomy::make('tags')->save();
@@ -26,7 +27,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEveryItemIsInstanceOf(LocalizedTerm::class, $terms);
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_wheres()
     {
         Taxonomy::make('tags')->save();
@@ -38,7 +39,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_or_wheres()
     {
         Taxonomy::make('tags')->save();
@@ -52,7 +53,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_or_where_ins()
     {
         Taxonomy::make('tags')->save();
@@ -67,7 +68,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd', 'e'], $terms->map->slug()->values()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function it_filters_using_or_where_not_ins()
     {
         Taxonomy::make('tags')->save();
@@ -83,7 +84,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['c', 'f'], $terms->map->slug()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_nested_wheres()
     {
         Taxonomy::make('tags')->save();
@@ -107,7 +108,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c', 'd', 'e'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_nested_where_ins()
     {
         Taxonomy::make('tags')->save();
@@ -132,7 +133,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'c', 'd', 'e', 'f'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_using_nested_where_not_ins()
     {
         Taxonomy::make('tags')->save();
@@ -153,7 +154,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_by_taxonomy()
     {
         Taxonomy::make('tags')->save();
@@ -171,7 +172,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'd'], $terms->map->slug()->sort()->values()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_sorts()
     {
         Taxonomy::make('tags')->save();
@@ -185,7 +186,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['c', 'b', 'e', 'a', 'd'], $terms->map->slug()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_where_column()
     {
         Taxonomy::make('tags')->save();
@@ -206,7 +207,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['a', 'b', 'e'], $terms->map->slug()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_usage_in_collections()
     {
         Taxonomy::make('tags')->save();
@@ -275,7 +276,7 @@ class TermQueryBuilderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_terms_by_id()
     {
         Taxonomy::make('tags')->save();
@@ -299,7 +300,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(collect($found->toArray())->except(['updated_at'])->all(), collect($substitute->toArray())->except(['updated_at'])->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_terms_by_uri()
     {
         Taxonomy::make('tags')->save();
@@ -322,7 +323,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals($found, $substitute);
     }
 
-    /** @test */
+    #[Test]
     public function it_substitutes_terms_by_uri_and_site()
     {
         $this->setSites([
@@ -384,7 +385,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertSame($found, $substituteFr);
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_date()
     {
         $this->createWhereDateTestTerms();
@@ -400,7 +401,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_month()
     {
         $this->createWhereDateTestTerms();
@@ -416,7 +417,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_day()
     {
         $this->createWhereDateTestTerms();
@@ -432,7 +433,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2', 'Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_year()
     {
         $this->createWhereDateTestTerms();
@@ -448,7 +449,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 4'], $entries->map->title->all());
     }
 
-    /** @test **/
+    #[Test]
     public function entries_are_found_using_where_time()
     {
         $this->createWhereDateTestTerms();
@@ -477,7 +478,7 @@ class TermQueryBuilderTest extends TestCase
         Term::make('e')->taxonomy('tags')->data(['title' => 'Post 5', 'test_date' => null])->save();
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -502,7 +503,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['1', '3'], $entries->map->slug()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -527,7 +528,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['2', '4', '5'], $entries->map->slug()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_or_where_json_contains()
     {
         if ($this->isUsingSqlite()) {
@@ -547,7 +548,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['1', '3', '5'], $entries->map->slug()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_or_where_json_doesnt_contain()
     {
         if ($this->isUsingSqlite()) {
@@ -567,7 +568,7 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['1', '2', '3', '4'], $entries->map->slug()->all());
     }
 
-    /** @test **/
+    #[Test]
     public function terms_are_found_using_where_json_length()
     {
         Taxonomy::make('tags')->save();

--- a/tests/Entries/EntryModelTest.php
+++ b/tests/Entries/EntryModelTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Entries;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Entries\EntryModel;
 use Tests\TestCase;
 
 class EntryModelTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_attributes_from_json_column()
     {
         $model = new EntryModel([

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
@@ -16,7 +17,7 @@ class EntryTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
+    #[Test]
     public function it_loads_from_entry_model()
     {
         Collection::make('blog')->title('blog')->save();
@@ -36,7 +37,7 @@ class EntryTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $entry->data()->except(['updated_at'])->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_to_entry_model()
     {
         $model = new EntryModel([
@@ -63,7 +64,7 @@ class EntryTest extends TestCase
         $this->assertEquals(collect($model->toArray())->except(['updated_at'])->all(), collect($entry->toModel()->toArray())->except('updated_at')->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_stores_computed_values()
     {
         $collection = Collection::make('blog')->title('blog')->routes([
@@ -93,7 +94,7 @@ class EntryTest extends TestCase
         $this->assertEquals(150, $entry->model()->data['shares']);
     }
 
-    /** @test */
+    #[Test]
     public function it_defers_to_the_live_computed_value_instead_of_the_stored_value()
     {
         $collection = Collection::make('blog')->title('blog')->routes([
@@ -127,7 +128,7 @@ class EntryTest extends TestCase
         $this->assertEquals(100, $freshEntry->shares);
     }
 
-    /** @test */
+    #[Test]
     public function it_propagates_entry_if_configured()
     {
         $this->setSites([
@@ -155,7 +156,7 @@ class EntryTest extends TestCase
         $this->assertNull($entry->descendants()->get('es')); // collection not configured for this site
     }
 
-    /** @test */
+    #[Test]
     public function it_propagates_updating_origin_data_to_descendent_models()
     {
         $this->setSites([
@@ -200,7 +201,7 @@ class EntryTest extends TestCase
         $this->assertNotNull($entry->descendants()->get('de')->model()->data['too'] ?? null);
     }
 
-    /** @test */
+    #[Test]
     public function it_propagates_origin_date_to_descendent_models()
     {
         $this->setSites([

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -3,13 +3,14 @@
 namespace Tests\Forms;
 
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Eloquent\Forms\SubmissionModel;
 use Tests\TestCase;
 
 class FormSubmissionTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_have_timestamps()
     {
         $form = FormModel::create([
@@ -29,7 +30,7 @@ class FormSubmissionTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $submission->updated_at);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_save_to_the_database()
     {
         $form = FormModel::create([
@@ -54,7 +55,7 @@ class FormSubmissionTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_not_overwrite_submissions()
     {
         $form = FormModel::create([

--- a/tests/Repositories/AssetContainerRepositoryTest.php
+++ b/tests/Repositories/AssetContainerRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection as IlluminateCollection;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Eloquent\Assets\AssetContainerRepository;
 use Statamic\Facades;
@@ -26,7 +27,7 @@ class AssetContainerRepositoryTest extends TestCase
         $this->repo->make('main')->title('Main Assets')->disk('local')->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_all_asset_containers()
     {
         $containers = $this->repo->all();
@@ -41,7 +42,7 @@ class AssetContainerRepositoryTest extends TestCase
         $this->assertEquals(['Another Asset Container', 'Main Assets'], $ordered->map->title()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_an_asset_container_by_handle()
     {
         tap($this->repo->findByHandle('main'), function ($container) {
@@ -61,7 +62,7 @@ class AssetContainerRepositoryTest extends TestCase
         $this->assertNull($this->repo->findByHandle('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_a_container_to_the_database()
     {
         $container = Facades\AssetContainer::make('new');

--- a/tests/Repositories/CollectionRepositoryTest.php
+++ b/tests/Repositories/CollectionRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection as IlluminateCollection;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Collections\CollectionRepository;
 use Statamic\Facades\Collection as CollectionAPI;
@@ -28,7 +29,7 @@ class CollectionRepositoryTest extends TestCase
         $this->repo->make('pages')->title('Pages')->routes('{parent_uri}/{slug}')->structureContents(['root' => true])->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_all_collections()
     {
         $collections = $this->repo->all();
@@ -42,7 +43,7 @@ class CollectionRepositoryTest extends TestCase
         $this->assertEquals(['Alphabetical', 'Blog', 'Numeric', 'Pages'], $ordered->map->title()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_collection_by_handle()
     {
         tap($this->repo->findByHandle('alphabetical'), function ($collection) {
@@ -72,7 +73,7 @@ class CollectionRepositoryTest extends TestCase
         $this->assertNull($this->repo->findByHandle('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_a_collection_to_the_database()
     {
         $collection = CollectionAPI::make('new');

--- a/tests/Repositories/GlobalRepositoryTest.php
+++ b/tests/Repositories/GlobalRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Globals\GlobalSet;
 use Statamic\Eloquent\Globals\GlobalRepository;
 use Statamic\Eloquent\Globals\Variables;
@@ -30,7 +31,7 @@ class GlobalRepositoryTest extends TestCase
         (new Variables())->globalSet($globalTwo)->data(['foo' => 'Bar'])->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_all_global_sets()
     {
         $sets = $this->repo->all();
@@ -45,7 +46,7 @@ class GlobalRepositoryTest extends TestCase
         $this->assertEquals(['Contact Details', 'General'], $ordered->map->title()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_global_set_by_id()
     {
         tap($this->repo->find('global'), function ($set) {
@@ -65,7 +66,7 @@ class GlobalRepositoryTest extends TestCase
         $this->assertNull($this->repo->find('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_global_set_by_handle()
     {
         tap($this->repo->findByHandle('global'), function ($set) {
@@ -85,7 +86,7 @@ class GlobalRepositoryTest extends TestCase
         $this->assertNull($this->repo->findByHandle('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_a_global_to_the_database()
     {
         $global = GlobalSetAPI::make('new');

--- a/tests/Repositories/NavigationRepositoryTest.php
+++ b/tests/Repositories/NavigationRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Structures\Structure;
 use Statamic\Eloquent\Structures\Nav;
 use Statamic\Eloquent\Structures\NavigationRepository;
@@ -28,7 +29,7 @@ class NavigationRepositoryTest extends TestCase
         $sidebar->makeTree('en', [['entry' => 'pages-contact'], ['entry' => 'pages-contact']])->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_all_navs()
     {
         $navs = $this->repo->all();
@@ -42,7 +43,7 @@ class NavigationRepositoryTest extends TestCase
         $this->assertEquals(['Footer', 'Sidebar'], $ordered->map->title()->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_nav_by_handle()
     {
         tap($this->repo->findByHandle('sidebar'), function ($nav) {
@@ -60,7 +61,7 @@ class NavigationRepositoryTest extends TestCase
         $this->assertNull($this->repo->findByHandle('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_a_nav_to_the_database()
     {
         $structure = (new Nav())->handle('new');

--- a/tests/Repositories/TaxonomyRepositoryTest.php
+++ b/tests/Repositories/TaxonomyRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Stache\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection as IlluminateCollection;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Collections\CollectionRepository;
 use Statamic\Eloquent\Taxonomies\Taxonomy;
 use Statamic\Eloquent\Taxonomies\TaxonomyRepository;
@@ -35,7 +36,7 @@ class TaxonomyRepositoryTest extends TestCase
         $this->repo->make('tags')->title('Tags')->save();
     }
 
-    /** @test */
+    //     #[Test]
     //     public function it_gets_all_taxonomies()
     //     {
     //         $taxonomies = $this->repo->all();
@@ -49,7 +50,7 @@ class TaxonomyRepositoryTest extends TestCase
     //         $this->assertEquals(['Categories', 'Tags'], $ordered->map->title()->all());
     //     }
     //
-    //     /** @test */
+    //     #[Test]
     //     public function it_gets_a_taxonomy_by_handle()
     //     {
     //         tap($this->repo->findByHandle('categories'), function ($taxonomy) {
@@ -67,7 +68,7 @@ class TaxonomyRepositoryTest extends TestCase
     //         $this->assertNull($this->repo->findByHandle('unknown'));
     //     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_taxonomy_by_uri()
     {
         tap($this->repo->findByUri('/categories'), function ($taxonomy) {
@@ -78,7 +79,7 @@ class TaxonomyRepositoryTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_taxonomy_by_uri_with_collection()
     {
         tap($this->repo->findByUri('/blog/categories'), function ($taxonomy) {
@@ -89,7 +90,7 @@ class TaxonomyRepositoryTest extends TestCase
         });
     }
 
-    /** @test */
+    //     #[Test]
     //     public function it_saves_a_taxonomy_to_the_stache_and_to_a_file()
     //     {
     //         $taxonomy = TaxonomyAPI::make('new');

--- a/tests/Repositories/TokenRepositoryTest.php
+++ b/tests/Repositories/TokenRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Repositories;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Tokens\Token;
 use Statamic\Eloquent\Tokens\TokenRepository;
 use Tests\TestCase;
@@ -21,7 +22,7 @@ class TokenRepositoryTest extends TestCase
         $this->repo->make('abc', 'ExampleHandler', ['foo' => 'bar'])->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_token()
     {
         tap($this->repo->find('abc'), function ($token) {
@@ -35,7 +36,7 @@ class TokenRepositoryTest extends TestCase
         $this->assertNull($this->repo->find('unknown'));
     }
 
-    /** @test */
+    #[Test]
     public function it_saves_a_token_to_the_database()
     {
         $token = $this->repo->make('new', 'ExampleHandler', ['foo' => 'bar']);


### PR DESCRIPTION
PHPUnit has started throwing deprecation warnings on the use of `/** @test **/` and dataproviders in comments. 

This PR updates the test suite to use attributes instead, which is going to be the only supported way from PHPUnit 12+.