### PR TITLE
Ensure asset container contents folder check finishes with /

### DIFF
--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -71,7 +71,7 @@ class AssetContainerContents extends CoreAssetContainerContents
 
         return $this->directories()
             ->filter(function ($dir) use ($folder) {
-                if ($folder && ! Str::startsWith($dir['path'], $folder)) {
+                if ($folder && ! Str::startsWith($dir['path'], Str::finish($folder, '/'))) {
                     return false;
                 }
 

--- a/tests/Assets/AssetContainerContentsTest.php
+++ b/tests/Assets/AssetContainerContentsTest.php
@@ -86,7 +86,7 @@ class AssetContainerContentsTest extends TestCase
     }
 
     #[Test]
-    public function it_doesnt_nest_folders_with_the_same_name()
+    public function it_doesnt_nest_folders_that_start_with_the_same_name()
     {
         $container = tap(AssetContainer::make('test')->disk('test'))->save();
         $container->makeAsset('one/file.txt')->upload(UploadedFile::fake()->create('one.txt'));

--- a/tests/Assets/AssetContainerContentsTest.php
+++ b/tests/Assets/AssetContainerContentsTest.php
@@ -84,4 +84,18 @@ class AssetContainerContentsTest extends TestCase
 
         $this->assertCount(3, $container->contents()->filteredDirectoriesIn('', true));
     }
+
+    #[Test]
+    public function it_doesnt_nest_folders_with_the_same_name()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $container->makeAsset('one/file.txt')->upload(UploadedFile::fake()->create('one.txt'));
+        $container->makeAsset('one-two/file.txt')->upload(UploadedFile::fake()->create('one.txt'));
+        $container->makeAsset('one/two/file.txt')->upload(UploadedFile::fake()->create('one.txt'));
+
+        $filtered = $container->contents()->filteredDirectoriesIn('one/', true);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($filtered->keys()->all(), ['one/two']);
+    }
 }


### PR DESCRIPTION
This PR updates the asset container contents folder filtering to ensure the folder finishes with /, which resolves any issues with folders starting with the same string.

Closes #355 