### PR TITLE
The root folder is / and not empty otherwise it's skipped

### DIFF
--- a/src/Commands/SyncAssets.php
+++ b/src/Commands/SyncAssets.php
@@ -46,7 +46,7 @@ class SyncAssets extends Command
         $this->processFolder($container);
     }
 
-    private function processFolder(AssetContainer $container, $folder = '')
+    private function processFolder(AssetContainer $container, $folder = '/')
     {
         $this->line("Processing folder: {$folder}");
 


### PR DESCRIPTION
The root folder of the container is listed as `/` in the database. Since the default was an empty string the default folder was never synced. For us this resulted in a big list of assets in assets meta that were no longer present on disk causing false 404's on pages.

This PR sets folder to `/` by default so the root folder (of the container) is also synced.