### PR TITLE
Optimize taxonomy <> collection queries

### DIFF
--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -237,7 +237,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                         'mysql' => "json_quote({$wrappedColumn})",
                                         default => $wrappedColumn,
                                     };
-                                    
                                     $columnExpression = new Expression($column);
                                     $join->on("{$enrtiesTable}.collection", '=', "{$enrtiesTable}.collection")
                                         ->whereIn("{$enrtiesTable}.collection", $this->collections)

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -250,6 +250,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                 ->pluck('slug');
                         }
 
+                        dump("using map");
                         return TermModel::where('taxonomy', $taxonomy)
                             ->select('slug')
                             ->get()

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -245,7 +245,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                     $query->select(DB::raw(1))
                                         ->from($entriesTable)
                                         ->whereIn('collection', $this->collections)
-                                        ->whereJsonContains("data->{$taxonomy}", $value);
+                                        ->whereJsonContains(Entry::query()->column($taxonomy->handle()), $value);
                                 })
                                 ->pluck('slug');
                         }
@@ -256,7 +256,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             ->map(function ($term) use ($taxonomy) {
                                 return Entry::query()
                                     ->whereIn('collection', $this->collections)
-                                    ->whereJsonContains('data->'.$taxonomy, [$term->slug])
+                                    ->whereJsonContains($taxonomy->handle(), [$term->slug])
                                     ->count() > 0 ? $term->slug : null;
                             })
                             ->filter()

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -237,7 +237,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                         ->whereJsonContains("{$enrtiesTable}.data->{$taxonomy}", $columnExpression);
                                 })
                                 ->select('taxonomy_terms.slug')
-                                ->get();
+                                ->pluck('slug');
                         } else {
                             $query = TermModel::where('taxonomy', $taxonomy)
                                 ->select('slug')

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -224,7 +224,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             return [];
                         }
 
-                        // workaround to handle potential n+1 queries on the database site
+                        // workaround to handle potential n+1 queries in the database
                         // if/when Statamic core supports relationships in a meaningful way this should be removed
                         if (config('statamic.eloquent-driver.entries.driver', 'file') == 'eloquent') {
                             $entryClass = app('statamic.eloquent.entries.model');

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -250,7 +250,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                 ->pluck('slug');
                         }
 
