### PR TITLE
Remove `initial_path` from import and export data

### DIFF
--- a/src/Commands/ExportNavs.php
+++ b/src/Commands/ExportNavs.php
@@ -81,7 +81,6 @@ class ExportNavs extends Command
                 ->collections($model->settings['collections'] ?? null)
                 ->maxDepth($model->settings['max_depth'] ?? null)
                 ->expectsRoot($model->settings['expects_root'] ?? false)
-                ->initialPath($model->settings['initial_path'] ?? null)
                 ->save();
         });
 
@@ -106,7 +105,6 @@ class ExportNavs extends Command
                         ->tree($treeModel->tree)
                         ->handle($treeModel->handle)
                         ->locale($treeModel->locale)
-                        ->initialPath($treeModel->settings['initial_path'] ?? null)
                         ->syncOriginal()
                         ->save();
                 });

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -15,7 +15,6 @@ class CollectionTree extends FileEntry
             ->tree($model->tree)
             ->handle($model->handle)
             ->locale($model->locale)
-            ->initialPath($model->settings['initial_path'] ?? null)
             ->syncOriginal()
             ->model($model);
     }
@@ -35,9 +34,7 @@ class CollectionTree extends FileEntry
             'locale' => $source->locale(),
         ])->fill([
             'tree'     => $source->tree(),
-            'settings' => [
-                'initial_path' => $source->initialPath(),
-            ],
+            'settings' => [],
         ]);
     }
 

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -18,7 +18,6 @@ class Nav extends FileEntry
             ->collections($model->settings['collections'] ?? null)
             ->maxDepth($model->settings['max_depth'] ?? null)
             ->expectsRoot($model->settings['expects_root'] ?? false)
-            ->initialPath($model->settings['initial_path'] ?? null)
             ->model($model);
     }
 
@@ -42,7 +41,6 @@ class Nav extends FileEntry
                 'collections'  => $source->collections()->map->handle(),
                 'max_depth'    => $source->maxDepth(),
                 'expects_root' => $source->expectsRoot(),
-                'initial_path' => $source->initialPath(),
             ],
         ]);
     }

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -15,7 +15,6 @@ class NavTree extends FileEntry
             ->tree($model->tree)
             ->handle($model->handle)
             ->locale($model->locale)
-            ->initialPath($model->settings['initial_path'] ?? null)
             ->syncOriginal()
             ->model($model);
     }
@@ -37,9 +36,7 @@ class NavTree extends FileEntry
             'locale' => $source->locale(),
         ])->fill([
             'tree'     => ($isFileEntry || $source->model) ? $source->tree() : [],
-            'settings' => [
-                'initial_path' => $source->initialPath(),
-            ],
+            'settings' => [],
         ]);
     }
 


### PR DESCRIPTION
This PR prevents the stache specific `initial_path` from being added to eloquent models.