### PR TITLE
Store sites in eloquent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "^5.14"
+        "statamic/cms": "^5.16"
     },
     "require-dev": {
         "doctrine/dbal": "^3.8",

--- a/config/eloquent-driver.php
+++ b/config/eloquent-driver.php
@@ -97,4 +97,9 @@ return [
         'driver' => 'file',
         'model' => \Statamic\Eloquent\Tokens\TokenModel::class,
     ],
+
+    'sites' => [
+        'driver' => 'file',
+        'model' => \Statamic\Eloquent\Sites\SiteModel::class,
+    ],
 ];

--- a/database/migrations/2024_07_16_100000_create_sites_table.php
+++ b/database/migrations/2024_07_16_100000_create_sites_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create($this->prefix('sites'), function (Blueprint $table) {
+            $table->id();
+            $table->string('handle')->unique();
+            $table->string('url');
+            $table->string('locale');
+            $table->string('lang');
+            $table->jsonb('attributes');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix('sites'));
+    }
+};

--- a/database/migrations/2024_07_16_100000_create_sites_table.php
+++ b/database/migrations/2024_07_16_100000_create_sites_table.php
@@ -11,6 +11,7 @@ return new class extends Migration
         Schema::create($this->prefix('sites'), function (Blueprint $table) {
             $table->id();
             $table->string('handle')->unique();
+            $table->string('name');
             $table->string('url');
             $table->string('locale');
             $table->string('lang');

--- a/src/Commands/ExportSites.php
+++ b/src/Commands/ExportSites.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Statamic\Eloquent\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Eloquent\Sites\SiteModel;
+use Statamic\Sites\Sites;
+
+class ExportSites extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:eloquent:export-sites';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Exports eloquent sites to flat files.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $sites = SiteModel::all()
+            ->mapWithKeys(function ($model) {
+                return [
+                    $model->handle => [
+                        'name' => $model->name,
+                        'lang' => $model->lang,
+                        'locale' => $model->locale,
+                        'url' => $model->url,
+                        'attributes' => $model->attributes ?? [],
+                    ],
+                ];
+            });
+
+        (new Sites)->setSites($sites)->save();
+
+        $this->newLine();
+        $this->info('Sites exported');
+
+        return 0;
+    }
+}

--- a/src/Commands/ImportSites.php
+++ b/src/Commands/ImportSites.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\Eloquent\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use Statamic\Console\RunsInPlease;
+use Statamic\Eloquent\Sites\Sites as EloquentSites;
+use Statamic\Sites\Sites;
+
+
+class ImportSites extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:eloquent:import-sites';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Imports file-based sites into the database.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $sites = (new Sites)->getConfig();
+
+        (new EloquentSites)->setSites($sites)->save();
+
+        $this->components->info('Sites imported successfully.');
+    }
+}

--- a/src/Commands/ImportSites.php
+++ b/src/Commands/ImportSites.php
@@ -3,12 +3,9 @@
 namespace Statamic\Eloquent\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\File;
 use Statamic\Console\RunsInPlease;
 use Statamic\Eloquent\Sites\Sites as EloquentSites;
 use Statamic\Sites\Sites;
-
 
 class ImportSites extends Command
 {

--- a/src/Commands/ImportSites.php
+++ b/src/Commands/ImportSites.php
@@ -30,10 +30,12 @@ class ImportSites extends Command
      */
     public function handle(): int
     {
-        $sites = (new Sites)->getConfig();
+        $sites = (new Sites)->config();
 
         (new EloquentSites)->setSites($sites)->save();
 
         $this->components->info('Sites imported successfully.');
+
+        return 0;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -83,6 +83,7 @@ class ServiceProvider extends AddonServiceProvider
             Commands\ExportNavs::class,
             Commands\ExportRevisions::class,
             Commands\ExportTaxonomies::class,
+            Commands\ExportSites::class,
             Commands\ImportAssets::class,
             Commands\ImportBlueprints::class,
             Commands\ImportCollections::class,
@@ -92,6 +93,7 @@ class ServiceProvider extends AddonServiceProvider
             Commands\ImportNavs::class,
             Commands\ImportRevisions::class,
             Commands\ImportTaxonomies::class,
+            Commands\ImportSites::class,
             Commands\SyncAssets::class,
         ]);
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -534,8 +534,6 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         $this->app->singleton(\Statamic\Sites\Sites::class, \Statamic\Eloquent\Sites\Sites::class);
-
-        Statamic::repository(TokenRepositoryContract::class, TokenRepository::class);
     }
 
     protected function addAboutCommandInfo()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -161,6 +161,10 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../database/migrations/2024_03_07_100000_create_tokens_table.php' => database_path('migrations/2024_03_07_100000_create_tokens_table.php'),
         ], 'statamic-eloquent-token-migrations');
 
