### PR TITLE
`export-sites` command: Prevent `lang` and `attributes` being exported with empty values

### DIFF
--- a/src/Commands/ExportSites.php
+++ b/src/Commands/ExportSites.php
@@ -34,14 +34,16 @@ class ExportSites extends Command
     {
         $sites = SiteModel::all()
             ->mapWithKeys(function ($model) {
+                $config = [
+                    'name' => $model->name,
+                    'lang' => $model->lang ?? null,
+                    'locale' => $model->locale,
+                    'url' => $model->url,
+                    'attributes' => $model->attributes ?? [],
+                ];
+
                 return [
-                    $model->handle => [
-                        'name' => $model->name,
-                        'lang' => $model->lang,
-                        'locale' => $model->locale,
-                        'url' => $model->url,
-                        'attributes' => $model->attributes ?? [],
-                    ],
+                    $model->handle => collect($config)->filter()->all()
                 ];
             });
 

--- a/src/Commands/ExportSites.php
+++ b/src/Commands/ExportSites.php
@@ -41,7 +41,7 @@ class ExportSites extends Command
                         'locale' => $model->locale,
                         'url' => $model->url,
                         'attributes' => $model->attributes ?? [],
-                    ])->filter()->all()
+                    ])->filter()->all(),
                 ];
             });
 

--- a/src/Commands/ExportSites.php
+++ b/src/Commands/ExportSites.php
@@ -34,16 +34,14 @@ class ExportSites extends Command
     {
         $sites = SiteModel::all()
             ->mapWithKeys(function ($model) {
-                $config = [
-                    'name' => $model->name,
-                    'lang' => $model->lang ?? null,
-                    'locale' => $model->locale,
-                    'url' => $model->url,
-                    'attributes' => $model->attributes ?? [],
-                ];
-
                 return [
-                    $model->handle => collect($config)->filter()->all()
+                    $model->handle => collect([
+                        'name' => $model->name,
+                        'lang' => $model->lang ?? null,
+                        'locale' => $model->locale,
+                        'url' => $model->url,
+                        'attributes' => $model->attributes ?? [],
+                    ])->filter()->all()
                 ];
             });
 

--- a/tests/Commands/ExportSitesTest.php
+++ b/tests/Commands/ExportSitesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Commands;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Sites\SiteModel;
+use Statamic\Sites\Sites;
+use Tests\TestCase;
+
+class ExportSitesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_exports_sites()
+    {
+        SiteModel::create(['handle' => 'en', 'name' => 'English', 'locale' => 'en_US', 'lang' => '', 'url' => 'http://test.com/', 'attributes' => []]);
+        SiteModel::create(['handle' => 'fr', 'name' => 'French', 'locale' => 'fr_FR', 'lang' => '', 'url' => 'http://fr.test.com/', 'attributes' => []]);
+        SiteModel::create(['handle' => 'es', 'name' => 'Spanish', 'locale' => 'es_ES', 'lang' => '', 'url' => 'http://test.com/es/', 'attributes' => []]);
+        SiteModel::create(['handle' => 'de', 'name' => 'German', 'locale' => 'de_DE', 'lang' => '', 'url' => 'http://test.com/de/', 'attributes' => []]);
+
+        $this->artisan('statamic:eloquent:export-sites')
+            ->expectsOutputToContain('Sites exported')
+            ->assertExitCode(0);
+
+        $this->assertEquals([
+            'en' => [
+                'name' => 'English',
+                'lang' => '',
+                'locale' => 'en_US',
+                'url' => 'http://test.com/',
+                'attributes' => [],
+            ],
+            'fr' => [
+                'name' => 'French',
+                'lang' => '',
+                'locale' => 'fr_FR',
+                'url' => 'http://fr.test.com/',
+                'attributes' => [],
+            ],
+            'es' => [
+                'name' => 'Spanish',
+                'lang' => '',
+                'locale' => 'es_ES',
+                'url' => 'http://test.com/es/',
+                'attributes' => [],
+            ],
+            'de' => [
+                'name' => 'German',
+                'lang' => '',
+                'locale' => 'de_DE',
+                'url' => 'http://test.com/de/',
+                'attributes' => [],
+            ],
+        ], (new Sites)->config());
+    }
+}

--- a/tests/Commands/ExportSitesTest.php
+++ b/tests/Commands/ExportSitesTest.php
@@ -17,8 +17,8 @@ class ExportSitesTest extends TestCase
     {
         SiteModel::create(['handle' => 'en', 'name' => 'English', 'locale' => 'en_US', 'lang' => '', 'url' => 'http://test.com/', 'attributes' => []]);
         SiteModel::create(['handle' => 'fr', 'name' => 'French', 'locale' => 'fr_FR', 'lang' => '', 'url' => 'http://fr.test.com/', 'attributes' => []]);
-        SiteModel::create(['handle' => 'es', 'name' => 'Spanish', 'locale' => 'es_ES', 'lang' => '', 'url' => 'http://test.com/es/', 'attributes' => []]);
-        SiteModel::create(['handle' => 'de', 'name' => 'German', 'locale' => 'de_DE', 'lang' => '', 'url' => 'http://test.com/de/', 'attributes' => []]);
+        SiteModel::create(['handle' => 'es', 'name' => 'Spanish', 'locale' => 'es_ES', 'lang' => '', 'url' => 'http://test.com/es/', 'attributes' => ['foo' => 'bar']]);
+        SiteModel::create(['handle' => 'de', 'name' => 'German', 'locale' => 'de_DE', 'lang' => 'de', 'url' => 'http://test.com/de/', 'attributes' => []]);
 
         $this->artisan('statamic:eloquent:export-sites')
             ->expectsOutputToContain('Sites exported')
@@ -27,31 +27,25 @@ class ExportSitesTest extends TestCase
         $this->assertEquals([
             'en' => [
                 'name' => 'English',
-                'lang' => '',
                 'locale' => 'en_US',
                 'url' => 'http://test.com/',
-                'attributes' => [],
             ],
             'fr' => [
                 'name' => 'French',
-                'lang' => '',
                 'locale' => 'fr_FR',
                 'url' => 'http://fr.test.com/',
-                'attributes' => [],
             ],
             'es' => [
                 'name' => 'Spanish',
-                'lang' => '',
                 'locale' => 'es_ES',
                 'url' => 'http://test.com/es/',
-                'attributes' => [],
+                'attributes' => ['foo' => 'bar'],
             ],
             'de' => [
                 'name' => 'German',
-                'lang' => '',
+                'lang' => 'de',
                 'locale' => 'de_DE',
                 'url' => 'http://test.com/de/',
-                'attributes' => [],
             ],
         ], (new Sites)->config());
     }


### PR DESCRIPTION
This pull request fixes an issue with the `php please eloquent:export-sites` command, where it would export `lang` as an empty string and leave `attribues` as an empty array.

Before this PR:

```yaml
en:
  name: 'The Getaway 1'
  lang: ''
  locale: en_US
  url: /
  attributes: {  }
de:
  name: 'Die Flucht 2'
  lang: ''
  locale: de_DE
  url: /de/
  attributes: {  }
fr:
  name: "L'Escapade 2"
  lang: ''
  locale: fr_FR
  url: /fr/
  attributes: {  }
```

After this PR:

```yaml
en:
  name: 'The Getaway'
  locale: en_US
  url: /
de:
  name: 'Die Flucht'
  locale: de_DE
  url: /de/
fr:
  name: "L'Escapade"
  locale: fr_FR
  url: /fr/
```

This PR also adds an `ExportSitesTest` to cover the export sites command.