### PR TITLE
Only retrieve forms once instead of for every item

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Forms\Form as Contract;
 use Statamic\Events\FormDeleted;
 use Statamic\Events\FormSaved;
+use Statamic\Facades\Blink;
 use Statamic\Forms\Form as FileEntry;
 
 class Form extends FileEntry
@@ -60,6 +61,9 @@ class Form extends FileEntry
 
         $this->model($model->fresh());
 
+        Blink::forget("eloquent-forms-{$this->handle()}");
+        Blink::forget('eloquent-forms');
+
         FormSaved::dispatch($this);
     }
 
@@ -67,6 +71,9 @@ class Form extends FileEntry
     {
         $this->submissions()->each->delete();
         $this->model()->delete();
+
+        Blink::forget("eloquent-forms-{$this->handle()}");
+        Blink::forget('eloquent-forms');
 
         FormDeleted::dispatch($this);
     }

--- a/src/Forms/SubmissionQueryBuilder.php
+++ b/src/Forms/SubmissionQueryBuilder.php
@@ -34,17 +34,9 @@ class SubmissionQueryBuilder extends EloquentQueryBuilder implements BuilderCont
 
     protected function transform($items, $columns = [])
     {
-        $forms = Form::all()->keyBy->handle();
-
-        return $items->map(function ($model) use ($forms) {
-            $submission = Submission::fromModel($model);
-
-            $form = $forms[$model->form] ?? null;
-            if ($form) {
-                $submission->form($form);
-            }
-
-            return $submission;
+        return $items->map(function ($model) {
+            return Submission::fromModel($model)
+                ->form(Form::find($model->form));
         });
     }
 

--- a/src/Forms/SubmissionQueryBuilder.php
+++ b/src/Forms/SubmissionQueryBuilder.php
@@ -34,9 +34,17 @@ class SubmissionQueryBuilder extends EloquentQueryBuilder implements BuilderCont
 
     protected function transform($items, $columns = [])
     {
-        return $items->map(function ($model) {
-            return Submission::fromModel($model)
-                ->form(Form::find($model->form));
+        $forms = Form::all()->keyBy->handle();
+
+        return $items->map(function ($model) use ($forms) {
+            $submission = Submission::fromModel($model);
+
+            $form = $forms[$model->form] ?? null;
+            if ($form) {
+                $submission->form($form);
+            }
+
+            return $submission;
         });
     }
 

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Forms;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades;
+use Tests\TestCase;
+
+class FormTest extends TestCase
+{
+    #[Test]
+    public function finding_a_form_sets_the_blink_cache()
+    {
+        Facades\Form::make('test')->title('Test form')->save();
+
+        $form = Facades\Form::find('test');
+
+        $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
+    }
+
+    #[Test]
+    public function getting_all_forms_sets_the_blink_cache()
+    {
+        $form = tap(Facades\Form::make('test')->title('Test form'))->save();
+
+        Facades\Form::all();
+
+        $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
+        $this->assertSame($form->handle(), Facades\Blink::get('eloquent-forms')->first()->handle());
+    }
+
+    #[Test]
+    public function saving_a_form_removes_the_blink_cache()
+    {
+        Facades\Form::make('test')->title('Test form')->save();
+
+        $form = Facades\Form::find('test');
+        Facades\Form::all(); // to set up eloquent-forms blink
+
+        $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
+        $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
+
+        $form->save();
+
+        $this->assertNull(Facades\Blink::get('eloquent-forms-test'));
+        $this->assertNull(Facades\Blink::get('eloquent-forms'));
+    }
+
+    #[Test]
+    public function deleting_a_form_removes_the_blink_cache()
+    {
+        Facades\Form::make('test')->title('Test form')->save();
+
+        $form = Facades\Form::find('test');
+        Facades\Form::all(); // to set up eloquent-forms blink
+
+        $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
+        $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
+
+        $form->delete();
+
+        $this->assertNull(Facades\Blink::get('eloquent-forms-test'));
+        $this->assertNull(Facades\Blink::get('eloquent-forms'));
+    }
+}


### PR DESCRIPTION
Hello everyone!

We stumbled upon a bug on `/admin/forms`. We would get endless loading screens and eventually timeouts when visiting this page. We have quiet an amount of form submissions (~150.000), and the query builder in the current setup retrieves all submissions, with the form for every one of them.

We're using Statamic 5 with this package, and even though we were able to fix this in the `FormsController` of the `statamic/cms` package (see https://github.com/statamic/cms/pull/10534), we figured this could still cause problems for other scenarios outside of the `FormsController`. So we wanted to propose it.

The proposed changes retrieve all forms only once before being connected to each submission, instead of retrieving the form every time. This drastically decreases the amount of queries being executed, and it fixes the timeout issues we were dealing with.

If you have any questions or comments about this, let me know!