### PR TITLE
Preserve select field order in blueprints and fieldsets

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -186,6 +186,7 @@ class BlueprintRepository extends StacheRepository
                     $tab['sections'] = collect($tab['sections'])
                         ->map(function ($section) use (&$sectionCount) {
                             $section['__count'] = $sectionCount++;
+                            $section['fields'] = $this->addOrderToBlueprintFields($section['fields']);
 
                             return $section;
                         });
@@ -196,6 +197,39 @@ class BlueprintRepository extends StacheRepository
             ->toArray();
 
         return $contents;
+    }
+
+    private function addOrderToBlueprintFields(array $fields): array
+    {
+        return collect($fields)->map(function ($field) {
+            if (in_array($field['field']['type'], ['replicator'])) {
+                $field['field']['sets'] = collect($field['field']['sets'])->map(function ($set) {
+                    $set['sets'] = collect($set['sets'])->map(function ($set) {
+                        $set['fields'] = $this->addOrderToBlueprintFields($set['fields']);
+
+                        return $set;
+                    })->all();
+
+                    return $set;
+                })->all();
+
+                return $field;
+            }
+
+            if (in_array($field['field']['type'], ['grid'])) {
+                $field['field']['fields'] = $this->addOrderToBlueprintFields($field['field']['fields']);
+
+                return $field;
+            }
+
+            if (! in_array($field['field']['type'], ['select'])) {
+                return $field;
+            }
+
+            $field['field']['__order'] = array_keys($field['field']['options']);
+
+            return $field;
+        })->all();
     }
 
     private function updateOrderFromBlueprintSections($contents)
@@ -211,6 +245,8 @@ class BlueprintRepository extends StacheRepository
                         ->map(function ($section) use (&$sectionCount) {
                             unset($section['__count']);
 
+                            $section['fields'] = $this->applyOrderToBlueprintFields($section['fields']);
+
                             return $section;
                         })
                         ->toArray();
@@ -221,6 +257,40 @@ class BlueprintRepository extends StacheRepository
             ->toArray();
 
         return $contents;
+    }
+
+    private function applyOrderToBlueprintFields(array $fields): array
+    {
+        return collect($fields)->map(function ($field) {
+            if (in_array($field['field']['type'], ['replicator'])) {
+                $field['field']['sets'] = collect($field['field']['sets'])->map(function ($set) {
+                    $set['sets'] = collect($set['sets'])->map(function ($set) {
+                        $set['fields'] = $this->applyOrderToBlueprintFields($set['fields']);
+
+                        return $set;
+                    })->all();
+
+                    return $set;
+                })->all();
+
+                return $field;
+            }
+
+            if (in_array($field['field']['type'], ['grid'])) {
+                $field['field']['fields'] = $this->applyOrderToBlueprintFields($field['field']['fields']);
+
+                return $field;
+            }
+
+            if (! $orderedKeys = Arr::get($field, 'field.__order')) {
+                return $field;
+            }
+
+            $field['field']['options'] = array_merge(array_flip($orderedKeys), $field['field']['options']);
+            unset($field['field']['__order']);
+
+            return $field;
+        })->all();
     }
 
     private function isEloquentDrivenNamespace(?string $namespace)

--- a/src/Fields/Traits/StoresAndRetrievesFieldOrder.php
+++ b/src/Fields/Traits/StoresAndRetrievesFieldOrder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Statamic\Eloquent\Fields\Traits;
+
+use Statamic\Support\Arr;
+
+trait StoresAndRetrievesFieldOrder
+{
+    private function addOrderToBlueprintFields(array $fields): array
+    {
+        return collect($fields)->map(function ($field) {
+            if (in_array($field['field']['type'], ['replicator'])) {
+                $field['field']['sets'] = collect($field['field']['sets'])->map(function ($set) {
+                    $set['sets'] = collect($set['sets'])->map(function ($set) {
+                        $set['fields'] = $this->addOrderToBlueprintFields($set['fields']);
+
+                        return $set;
+                    })->all();
+
+                    return $set;
+                })->all();
+
+                return $field;
+            }
+
+            if (in_array($field['field']['type'], ['grid'])) {
+                $field['field']['fields'] = $this->addOrderToBlueprintFields($field['field']['fields']);
+
+                return $field;
+            }
+
+            if (!in_array($field['field']['type'], ['select'])) {
+                return $field;
+            }
+
+            $field['field']['__order'] = array_keys($field['field']['options']);
+
+            return $field;
+        })->all();
+    }
+
+    private function applyOrderToBlueprintFields(array $fields): array
+    {
+        return collect($fields)->map(function ($field) {
+            if (in_array($field['field']['type'], ['replicator'])) {
+                $field['field']['sets'] = collect($field['field']['sets'])->map(function ($set) {
+                    $set['sets'] = collect($set['sets'])->map(function ($set) {
+                        $set['fields'] = $this->applyOrderToBlueprintFields($set['fields']);
+
+                        return $set;
+                    })->all();
+
+                    return $set;
+                })->all();
+
+                return $field;
+            }
+
+            if (in_array($field['field']['type'], ['grid'])) {
+                $field['field']['fields'] = $this->applyOrderToBlueprintFields($field['field']['fields']);
+
+                return $field;
+            }
+
+            if (! $orderedKeys = Arr::get($field, 'field.__order')) {
+                return $field;
+            }
+
+            $field['field']['options'] = array_merge(array_flip($orderedKeys), $field['field']['options']);
+            unset($field['field']['__order']);
+
+            return $field;
+        })->all();
+    }
+}

