### PR TITLE
return revisions in chronological order

### DIFF
--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -16,6 +16,7 @@ class RevisionRepository extends StacheRepository
     public function whereKey($key)
     {
         return app('statamic.eloquent.revisions.model')::where('key', $key)
+            ->orderBy('created_at')
             ->get()
             ->map(function ($revision) use ($key) {
                 return $this->makeRevisionFromFile($key, $revision);


### PR DESCRIPTION
Statamic revisions are expected to be returned in chronological order. 
When using file based revisions, this is always the case, since the revisions are written in there in correct order and read back line-by-line.

When using eloquent and for example postgres, the ordering of the returned rows is undefined and depends on postgres internals, therefore an explicit `orderBy` clause is introduced. 