### PR TITLE
Support canSelectAcrossSites on navs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "^5.16"
+        "statamic/cms": "^5.17"
     },
     "require-dev": {
         "doctrine/dbal": "^3.8",

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -18,6 +18,7 @@ class Nav extends FileEntry
             ->collections($model->settings['collections'] ?? null)
             ->maxDepth($model->settings['max_depth'] ?? null)
             ->expectsRoot($model->settings['expects_root'] ?? false)
+            ->canSelectAcrossSites($model->settings['select_across_sites'] ?? null)
             ->model($model);
     }
 
@@ -39,6 +40,7 @@ class Nav extends FileEntry
             'title'    => $source->title(),
             'settings' => [
                 'collections'  => $source->collections()->map->handle(),
+                'select_across_sites' => $source->canSelectAcrossSites(),
                 'max_depth'    => $source->maxDepth(),
                 'expects_root' => $source->expectsRoot(),
             ],


### PR DESCRIPTION
PR 9229 on statamic/cms will introduce canSelectAcrossSites() to Nav's, this PR enables support for storing it.

Related: https://github.com/statamic/cms/pull/9229