### PR TITLE
Fallback to locale or 'en' when site lang is not present

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Eloquent\Sites;
 
+use Statamic\Support\Str;
+
 class Sites extends \Statamic\Sites\Sites
 {
     protected function getSavedSites()
@@ -24,10 +26,12 @@ class Sites extends \Statamic\Sites\Sites
     protected function saveToStore()
     {
         foreach ($this->config() as $handle => $config) {
+            $lang = $config['lang'] ?? Str::before($config['locale'] ?? '', '_') ?? 'en';
+
             app('statamic.eloquent.sites.model')::firstOrNew(['handle' => $handle])
                 ->fill([
                     'name' => $config['name'] ?? '',
-                    'lang' => $config['lang'] ?? '',
+                    'lang' => $lang,
                     'locale' => $config['locale'] ?? '',
                     'url' => $config['url'] ?? '',
                     'attributes' => $config['attributes'] ?? [],


### PR DESCRIPTION
This PR ensures an empty site `lang` is not inserted to the database by falling back to the language in the locale, or `en` if no locale is present

Closes https://github.com/statamic/eloquent-driver/issues/371