### PR TITLE
Attempt to make term <> collection query more performant

### DIFF
--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -223,6 +223,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                         }
 
                         return TermModel::where('taxonomy', $taxonomy)
+                            ->select('slug')
                             ->get()
                             ->map(function ($term) use ($taxonomy) {
                                 return Entry::query()
@@ -232,7 +233,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             })
                             ->filter()
                             ->values();
-
                     });
 
                     if ($terms->isNotEmpty()) {

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Facades\Blink;


### PR DESCRIPTION
This PR updates the collection checking clause in the TermQueryBuilder to be more performant.

Previously we were looping over all entries to get their terms, and when the number of entries increases this became an issue. Now, we loop over the terms and check if an entry has that term, and if so we query for it, otherwise we don't.

The hope is that most users will have less terms than entries. 

Ideally we'd have a pivot table of some sort but that would require significant changes in core.