### PR TITLE
Adjust length of form handle column in form submission table

### DIFF
--- a/database/migrations/2024_03_07_100000_create_form_submissions_table.php
+++ b/database/migrations/2024_03_07_100000_create_form_submissions_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->id();
-            $table->string('form', 30)->nullable()->index();
+            $table->string('form', 255)->nullable()->index();
             $table->jsonb('data')->nullable();
             $table->timestamps(6);
 

--- a/database/migrations/2024_03_07_100000_create_form_submissions_table.php
+++ b/database/migrations/2024_03_07_100000_create_form_submissions_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create($this->prefix('form_submissions'), function (Blueprint $table) {
             $table->id();
-            $table->string('form', 255)->nullable()->index();
+            $table->string('form')->nullable()->index();
             $table->jsonb('data')->nullable();
             $table->timestamps(6);
 


### PR DESCRIPTION
I ran into an issue while migrating form submissions from files to eloquent.

Some of the handles of my forms are longer than 30 characters, so i ran into an exception because there's currently a max length of 30 on the form column in the form submissions table.
In the forms table, this column has 255 characters. Not sure why the discrepancy is there (maybe because of the index on the column?)

I fixed my migration by adjusting the migration file for submissions like I did below. 