### PR TITLE
use created_at column for submission sorting

### DIFF
--- a/src/Forms/SubmissionQueryBuilder.php
+++ b/src/Forms/SubmissionQueryBuilder.php
@@ -20,7 +20,7 @@ class SubmissionQueryBuilder extends EloquentQueryBuilder implements BuilderCont
         }
 
         if ($column == 'datestamp') {
-            $column = 'date';
+            $column = 'created_at';
         }
 
         if (! in_array($column, self::COLUMNS)) {


### PR DESCRIPTION
Submissions are not sortable due to this query which expects the date to be in the data.
This issue is a regression from https://github.com/statamic/eloquent-driver/pull/306 where the date field is grabbed from the created_at column instead. 

Result is that old submissions are sortable due to having a date property in data, but new entries do not.

Current query.
`select * from form_submissions where form = 'tip_os' order by json_unquote(json_extract(data, '$."date"')) desc limit 100 offset 0`

This PR changes the query builder to use the `created_at` column for sorting

The new query will look like this:
`select * from form_submissions where form = 'tip_os' order by created_at desc limit 100 offset 0`