--- a/src/Fields/Traits/StoresAndRetrievesFieldOrder.php
+++ b/src/Fields/Traits/StoresAndRetrievesFieldOrder.php
@@ -29,7 +29,7 @@ trait StoresAndRetrievesFieldOrder
                 return $field;
             }
 
-            if (!in_array($field['field']['type'], ['select'])) {
+            if (! in_array($field['field']['type'], ['select'])) {
                 return $field;
             }
 

--- a/tests/Data/Fields/FieldsetTest.php
+++ b/tests/Data/Fields/FieldsetTest.php
@@ -4,7 +4,6 @@ namespace Tests\Data\Fields;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Eloquent\Fields\FieldsetModel;
 use Statamic\Facades\Fieldset;
 use Statamic\Support\Arr;
 use Tests\TestCase;

--- a/tests/Data/Fields/FieldsetTest.php
+++ b/tests/Data/Fields/FieldsetTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Data\Fields;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Fields\FieldsetModel;
+use Statamic\Facades\Fieldset;
+use Statamic\Support\Arr;
+use Tests\TestCase;
+
+class FieldsetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->singleton(
+            'Statamic\Fields\FieldsetRepository',
+            'Statamic\Eloquent\Fields\FieldsetRepository'
+        );
+
+        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
+            return \Statamic\Eloquent\Fields\FieldsetModel::class;
+        });
+    }
+
+    #[Test]
+    public function it_stores_and_resets_select_field_order()
+    {
+        $contents = json_decode(file_get_contents(__DIR__.'/__fixtures__/fieldset.json'), true);
+
+        $fieldset = Fieldset::make('test')
+            ->setContents($contents)
+            ->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.0.field'));
+        $this->assertSame(['one', 'two'], Arr::get($savedData, 'fields.0.field.__order'));
+
+        Arr::set($contents, 'fields.0.field.options', ['two' => 'Two', 'one' => 'One']);
+
+        $fieldset->setContents($contents)->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.0.field'));
+        $this->assertSame(['two', 'one'], Arr::get($savedData, 'fields.0.field.__order'));
+    }
+
+    #[Test]
+    public function it_stores_and_resets_select_field_order_within_replicators()
+    {
+        $contents = json_decode(file_get_contents(__DIR__.'/__fixtures__/fieldset.json'), true);
+
+        $fieldset = Fieldset::make('test')
+            ->setContents($contents)
+            ->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.1.field.sets.new_set_group.sets.new_set.fields.0.field'));
+        $this->assertSame(['one', 'two'], Arr::get($savedData, 'fields.1.field.sets.new_set_group.sets.new_set.fields.0.field.__order'));
+
+        Arr::set($contents, 'fields.1.field.sets.new_set_group.sets.new_set.fields.0.field.options', ['two' => 'Two', 'one' => 'One']);
+
+        $fieldset->setContents($contents)->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.1.field.sets.new_set_group.sets.new_set.fields.0.field'));
+        $this->assertSame(['two', 'one'], Arr::get($savedData, 'fields.1.field.sets.new_set_group.sets.new_set.fields.0.field.__order'));
+    }
+
+    #[Test]
+    public function it_stores_and_resets_select_field_order_within_grids()
+    {
+        $contents = json_decode(file_get_contents(__DIR__.'/__fixtures__/fieldset.json'), true);
+
+        $fieldset = Fieldset::make('test')
+            ->setContents($contents)
+            ->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.2.field.fields.0.field'));
+        $this->assertSame(['one', 'two'], Arr::get($savedData, 'fields.2.field.fields.0.field.__order'));
+
+        Arr::set($contents, 'fields.2.field.fields.0.field.options', ['two' => 'Two', 'one' => 'One']);
+
+        $fieldset->setContents($contents)->save();
+
+        $savedData = Fieldset::getModel($fieldset)->data;
+
+        $this->assertArrayHasKey('__order', Arr::get($savedData, 'fields.2.field.fields.0.field'));
+        $this->assertSame(['two', 'one'], Arr::get($savedData, 'fields.2.field.fields.0.field.__order'));
+    }
+}

