### PR TITLE
Fix entries export to use correct model, blueprint column, and set ID when exporting UUIDs

### DIFF
--- a/src/Commands/ExportEntries.php
+++ b/src/Commands/ExportEntries.php
@@ -10,7 +10,6 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
-use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Entries\Entry as StacheEntry;
 use Statamic\Facades\Entry;
 use Statamic\Stache\Repositories\CollectionRepository;

--- a/src/Commands/ExportEntries.php
+++ b/src/Commands/ExportEntries.php
@@ -83,7 +83,7 @@ class ExportEntries extends Command
                 ->slug($model->slug)
                 ->collection($model->collection)
                 ->data($model->data)
-                ->blueprint($model->data['blueprint'] ?? null)
+                ->blueprint($model->blueprint)
                 ->published($model->published);
 
             if (in_array(HasUuids::class, class_uses_recursive($model))) {

--- a/src/Commands/ExportEntries.php
+++ b/src/Commands/ExportEntries.php
@@ -4,6 +4,7 @@ namespace Statamic\Eloquent\Commands;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
@@ -63,7 +64,7 @@ class ExportEntries extends Command
 
     private function importEntries()
     {
-        $entries = EntryModel::all();
+        $entries = app('statamic.eloquent.entries.entry')::all();
 
         $entriesWithOrigin = $entries->filter(function ($model) {
             return (bool) $model->origin_id;
@@ -85,6 +86,10 @@ class ExportEntries extends Command
                 ->data($model->data)
                 ->blueprint($model->data['blueprint'] ?? null)
                 ->published($model->published);
+
+            if (in_array(HasUuids::class, class_uses_recursive($model))) {
+                $entry->id($model->getKey());
+            }
 
             if ($model->date && $entry->collection()->dated()) {
                 $entry->date($model->date);


### PR DESCRIPTION
This PR updates the export entries logic to use the model specified in the config, rather than forcing a numeric ID based model. This allows us to check if its a UUID model and if so also to export out IDs.

@lokmanm this is what I was meaning.

Closes https://github.com/statamic/eloquent-driver/issues/361