### PR TITLE
Drop indexes before dropping the column

### DIFF
--- a/database/migrations/updates/relate_form_submissions_by_handle.php.stub
+++ b/database/migrations/updates/relate_form_submissions_by_handle.php.stub
@@ -34,6 +34,7 @@ return new class extends Migration {
                 }
             });
 
+            $table->dropUnique(['form_id', 'created_at']);
             $table->dropColumn('form_id');
         });
     }

--- a/database/migrations/updates/update_assets_table.php.stub
+++ b/database/migrations/updates/update_assets_table.php.stub
@@ -40,6 +40,7 @@ return new class extends Migration {
             });
 
         Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->dropIndex(['handle']);
             $table->dropColumn('handle');
         });
     }


### PR DESCRIPTION
SQLite requires deleting the indexes before deleting the column. Relates to this: https://github.com/laravel/framework/pull/51373