### PR TITLE
Store form data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "^5.17"
+        "statamic/cms": "^5.18"
     },
     "require-dev": {
         "doctrine/dbal": "^3.8",

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -21,6 +21,7 @@ class Form extends FileEntry
             ->store($model->settings['store'] ?? null)
             ->email($model->settings['email'] ?? null)
             ->honeypot($model->settings['honeypot'] ?? null)
+            ->data($model->settings['data'] ?? [])
             ->model($model);
     }
 
@@ -39,6 +40,7 @@ class Form extends FileEntry
                 'store'    => $source->store(),
                 'email'    => $source->email(),
                 'honeypot' => $source->honeypot(),
+                'data' => $source->data(),
             ],
         ]);
     }

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -4,6 +4,7 @@ namespace Tests\Forms;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades;
+use Statamic\Support\Arr;
 use Tests\TestCase;
 
 class FormTest extends TestCase
@@ -61,5 +62,13 @@ class FormTest extends TestCase
 
         $this->assertNull(Facades\Blink::get('eloquent-forms-test'));
         $this->assertNull(Facades\Blink::get('eloquent-forms'));
+    }
+
+    #[Test]
+    public function it_stores_form_data()
+    {
+        $form = tap(Facades\Form::make('test')->title('Test form')->data(['some' => 'data']))->save();
+
+        $this->assertSame(['some' => 'data'], Arr::get($form->model(), 'settings.data'));
     }
 }


### PR DESCRIPTION
This PR adds support for storing form data from extra config which was added to core in https://github.com/statamic/cms/pull/8491

Closes https://github.com/statamic/eloquent-driver/issues/341