### PR TITLE
Fix migration errors on form_submissions

### DIFF
--- a/database/migrations/updates/relate_form_submissions_by_handle.php.stub
+++ b/database/migrations/updates/relate_form_submissions_by_handle.php.stub
@@ -9,6 +9,10 @@ use Statamic\Eloquent\Forms\SubmissionModel;
 return new class extends Migration {
     public function up()
     {
+        if (Schema::hasColumn($this->prefix('form_submissions'), 'form')) {
+            return;
+        }
+
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->string('form', 30)->nullable()->index()->after('id');
         });
@@ -24,7 +28,10 @@ return new class extends Migration {
             });
 
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            $table->dropForeign(['form_id']);
+            if (in_array($this->prefix('form_submissions').'_form_id_foreign', $this->listTableForeignKeys($this->prefix('form_submissions')))) {
+                $table->dropForeign(['form_id']);
+            }
+
             $table->dropColumn('form_id');
         });
     }
@@ -48,5 +55,14 @@ return new class extends Migration {
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->dropColumn('form');
         });
+    }
+
+    private function listTableForeignKeys($table)
+    {
+        $conn = Schema::getConnection()->getDoctrineSchemaManager();
+
+        return array_map(function($key) {
+    		return $key->getName();
+        }, $conn->listTableForeignKeys($table));
     }
 };

--- a/database/migrations/updates/relate_form_submissions_by_handle.php.stub
+++ b/database/migrations/updates/relate_form_submissions_by_handle.php.stub
@@ -28,9 +28,11 @@ return new class extends Migration {
             });
 
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            if (in_array($this->prefix('form_submissions').'_form_id_foreign', $this->listTableForeignKeys($this->prefix('form_submissions')))) {
-                $table->dropForeign(['form_id']);
-            }
+            collect(Schema::getForeignKeys($this->prefix('form_submissions')))->each(function ($fk) use ($table) {
+                if (count($fk['columns']) == 1 && in_array('form_id', $fk['columns'])) {
+                    $table->dropForeign(['form_id']);
+                }
+            });
 
             $table->dropColumn('form_id');
         });
@@ -55,14 +57,5 @@ return new class extends Migration {
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->dropColumn('form');
         });
-    }
-
-    private function listTableForeignKeys($table)
-    {
-        $conn = Schema::getConnection()->getDoctrineSchemaManager();
-
-        return array_map(function($key) {
-    		return $key->getName();
-        }, $conn->listTableForeignKeys($table));
     }
 };


### PR DESCRIPTION
This PR updates the form_submissions update migration to check it needs to be run. It also ensures we only drop the foreign key if it exists.

Closes: https://github.com/statamic/eloquent-driver/issues/323
Fixes: https://github.com/statamic/eloquent-driver/pull/285#issuecomment-2230351766
