### PR TITLE
Ensure we store the latest Entry uri

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -109,12 +109,15 @@ class Entry extends FileEntry
             Blink::store('entry-uris')->forget($source->id());
         }
 
+        // disable the uri cache so any slug updates give us the latest slug
+        $source->structure()?->in($source->locale())->disableUriCache();
+
         $attributes = [
             ...$attributes,
             'origin_id' => $origin?->id(),
             'site' => $source->locale(),
             'slug' => $source->slug(),
-            'uri' => $source->routableUri(), // we intentionally go to the trait to get the most up to date uri
+            'uri' => $source->uri() ?? $source->routableUri(),
             'date' => $date,
             'collection' => $source->collectionHandle(),
             'blueprint' => $source->blueprint ?? $source->blueprint()->handle(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -114,7 +114,7 @@ class Entry extends FileEntry
             'origin_id' => $origin?->id(),
             'site' => $source->locale(),
             'slug' => $source->slug(),
-            'uri' => $source->uri(),
+            'uri' => $source->routableUri(), // we intentionally go to the trait to get the most up to date uri
             'date' => $date,
             'collection' => $source->collectionHandle(),
             'blueprint' => $source->blueprint ?? $source->blueprint()->handle(),


### PR DESCRIPTION
This PR updates entry saving to use the routableUri, not the uri, which ensures we always have the latest uri in the database, even when the entry is new or when the slug is changed.

Closes https://github.com/statamic/eloquent-driver/issues/391