### PR TITLE
Fall back to boolean instead of null

### DIFF
--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -18,7 +18,7 @@ class Nav extends FileEntry
             ->collections($model->settings['collections'] ?? null)
             ->maxDepth($model->settings['max_depth'] ?? null)
             ->expectsRoot($model->settings['expects_root'] ?? false)
-            ->canSelectAcrossSites($model->settings['select_across_sites'] ?? null)
+            ->canSelectAcrossSites($model->settings['select_across_sites'] ?? false)
             ->model($model);
     }
 


### PR DESCRIPTION
Hi!

This change fixes the following error we receive when navigating to the CP /navigation/<nav_name>:

```
Statamic\Support\Str::bool(): Argument #1 ($value) must be of type bool, null given, called in /<redacted>/storage/framework/views/f7f7a695478ceb1af2141e5f7389a1b0.php on line 21 (View: /<redacted>/vendor/statamic/cms/resources/views/navigation/show.blade.php)
```

This started happening after updating Composer dependencies, limited to patch and minor versions. The change in this PR is a possible fix, but that depends on if the default is considered `false`. Otherwise another option could be:

```diff
// vendor/statamic/cms/src/Structures/Nav.php

public function canSelectAcrossSites($canSelect = null)
{
    return $this
        ->fluentlyGetOrSet('canSelectAcrossSites')
+        ->setter(function ($canSelect) {
+            return (bool) $canSelect;
+        })
        ->args(func_get_args());
}
```

Let me know what you think!