--- a/tests/Data/Fields/__fixtures__/blueprint.json
+++ b/tests/Data/Fields/__fixtures__/blueprint.json
@@ -1,0 +1,148 @@
+{
+    "tabs": {
+        "SEO": {
+            "__count": 2,
+            "display": "SEO",
+            "sections": [
+                {
+                    "fields": [
+                        {
+                            "field": {
+                                "type": "seo_pro",
+                                "display": "SEO",
+                                "listable": false,
+                                "localizable": false
+                            },
+                            "handle": "seo"
+                        }
+                    ],
+                    "__count": 0
+                }
+            ]
+        },
+        "main": {
+            "__count": 0,
+            "display": "Main",
+            "sections": [
+                {
+                    "fields": [
+                        {
+                            "field": {
+                                "type": "text",
+                                "required": true,
+                                "validate": [
+                                    "required"
+                                ],
+                                "localizable": false
+                            },
+                            "handle": "title"
+                        },
+                        {
+                            "field": {
+                                "type": "select",
+                                "display": "Select Field",
+                                "options": {
+                                    "sms": "SMS",
+                                    "tel": "Telephone",
+                                    "email": "Email"
+                                },
+                                "localizable": false
+                            },
+                            "handle": "select_field"
+                        },
+                        {
+                            "field": {
+                                "sets": {
+                                    "new_set_group": {
+                                        "sets": {
+                                            "new_set": {
+                                                "fields": [
+                                                    {
+                                                        "field": {
+                                                            "type": "select",
+                                                            "display": "Select Field",
+                                                            "options": {
+                                                                "one": "One",
+                                                                "two": "Two"
+                                                            },
+                                                            "localizable": false
+                                                        },
+                                                        "handle": "select_field"
+                                                    }
+                                                ],
+                                                "display": "New Set"
+                                            }
+                                        },
+                                        "display": "New Set Group"
+                                    }
+                                },
+                                "type": "replicator",
+                                "display": "Replicator Field",
+                                "localizable": false
+                            },
+                            "handle": "replicator_field"
+                        },
+                        {
+                            "field": {
+                                "type": "grid",
+                                "fields": [
+                                    {
+                                        "field": {
+                                            "type": "select",
+                                            "display": "Select Field",
+                                            "options": {
+                                                "one": "One",
+                                                "two": "Two"
+                                            },
+                                            "localizable": false
+                                        },
+                                        "handle": "select_field"
+                                    }
+                                ],
+                                "display": "Grid Field",
+                                "localizable": false
+                            },
+                            "handle": "grid_field"
+                        }
+                    ],
+                    "__count": 0
+                }
+            ]
+        },
+        "sidebar": {
+            "__count": 1,
+            "display": "Sidebar",
+            "sections": [
+                {
+                    "fields": [
+                        {
+                            "field": {
+                                "type": "slug",
+                                "validate": [
+                                    "required",
+                                    "unique_entry_value:{collection},{id},{site}"
+                                ],
+                                "localizable": true
+                            },
+                            "handle": "slug"
+                        },
+                        {
+                            "field": {
+                                "type": "entries",
+                                "listable": true,
+                                "max_items": 1,
+                                "collections": [
+                                    "pretend_terms"
+                                ],
+                                "localizable": true
+                            },
+                            "handle": "parent"
+                        }
+                    ],
+                    "__count": 0
+                }
+            ]
+        }
+    },
+    "title": "Pretend term"
+}

--- a/tests/Data/Fields/__fixtures__/fieldset.json
+++ b/tests/Data/Fields/__fixtures__/fieldset.json
@@ -1,0 +1,71 @@
+{
+    "title": "Testing",
+    "fields": [
+        {
+            "field": {
+                "type": "select",
+                "display": "Select Field",
+                "options": {
+                    "one": "One",
+                    "two": "Two"
+                },
+                "localizable": false
+            },
+            "handle": "select_field"
+        },
+        {
+            "field": {
+                "sets": {
+                    "new_set_group": {
+                        "sets": {
+                            "new_set": {
+                                "fields": [
+                                    {
+                                        "field": {
+                                            "type": "select",
+                                            "display": "Select Field",
+                                            "options": {
+                                                "one": "One",
+                                                "two": "Two"
+                                            },
+                                            "localizable": false
+                                        },
+                                        "handle": "select_field"
+                                    }
+                                ],
+                                "display": "New Set"
+                            }
+                        },
+                        "display": "New Set Group"
+                    }
+                },
+                "type": "replicator",
+                "display": "Replicator Field",
+                "localizable": false
+            },
+            "handle": "replicator_field"
+        },
+        {
+            "field": {
+                "type": "grid",
+                "fields": [
+                    {
+                        "field": {
+                            "type": "select",
+                            "display": "Select Field",
+                            "options": {
+                                "one": "One",
+                                "two": "Two"
+                            },
+                            "localizable": false
+                        },
+                        "handle": "select_field"
+                    }
+                ],
+                "display": "Grid Field",
+                "localizable": false
+            },
+            "handle": "grid_field"
+        }
+    ]
+}


### PR DESCRIPTION
This PR updates the logic when saving blueprints and fieldsets to ensure that the order of select field options is preserved. Currently we rely on the underlying database engine to preserve the order which is unreliable.

- [x] Blueprints
- [x] Fieldsets

Closes https://github.com/statamic/eloquent-driver/issues/312