### PR TITLE
Ensure entry order is set when using queue

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -21,6 +21,10 @@ class Entry extends FileEntry
             $data[$key] = $model->$key;
         }
 
+        if ($model->order) {
+            $data['order'] = $model->order;
+        }
+
         $entry = (new static)
             ->origin($model->origin_id)
             ->locale($model->site)

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -85,8 +85,8 @@ class EntryRepository extends StacheRepository
         $collection->queryEntries()
             ->when($ids, fn ($query) => $query->whereIn('id', $ids))
             ->get(['id'])
-            ->each(function ($entry) {
-                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id(), $entry->order());
+            ->each(function ($entry, $index) {
+                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id(), $index + 1);
 
                 $connection = config('statamic.eloquent-driver.collections.update_entry_order_connection', 'default');
 

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -86,7 +86,7 @@ class EntryRepository extends StacheRepository
             ->when($ids, fn ($query) => $query->whereIn('id', $ids))
             ->get(['id'])
             ->each(function ($entry) {
-                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id());
+                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id(), $entry->order());
 
                 $connection = config('statamic.eloquent-driver.collections.update_entry_order_connection', 'default');
 

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -85,8 +85,8 @@ class EntryRepository extends StacheRepository
         $collection->queryEntries()
             ->when($ids, fn ($query) => $query->whereIn('id', $ids))
             ->get(['id'])
-            ->each(function ($entry, $index) {
-                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id(), $index + 1);
+            ->each(function ($entry) {
+                $dispatch = UpdateCollectionEntryOrder::dispatch($entry->id(), $entry->order());
 
                 $connection = config('statamic.eloquent-driver.collections.update_entry_order_connection', 'default');
 

--- a/src/Jobs/UpdateCollectionEntryOrder.php
+++ b/src/Jobs/UpdateCollectionEntryOrder.php
@@ -12,16 +12,17 @@ class UpdateCollectionEntryOrder implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    public $entryId;
-
-    public function __construct($entryId)
+    public function __construct(public $entryId, public $order)
     {
-        $this->entryId = $entryId;
     }
 
     public function handle()
     {
         if ($entry = Entry::find($this->entryId)) {
+            if ($this->order) {
+                $entry->order($this->order);
+            }
+
             $entry->save();
         }
     }

--- a/src/Jobs/UpdateCollectionEntryOrder.php
+++ b/src/Jobs/UpdateCollectionEntryOrder.php
@@ -12,15 +12,13 @@ class UpdateCollectionEntryOrder implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    public function __construct(public $entryId, public $order)
-    {
-    }
+    public function __construct(public $entryId, public $entryOrder) {}
 
     public function handle()
     {
         if ($entry = Entry::find($this->entryId)) {
-            if ($this->order) {
-                $entry->order($this->order);
+            if ($this->entryOrder) {
+                $entry->order($this->entryOrder);
             }
 
             $entry->save();

--- a/src/Jobs/UpdateCollectionEntryOrder.php
+++ b/src/Jobs/UpdateCollectionEntryOrder.php
@@ -18,7 +18,7 @@ class UpdateCollectionEntryOrder implements ShouldQueue
     {
         if ($entry = Entry::find($this->entryId)) {
             if ($this->entryOrder) {
-                $entry->order($this->entryOrder);
+                $entry->set('order', $this->entryOrder);
             }
 
             $entry->save();


### PR DESCRIPTION
This PR ensures that entry order is saved correctly when using a queue.

The order was being set however as the entry wasn't saved during the same request the new order did not persist to the database. This was initially missed as testing was using sync. 

After this PR we pass the order to the saving job which ensures it is persisted to the database.

Closes https://github.com/statamic/eloquent-driver/issues/368