### PR TITLE
Allow non-CP collection config fields to persist

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -68,17 +68,19 @@ class AssetContainer extends FileEntry
         $model = app('statamic.eloquent.assets.container_model')::firstOrNew(['handle' => $source->handle()])->fill([
             'title'    => $source->title(),
             'disk'     => $source->diskHandle() ?? config('filesystems.default'),
-            'settings' => [
-                'allow_uploads'     => $source->allowUploads(),
-                'allow_downloading' => $source->allowDownloading(),
-                'allow_moving'      => $source->allowMoving(),
-                'allow_renaming'    => $source->allowRenaming(),
-                'create_folders'    => $source->createFolders(),
-                'search_index'      => $source->searchIndex(),
-                'source_preset'     => $source->sourcePreset,
-                'warm_presets'      => $source->warmPresets,
-                'validation_rules'  => $source->validationRules(),
-            ],
+            'settings' => [],
+        ]);
+
+        $model->settings = array_merge($model->settings ?? [], [
+            'allow_uploads'     => $source->allowUploads(),
+            'allow_downloading' => $source->allowDownloading(),
+            'allow_moving'      => $source->allowMoving(),
+            'allow_renaming'    => $source->allowRenaming(),
+            'create_folders'    => $source->createFolders(),
+            'search_index'      => $source->searchIndex(),
+            'source_preset'     => $source->sourcePreset,
+            'warm_presets'      => $source->warmPresets,
+            'validation_rules'  => $source->validationRules(),
         ]);
 
         // Set initial timestamps.

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -54,7 +54,7 @@ class Collection extends FileEntry
             'settings' => [],
         ]);
 
-        $model->settings = array_merge($model->settings, [
+        $model->settings = array_merge($model->settings ?? [], [
             'routes'               => $source->routes,
             'slugs'                => $source->requiresSlugs(),
             'title_formats'        => collect($source->titleFormats())->filter(),

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -49,32 +49,36 @@ class Collection extends FileEntry
     {
         $class = app('statamic.eloquent.collections.model');
 
-        return $class::firstOrNew(['handle' => $source->handle])->fill([
+        $model = $class::firstOrNew(['handle' => $source->handle])->fill([
             'title'    => $source->title ?? $source->handle,
-            'settings' => [
-                'routes'               => $source->routes,
-                'slugs'                => $source->requiresSlugs(),
-                'title_formats'        => collect($source->titleFormats())->filter(),
-                'mount'                => $source->mount,
-                'dated'                => $source->dated,
-                'sites'                => $source->sites,
-                'template'             => $source->template,
-                'layout'               => $source->layout,
-                'inject'               => $source->cascade,
-                'search_index'         => $source->searchIndex,
-                'revisions'            => $source->revisionsEnabled(),
-                'default_status'       => $source->defaultPublishState,
-                'structure'            => $source->structureContents(),
-                'sort_dir'             => $source->customSortDirection(),
-                'sort_field'           => $source->customSortField(),
-                'taxonomies'           => $source->taxonomies,
-                'propagate'            => $source->propagate(),
-                'past_date_behavior'   => $source->pastDateBehavior(),
-                'future_date_behavior' => $source->futureDateBehavior(),
-                'preview_targets'      => $source->previewTargets(),
-                'origin_behavior'      => $source->originBehavior(),
-            ],
+            'settings' => [],
         ]);
+
+        $model->settings = array_merge($model->settings, [
+            'routes'               => $source->routes,
+            'slugs'                => $source->requiresSlugs(),
+            'title_formats'        => collect($source->titleFormats())->filter(),
+            'mount'                => $source->mount,
+            'dated'                => $source->dated,
+            'sites'                => $source->sites,
+            'template'             => $source->template,
+            'layout'               => $source->layout,
+            'inject'               => $source->cascade,
+            'search_index'         => $source->searchIndex,
+            'revisions'            => $source->revisionsEnabled(),
+            'default_status'       => $source->defaultPublishState,
+            'structure'            => $source->structureContents(),
+            'sort_dir'             => $source->customSortDirection(),
+            'sort_field'           => $source->customSortField(),
+            'taxonomies'           => $source->taxonomies,
+            'propagate'            => $source->propagate(),
+            'past_date_behavior'   => $source->pastDateBehavior(),
+            'future_date_behavior' => $source->futureDateBehavior(),
+            'preview_targets'      => $source->previewTargets(),
+            'origin_behavior'      => $source->originBehavior(),
+        ]);
+
+        return $model;
     }
 
     public function model($model = null)

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -36,15 +36,19 @@ class Nav extends FileEntry
     {
         $class = app('statamic.eloquent.navigations.model');
 
-        return $class::firstOrNew(['handle' => $source->handle()])->fill([
+        $model = $class::firstOrNew(['handle' => $source->handle()])->fill([
             'title'    => $source->title(),
-            'settings' => [
-                'collections'  => $source->collections()->map->handle(),
-                'select_across_sites' => $source->canSelectAcrossSites(),
-                'max_depth'    => $source->maxDepth(),
-                'expects_root' => $source->expectsRoot(),
-            ],
+            'settings' => [],
         ]);
+
+        $model->settings = array_merge($model->settings ?? [], [
+            'collections'  => $source->collections()->map->handle(),
+            'select_across_sites' => $source->canSelectAcrossSites(),
+            'max_depth'    => $source->maxDepth(),
+            'expects_root' => $source->expectsRoot(),
+        ]);
+
+        return $model;
     }
 
     public function model($model = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -40,7 +40,7 @@ class Taxonomy extends FileEntry
             'settings' => [],
         ]);
 
-        $model->settings = array_merge($model->settings, [
+        $model->settings = array_merge($model->settings ?? [], [
             'revisions' => $source->revisionsEnabled(),
             'preview_targets' => $source->previewTargets(),
             'term_template' => $source->hasCustomTermTemplate() ? $source->termTemplate() : null,

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -34,17 +34,21 @@ class Taxonomy extends FileEntry
     {
         $class = app('statamic.eloquent.taxonomies.model');
 
-        return $class::firstOrNew(['handle' => $source->handle()])->fill([
+        $model = $class::firstOrNew(['handle' => $source->handle()])->fill([
             'title' => $source->title(),
             'sites' => $source->sites(),
-            'settings' => [
-                'revisions' => $source->revisionsEnabled(),
-                'preview_targets' => $source->previewTargets(),
-                'term_template' => $source->hasCustomTermTemplate() ? $source->termTemplate() : null,
-                'template' => $source->hasCustomTemplate() ? $source->template() : null,
-                'layout' => $source->layout,
-            ],
+            'settings' => [],
         ]);
+
+        $model->settings = array_merge($model->settings, [
+            'revisions' => $source->revisionsEnabled(),
+            'preview_targets' => $source->previewTargets(),
+            'term_template' => $source->hasCustomTermTemplate() ? $source->termTemplate() : null,
+            'template' => $source->hasCustomTemplate() ? $source->template() : null,
+            'layout' => $source->layout,
+        ]);
+
+        return $model;
     }
 
     public function model($model = null)


### PR DESCRIPTION
This PR updates any config `settings` to merge with exiting values if present, ensuring that any extra (non-CP) config fields are not overwritten.

Closes https://github.com/statamic/eloquent-driver/issues/380