### PR TITLE
Use database to build asset folder list

### DIFF
--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -39,27 +39,12 @@ class AssetContainerContents extends CoreAssetContainerContents
             return $this->folders;
         }
 
-        $this->folders = Cache::remember($this->key(), $this->ttl(), function () {
-            return collect($this->directoryRecurse(''))
-                ->map(fn ($dir) => ['path' => $dir, 'type' => 'dir']);
+        return Cache::remember($this->key(), $this->ttl(), function () {
+            return $this->query()->select(['folder'])
+                ->distinct()
+                ->get()
+                ->map(fn ($model) => ['path' => $model->folder, 'type' => 'dir']);
         });
-
-        return $this->folders;
-    }
-
-    private function directoryRecurse($directory)
-    {
-        $rootFolders = $this->container->disk()->getFolders($directory, false);
-
-        $folders = [];
-        foreach ($rootFolders as $folder) {
-            $folders[] = $folder;
-            if ($subfolders = $this->directoryRecurse($folder)) {
-                $folders = array_merge($folders, $subfolders);
-            }
-        }
-
-        return $folders;
     }
 
     public function metaFilesIn($folder, $recursive)

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -39,12 +39,14 @@ class AssetContainerContents extends CoreAssetContainerContents
             return $this->folders;
         }
 
-        return Cache::remember($this->key(), $this->ttl(), function () {
+        $this->folders = Cache::remember($this->key(), $this->ttl(), function () {
             return $this->query()->select(['folder'])
                 ->distinct()
                 ->get()
                 ->map(fn ($model) => ['path' => $model->folder, 'type' => 'dir']);
         });
+
+        return $this->folders;
     }
 
     public function metaFilesIn($folder, $recursive)

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -51,7 +51,9 @@ class SyncAssets extends Command
         $this->line("Processing folder: {$folder}");
 
         // get raw listing of this folder, avoiding any of statamic's asset container caching
-        $files = collect($container->disk()->filesystem()->listContents($folder))
+        $contents = collect($container->disk()->filesystem()->listContents($folder));
+
+        $files = $contents
             ->reject(fn ($item) => $item['type'] != 'file')
             ->pluck('path');
 
@@ -86,11 +88,15 @@ class SyncAssets extends Command
             });
 
         // process any sub-folders of this folder
-        $container->folders($folder)
+        $contents
+            ->reject(fn ($item) => $item['type'] != 'dir')
+            ->pluck('path')
             ->each(function ($subfolder) use ($container, $folder) {
                 if (str_contains($subfolder.'/', '.meta/')) {
                     return;
                 }
+
+                $this->info($folder.'|'.$subfolder);
 
                 if ($folder != $subfolder && (strlen($subfolder) > strlen($folder))) {
                     $this->processFolder($container, $subfolder);

--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -96,8 +96,6 @@ class SyncAssets extends Command
                     return;
                 }
 
-                $this->info($folder.'|'.$subfolder);
-
                 if ($folder != $subfolder && (strlen($subfolder) > strlen($folder))) {
                     $this->processFolder($container, $subfolder);
                 }

--- a/tests/Assets/AssetContainerContentsTest.php
+++ b/tests/Assets/AssetContainerContentsTest.php
@@ -38,13 +38,13 @@ class AssetContainerContentsTest extends TestCase
 
         $this->assertSame([
             [
-                'path' => "one",
-                'type' => "dir",
+                'path' => 'one',
+                'type' => 'dir',
             ],
             [
-                'path' => "two",
-                'type' => "dir",
-            ]
+                'path' => 'two',
+                'type' => 'dir',
+            ],
         ], $container->contents()->directories()->all());
     }
 

--- a/tests/Assets/AssetContainerContentsTest.php
+++ b/tests/Assets/AssetContainerContentsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Assets;
+
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class AssetContainerContentsTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/tmp',
+        ]]);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory(__DIR__.'/tmp');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_gets_a_folder_listing()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $container->makeAsset('one/one.txt')->upload(UploadedFile::fake()->create('one.txt'));
+        $container->makeAsset('two/two.txt')->upload(UploadedFile::fake()->create('two.txt'));
+
+        $this->assertSame([
+            [
+                'path' => "one",
+                'type' => "dir",
+            ],
+            [
+                'path' => "two",
+                'type' => "dir",
+            ]
+        ], $container->contents()->directories()->all());
+    }
+
+    #[Test]
+    public function it_adds_to_a_folder_listing()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $container->makeAsset('one/one.txt')->upload(UploadedFile::fake()->create('one.txt'));
+        $container->makeAsset('two/two.txt')->upload(UploadedFile::fake()->create('two.txt'));
+
+        $this->assertCount(2, $container->contents()->directories()->all());
+
+        $container->contents()->add('three');
+
+        $this->assertCount(3, $container->contents()->directories()->all());
+    }
+
+    #[Test]
+    public function it_forgets_a_folder_listing()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $container->makeAsset('one/one.txt')->upload(UploadedFile::fake()->create('one.txt'));
+        $container->makeAsset('two/two.txt')->upload(UploadedFile::fake()->create('two.txt'));
+
+        $this->assertCount(2, $container->contents()->directories()->all());
+
+        $container->contents()->forget('one');
+
+        $this->assertCount(1, $container->contents()->directories()->all());
+    }
+
+    #[Test]
+    public function it_creates_parent_folders_where_they_dont_exist()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $container->makeAsset('one/two/three/file.txt')->upload(UploadedFile::fake()->create('one.txt'));
+
+        $this->assertCount(3, $container->contents()->filteredDirectoriesIn('', true));
+    }
+}


### PR DESCRIPTION
Now that we have an eloquent AssetContainerContents we should go the whole haul and use it to build the folder list as it will be significantly quicker than querying the file system directly.

This PR implements it, as well as the changes needed to the SyncAssets command to prevent it trying to use the AssetContainerContents directory list, as initially this will be empty.

Closes https://github.com/statamic/eloquent-driver/issues/294