### PR TITLE
Prevent freezing of ImportAssets for asset meta data when importing a large number of files

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -137,6 +137,6 @@ class AssetContainer extends FileEntry
         return $this->queryAssets()
             ->when($recursive, fn ($query) => $query->where('folder', $folder), fn ($query) => $query->where('folder', 'like', Str::replaceEnd('/', '', $folder).'/%'))
             ->get()
-            ->pluck('path');
+            ->transform(fn ($value) => $value->path());
     }
 }

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -136,7 +136,7 @@ class AssetContainer extends FileEntry
 
         return $this->queryAssets()
             ->when($recursive, fn ($query) => $query->where('folder', $folder), fn ($query) => $query->where('folder', 'like', Str::replaceEnd('/', '', $folder).'/%'))
-            ->get()
-            ->transform(fn ($value) => $value->path());
+            ->lazy()
+            ->map(fn ($value) => $value->path());
     }
 }

--- a/tests/Commands/ImportAssetsTest.php
+++ b/tests/Commands/ImportAssetsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Commands;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
@@ -44,6 +45,21 @@ class ImportAssetsTest extends TestCase
         app('files')->deleteDirectory(__DIR__.'/tmp');
 
         parent::tearDown();
+    }
+
+    #[Test]
+    public function it_gets_all_meta_files_by_default()
+    {
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        Storage::disk('test')->put('.meta/a.txt.yaml',
+            "data:
+                    title: 'File A'
+                    size: 123
+                    last_modified: 0000000000"
+        );
+        $this->assertEquals([
+            '.meta/a.txt.yaml',
+        ], $container->metaFiles()->all());
     }
 
     #[Test]


### PR DESCRIPTION
fixes https://github.com/statamic/eloquent-driver/issues/359