### PR TITLE
Update entry URIs when collection route is changed

### DIFF
--- a/src/Jobs/UpdateCollectionEntryUris.php
+++ b/src/Jobs/UpdateCollectionEntryUris.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Eloquent\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Statamic\Facades\Entry;
+
+class UpdateCollectionEntryUris implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(public string $collection) {}
+
+    public function handle()
+    {
+        Entry::query()
+            ->where('collection', $this->collection)
+            ->chunk(100, fn ($entries) => $entries->each->save());
+    }
+}

--- a/tests/Entries/CollectionTest.php
+++ b/tests/Entries/CollectionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Entries;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Collections\Collection;
+use Statamic\Eloquent\Collections\CollectionModel;
+use Statamic\Facades\Collection as CollectionFacade;
+use Tests\TestCase;
+
+class CollectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_finds_collection()
+    {
+        $model = CollectionModel::create([
+            'title' => 'Blog',
+            'handle' => 'blog',
+            'settings' => [],
+        ]);
+
+        $find = CollectionFacade::find('blog');
+
+        $this->assertTrue($model->is($find->model()));
+        $this->assertEquals('blog', $find->handle());
+        $this->assertEquals('Blog', $find->title());
+    }
+
+    #[Test]
+    public function it_saves_to_collection_model()
+    {
+        $collection = (new Collection)->handle('test');
+
+        $this->assertDatabaseMissing('collections', ['handle' => 'test']);
+
+        $collection->save();
+
+        $this->assertDatabaseHas('collections', ['handle' => 'test']);
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue when changing a collection's route, where it wouldn't trigger the `uri` column on the `entries` table to be updated.

Closes #378.