+        $this->publishes($siteMigrations = [
+            __DIR__.'/../database/migrations/2024_07_16_100000_create_sites_table.php' => database_path('migrations/2024_07_16_100000_create_sites_table.php'),
+        ], 'statamic-eloquent-site-migrations');
+
         $this->publishes(
             array_merge(
                 $taxonomyMigrations,
@@ -177,7 +181,8 @@ class ServiceProvider extends AddonServiceProvider
                 $assetContainerMigrations,
                 $assetMigrations,
                 $revisionMigrations,
-                $tokenMigrations
+                $tokenMigrations,
+                $siteMigrations,
             ),
             'migrations'
         );
@@ -210,6 +215,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerTaxonomies();
         $this->registerTerms();
         $this->registerTokens();
+        $this->registerSites();
     }
 
     private function registerAssetContainers()
@@ -517,6 +523,21 @@ class ServiceProvider extends AddonServiceProvider
         Statamic::repository(TokenRepositoryContract::class, TokenRepository::class);
     }
 
+    public function registerSites()
+    {
+        if (config('statamic.eloquent-driver.sites.driver', 'file') != 'eloquent') {
+            return;
+        }
+
+        $this->app->bind('statamic.eloquent.sites.model', function () {
+            return config('statamic.eloquent-driver.sites.model');
+        });
+
+        $this->app->singleton(\Statamic\Sites\Sites::class, \Statamic\Eloquent\Sites\Sites::class);
+
+        Statamic::repository(TokenRepositoryContract::class, TokenRepository::class);
+    }
+
     protected function addAboutCommandInfo()
     {
         if (! class_exists(AboutCommand::class)) {
@@ -539,6 +560,7 @@ class ServiceProvider extends AddonServiceProvider
             'Taxonomies' => config('statamic.eloquent-driver.taxonomies.driver', 'file'),
             'Terms' => config('statamic.eloquent-driver.terms.driver', 'file'),
             'Tokens' => config('statamic.eloquent-driver.tokens.driver', 'file'),
+            'Sites' => config('statamic.eloquent-driver.sites.driver', 'file'),
         ])->map(fn ($value) => $this->applyAboutCommandFormatting($value))->all());
     }
 