-                        dump("using map");
                         return TermModel::where('taxonomy', $taxonomy)
                             ->select('slug')
                             ->get()

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -231,7 +231,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             $termsTable = (new TermModel)->getTable();
                             $query = TermModel::where('taxonomy', $taxonomy)
                                 ->join($enrtiesTable, function (JoinClause $join) use ($taxonomy, $enrtiesTable, $termsTable) {
-                                    // TODO: make Expression db driver independent
                                     $wrappedColumn = $join->getGrammar()->wrap("{$termsTable}.slug");
                                     $column = match (DB::getDriverName()) {
                                         'mysql' => "json_quote({$wrappedColumn})",

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -235,6 +235,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                     $wrappedColumn = $join->getGrammar()->wrap("{$termsTable}.slug");
                                     $column = match (DB::getDriverName()) {
                                         'mysql' => "json_quote({$wrappedColumn})",
+                                        'pgsql' => "to_jsonb({$wrappedColumn}::text)",
                                         default => $wrappedColumn,
                                     };
                                     $columnExpression = new Expression($column);

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -231,9 +231,10 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             $query = TermModel::where('taxonomy', $taxonomy)
                                 ->join($enrtiesTable, function (JoinClause $join) use ($taxonomy, $enrtiesTable, $termsTable) {
                                     // TODO: make Expression db driver independent
-                                    $columnExpression = new Expression("JSON_QUOTE({$termsTable}.slug)");
+                                    $wrappedColumn = $join->getGrammar()->wrap("{$termsTable}.slug");
+                                    $columnExpression = new Expression("json_quote({$wrappedColumn})");
                                     $join->on("{$enrtiesTable}.collection", '=', "{$enrtiesTable}.collection")
-                                        ->where("{$enrtiesTable}.collection", $this->collections)
+                                        ->whereIn("{$enrtiesTable}.collection", $this->collections)
                                         ->whereJsonContains("{$enrtiesTable}.data->{$taxonomy}", $columnExpression);
                                 })
                                 ->select('taxonomy_terms.slug')

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -249,16 +249,16 @@ class TermQueryBuilder extends EloquentQueryBuilder
                         }
 
                         return TermModel::where('taxonomy', $taxonomy)
-                                ->select('slug')
-                                ->get()
-                                ->map(function ($term) use ($taxonomy) {
-                                    return Entry::query()
-                                        ->whereIn('collection', $this->collections)
-                                        ->whereJsonContains('data->'.$taxonomy, [$term->slug])
-                                        ->count() > 0 ? $term->slug : null;
-                                })
-                                ->filter()
-                                ->values();
+                            ->select('slug')
+                            ->get()
+                            ->map(function ($term) use ($taxonomy) {
+                                return Entry::query()
+                                    ->whereIn('collection', $this->collections)
+                                    ->whereJsonContains('data->'.$taxonomy, [$term->slug])
+                                    ->count() > 0 ? $term->slug : null;
+                            })
+                            ->filter()
+                            ->values();
                     });
 
                     if ($terms->isNotEmpty()) {

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -2,12 +2,9 @@
 
 namespace Statamic\Eloquent\Taxonomies;
 
-use Illuminate\Database\Query\Expression;
-use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
-use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -229,12 +226,12 @@ class TermQueryBuilder extends EloquentQueryBuilder
                         // workaround to handle potential n+1 queries on the database site
                         // if/when Statamic core supports relationships in a meaningful way this should be removed
                         if (config('statamic.eloquent-driver.entries.driver', 'file') == 'eloquent') {
-                            $entriesTable = (new EntryModel)->getTable();
-                            $termsTable = (new TermModel)->getTable();
+                            $entriesTable = (new app('statamic.eloquent.entries.entry'))->getTable();
+                            $termsTable = (new app('statamic.eloquent.terms.model'))->getTable();
 
                             $query = TermModel::where('taxonomy', $taxonomy)
                                 ->whereExists(function ($query) use ($entriesTable, $taxonomy, $termsTable) {
-                                    $value = match($query->getConnection()->getDriverName()) {
+                                    $value = match ($query->getConnection()->getDriverName()) {
                                         'sqlite' => DB::raw('"" || '.$termsTable.'. slug || ""'),
                                         default => DB::raw('concat(\'"\', '.$termsTable.'.slug, \'"\')'),
                                     };

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -227,10 +227,10 @@ class TermQueryBuilder extends EloquentQueryBuilder
                         }
 
                         if (config('statamic.eloquent-driver.entries.driver', 'file') == 'eloquent') {
-                            $enrtiesTable = (new EntryModel)->getTable();
+                            $entriesTable = (new EntryModel)->getTable();
                             $termsTable = (new TermModel)->getTable();
                             $query = TermModel::where('taxonomy', $taxonomy)
-                                ->join($enrtiesTable, function (JoinClause $join) use ($taxonomy, $enrtiesTable, $termsTable) {
+                                ->join($entriesTable, function (JoinClause $join) use ($taxonomy, $entriesTable, $termsTable) {
                                     $wrappedColumn = $join->getGrammar()->wrap("{$termsTable}.slug");
                                     $column = match (DB::getDriverName()) {
                                         'mysql' => "json_quote({$wrappedColumn})",
@@ -238,9 +238,9 @@ class TermQueryBuilder extends EloquentQueryBuilder
                                         default => $wrappedColumn,
                                     };
                                     $columnExpression = new Expression($column);
-                                    $join->on("{$enrtiesTable}.collection", '=', "{$enrtiesTable}.collection")
-                                        ->whereIn("{$enrtiesTable}.collection", $this->collections)
-                                        ->whereJsonContains("{$enrtiesTable}.data->{$taxonomy}", $columnExpression);
+                                    $join->on("{$entriesTable}.collection", '=', "{$entriesTable}.collection")
+                                        ->whereIn("{$entriesTable}.collection", $this->collections)
+                                        ->whereJsonContains("{$entriesTable}.data->{$taxonomy}", $columnExpression);
                                 })
                                 ->select('taxonomy_terms.slug')
                                 ->pluck('slug');

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -208,6 +208,16 @@ class TermQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function it_filters_usage_in_collections_using_file_based_entries()
+    {
+        config()->set('statamic.eloquent-driver.entries.driver', 'file');
+        $this->it_filters_usage_in_collections();
+
+        // revert config to original
+        config()->set('statamic.eloquent-driver.entries.driver', 'eloquent');
+    }
+
+    #[Test]
     public function it_filters_usage_in_collections()
     {
         Taxonomy::make('tags')->save();


### PR DESCRIPTION
Working on a draft to fix issue #373 

The current implementation does not yet pass the tests due to not being fully db driver independent. 
The test fails because `JSON_QUOTE` seems to behave different in sqllite than mysql.
The `JSON_QUOTE` should probably not be hard coded here as well because we can't assume the db driver that is in use.

Closes https://github.com/statamic/eloquent-driver/issues/373