### PR TITLE
Prevent creation of duplicate terms on slug change

### DIFF
--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -74,10 +74,11 @@ class Term extends FileEntry
         }
 
         return $class::firstOrNew([
-            'slug'     => $source->slug(),
+            'slug'     => $source->getOriginal('slug', $source->slug()),
             'taxonomy' => $source->taxonomy(),
             'site'     => $source->locale(),
         ])->fill([
+            'slug'       => $source->slug(),
             'uri'        => $source->uri(),
             'data'       => $data,
             'updated_at' => $source->lastModified(),

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Terms;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Taxonomies\Taxonomy;
+use Statamic\Eloquent\Taxonomies\TermModel;
+use Statamic\Facades\Term as TermFacade;
+use Tests\TestCase;
+
+class TermTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_doesnt_create_a_new_model_when_slug_is_changed()
+    {
+        Taxonomy::make('test')->title('test')->save();
+
+        $term = tap(TermFacade::make('test-term')->taxonomy('test')->data([]))->save();
+
+        $this->assertCount(1, TermModel::all());
+        $this->assertSame('test-term', TermModel::first()->slug);
+
+        $term->slug('new-slug');
+        $term->save();
+
+        $this->assertCount(1, TermModel::all());
+        $this->assertSame('new-slug', TermModel::first()->slug);
+    }
+}


### PR DESCRIPTION
Make sure we're using the original slug to query for a term after an update.

Prevents duplicates being created when changing a term's slug in the control panel.

Probably needs tests to avoid regressions.

Fixes #383