--- a/src/Sites/SiteModel.php
+++ b/src/Sites/SiteModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Eloquent\Sites;
+
+use Illuminate\Support\Arr;
+use Statamic\Eloquent\Database\BaseModel;
+
+class SiteModel extends BaseModel
+{
+    protected $guarded = [];
+
+    protected $table = 'sites';
+
+    protected $casts = [
+        'attributes' => 'json',
+    ];
+
+    public function getAttribute($key)
+    {
+        return Arr::get($this->getAttributeValue('attributes'), $key, parent::getAttribute($key));
+    }
+}

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -6,7 +6,7 @@ class Sites extends \Statamic\Sites\Sites
 {
     protected function getSavedSites()
     {
-        $sites = SiteModel::all();
+        $sites = app('statamic.eloquent.sites.model')::all();
 
         return $sites->isEmpty() ? $this->getDefaultSite() : $sites->mapWithKeys(function ($model) {
             return [
@@ -24,7 +24,7 @@ class Sites extends \Statamic\Sites\Sites
     protected function saveToStore()
     {
         foreach ($this->config() as $handle => $config) {
-            SiteModel::firstOrNew(['handle' => $handle])
+            app('statamic.eloquent.sites.model')::firstOrNew(['handle' => $handle])
                 ->fill([
                     'name' => $config['name'] ?? '',
                     'lang' => $config['lang'] ?? '',
@@ -35,6 +35,6 @@ class Sites extends \Statamic\Sites\Sites
                 ->save();
         }
 
-        SiteModel::whereNotIn('handle', array_keys($this->config()))->get()->each->delete();
+        app('statamic.eloquent.sites.model')::whereNotIn('handle', array_keys($this->config()))->get()->each->delete();
     }
 }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Statamic\Eloquent\Sites;
+
+class Sites extends \Statamic\Sites\Sites
+{
+    protected function getSavedSites()
+    {
+        $sites = SiteModel::all();
+
+        return $sites->isEmpty() ? $this->getDefaultSite() : $sites->mapWithKeys(function ($model) {
+            return [
+                $model->handle => [
+                    'name' => $model->name,
+                    'lang' => $model->lang,
+                    'locale' => $model->locale,
+                    'url' => $model->url,
+                    'attributes' => $model->attributes ?? [],
+                ],
+            ];
+        });
+    }
+
+    protected function saveToStore()
+    {
+        foreach ($this->config() as $handle => $config) {
+            SiteModel::firstOrNew(['handle' => $handle])
+                ->fill([
+                    'name' => $config['name'] ?? '',
+                    'lang' => $config['lang'] ?? '',
+                    'locale' => $config['locale'] ?? '',
+                    'url' => $config['url'] ?? '',
+                    'attributes' => $config['attributes'] ?? [],
+                ])
+                ->save();
+        }
+
+        SiteModel::whereNotIn('handle', array_keys($this->config()))->get()->each->delete();
+    }
+}

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -8,7 +8,7 @@ class Sites extends \Statamic\Sites\Sites
     {
         $sites = app('statamic.eloquent.sites.model')::all();
 
-        return $sites->isEmpty() ? $this->getDefaultSite() : $sites->mapWithKeys(function ($model) {
+        return $sites->isEmpty() ? $this->getFallbackConfig() : $sites->mapWithKeys(function ($model) {
             return [
                 $model->handle => [
                     'name' => $model->name,

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -32,6 +32,8 @@ class ImportSitesTest extends TestCase
             'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
         ]);
 
+        \Statamic\Facades\Site::save();
+
         $this->artisan('statamic:eloquent:import-sites')
             ->expectsOutputToContain('Sites imported successfully.')
             ->assertExitCode(0);

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -2,6 +2,7 @@
 
 namespace Commands;
 
+use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Sites\SiteModel;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -10,6 +11,22 @@ use Tests\TestCase;
 class ImportSitesTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->bind('statamic.eloquent.sites.model', function () {
+            return SiteModel::class;
+        });
+
+        $this->app->singleton(
+            'Statamic\Sites\Sites',
+            'Statamic\Eloquent\Sites\Sites'
+        );
+
+        Facade::clearResolvedInstance(\Statamic\Sites\Sites::class);
+    }
 
     #[Test]
     public function it_imports_sites()
@@ -20,11 +37,26 @@ class ImportSitesTest extends TestCase
             ->expectsOutputToContain('Sites imported successfully.')
             ->assertExitCode(0);
 
-        $this->assertCount(1, SiteModel::all());
+        $this->assertCount(4, SiteModel::all());
 
         $this->assertDatabaseHas('sites', [
             'handle' => 'en',
             'name' => 'English',
+        ]);
+
+        $this->assertDatabaseHas('sites', [
+            'handle' => 'fr',
+            'name' => 'French',
+        ]);
+
+        $this->assertDatabaseHas('sites', [
+            'handle' => 'de',
+            'name' => 'German',
+        ]);
+
+        $this->assertDatabaseHas('sites', [
+            'handle' => 'es',
+            'name' => 'Spanish',
         ]);
     }
 }

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -3,6 +3,7 @@
 namespace Commands;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Sites\SiteModel;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Commands;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Revisions\Revision as RevisionContract;
+use Statamic\Contracts\Revisions\RevisionRepository as RevisionRepositoryContract;
+use Statamic\Eloquent\Revisions\RevisionModel;
+use Statamic\Facades\Revision;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ImportSitesTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_imports_sites()
+    {
+        $this->assertCount(0, SiteModel::all());
+
+        $this->artisan('statamic:eloquent:import-sites')
+            ->expectsOutputToContain('Sites imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, SiteModel::all());
+
+        $this->assertDatabaseHas('sites', [
+            'handle' => 'en',
+            'name' => 'English',
+        ]);
+    }
+}

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -25,6 +25,13 @@ class ImportSitesTest extends TestCase
     {
         $this->assertCount(0, SiteModel::all());
 
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
         $this->artisan('statamic:eloquent:import-sites')
             ->expectsOutputToContain('Sites imported successfully.')
             ->assertExitCode(0);

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -2,7 +2,6 @@
 
 namespace Commands;
 
-use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Sites\SiteModel;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -2,13 +2,7 @@
 
 namespace Commands;
 
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Contracts\Revisions\Revision as RevisionContract;
-use Statamic\Contracts\Revisions\RevisionRepository as RevisionRepositoryContract;
-use Statamic\Eloquent\Revisions\RevisionModel;
-use Statamic\Facades\Revision;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 

--- a/tests/Commands/ImportSitesTest.php
+++ b/tests/Commands/ImportSitesTest.php
@@ -19,13 +19,6 @@ class ImportSitesTest extends TestCase
         $this->app->bind('statamic.eloquent.sites.model', function () {
             return SiteModel::class;
         });
-
-        $this->app->singleton(
-            'Statamic\Sites\Sites',
-            'Statamic\Eloquent\Sites\Sites'
-        );
-
-        Facade::clearResolvedInstance(\Statamic\Sites\Sites::class);
     }
 
     #[Test]

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Sites;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Sites\SiteModel;
-use Statamic\Facades\Sites;
+use Statamic\Facades\Site;
 use Tests\TestCase;
 
 class SitesTest extends TestCase
@@ -24,12 +25,14 @@ class SitesTest extends TestCase
             'Statamic\Sites\Sites',
             'Statamic\Eloquent\Sites\Sites'
         );
+
+        Facade::clearResolvedInstance(\Statamic\Sites\Sites::class);
     }
 
     #[Test]
     public function it_saves_sites()
     {
-        $this->assertCount(0, Sites: all());
+        $this->assertCount(0, SiteModel::all());
 
         $this->setSites([
             'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
@@ -38,16 +41,16 @@ class SitesTest extends TestCase
             'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
         ]);
 
-        Sites::save();
+        Site::save();
 
-        $this->assertCount(4, Sites: all());
+        $this->assertCount(4, Site::all());
         $this->assertCount(4, SiteModel::all());
     }
 
     #[Test]
     public function it_deletes_sites()
     {
-        $this->assertCount(0, Sites: all());
+        $this->assertCount(0, SiteModel::all());
 
         $this->setSites([
             'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
@@ -56,7 +59,7 @@ class SitesTest extends TestCase
             'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
         ]);
 
-        Sites::save();
+        Site::save();
 
         $this->setSites([
             'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
@@ -64,7 +67,9 @@ class SitesTest extends TestCase
             'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
         ]);
 
-        $this->assertCount(3, Sites: all());
+        Site::save();
+
+        $this->assertCount(3, Site::all());
         $this->assertCount(3, SiteModel::all());
         $this->assertSame(['en', 'fr', 'es'], SiteModel::all()->pluck('handle')->all());
     }

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Sites;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Sites\SiteModel;
+use Statamic\Facades\Sites;
+use Tests\TestCase;
+
+class SitesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->bind('statamic.eloquent.sites.model', function () {
+            return SiteModel::class;
+        });
+
+        $this->app->singleton(
+            'Statamic\Sites\Sites',
+            'Statamic\Eloquent\Sites\Sites'
+        );
+    }
+
+    #[Test]
+    public function it_saves_sites()
+    {
+        $this->assertCount(0, Sites: all());
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
+        Sites::save();
+
+        $this->assertCount(4, Sites: all());
+        $this->assertCount(4, SiteModel::all());
+    }
+
+    #[Test]
+    public function it_deletes_sites()
+    {
+        $this->assertCount(0, Sites: all());
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
+        Sites::save();
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+        ]);
+
+        $this->assertCount(3, Sites: all());
+        $this->assertCount(3, SiteModel::all());
+        $this->assertSame(['en', 'fr', 'es'], SiteModel::all()->pluck('handle')->all());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ abstract class TestCase extends AddonTestCase
 
         collect(config('statamic.eloquent-driver'))
             ->filter(fn ($config) => isset($config['driver']))
+            ->reject(fn ($config, $key) => $key === 'sites')
             ->each(fn ($config, $key) => $app['config']->set("statamic.eloquent-driver.{$key}.driver", 'eloquent'));
     }
 


### PR DESCRIPTION
This PR adds the ability to store sites in Eloquent rather than YAML on the filesystem.

Tasks:
- [x] Get storage up and running
- [x] Wait for https://github.com/statamic/cms/pull/10461 to merge
- [x] Write importer and exporter

Closes https://github.com/statamic/eloquent-driver/issues/320