### PR TITLE
Empty namespace should default to file when namespaces is not `all`

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -225,13 +225,13 @@ class BlueprintRepository extends StacheRepository
 
     private function isEloquentDrivenNamespace(?string $namespace)
     {
-        if (! $namespace) {
-            return true;
-        }
-
         $eloquentNamespaces = config('statamic.eloquent-driver.blueprints.namespaces', 'all');
 
         if ($eloquentNamespaces !== 'all') {
+            if (! $namespace) {
+                return false;
+            }
+
             if (! in_array($namespace, Arr::wrap($eloquentNamespaces))) {
                 return false;
             }


### PR DESCRIPTION
This PR updates the logic of where the default blueprint namespace is stored to take into account whether eloquent is being used for all blueprints or not.