### PR TITLE
[5.x] Cast entry dates to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ By default, the Eloquent Driver stores all data in a single `data` column. Howev
         {
             return [
                 // The casts from Statamic's base model...
-                'date'      => 'datetime',
                 'data'      => 'json',
                 'published' => 'boolean',
         

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Statamic\Eloquent\Database\BaseModel;
 
 class EntryModel extends BaseModel
@@ -17,6 +19,26 @@ class EntryModel extends BaseModel
             'data'      => 'json',
             'published' => 'boolean',
         ];
+    }
+
+    public function date(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                return Carbon::parse($value, 'UTC');
+            },
+            set: function ($value) {
+                if (! $value instanceof Carbon) {
+                    $value = Carbon::parse($value, 'UTC');
+                }
+
+                if ($value->tzName !== 'UTC') {
+                    $value = $value->utc();
+                }
+
+                return $value->format('Y-m-d H:i:s');
+            },
+        );
     }
 
     public function author()

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -3,6 +3,8 @@
 namespace Statamic\Eloquent\Entries;
 
 use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Carbon;
 use Statamic\Eloquent\Database\BaseModel;
 
 class EntryModel extends BaseModel
@@ -12,10 +14,29 @@ class EntryModel extends BaseModel
     protected $table = 'entries';
 
     protected $casts = [
-        'date'      => 'datetime',
         'data'      => 'json',
         'published' => 'boolean',
     ];
+
+    public function date(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                return Carbon::parse($value, 'UTC');
+            },
+            set: function ($value) {
+                if (! $value instanceof Carbon) {
+                    $value = Carbon::parse($value, 'UTC');
+                }
+
+                if ($value->tzName !== 'UTC') {
+                    $value = $value->utc();
+                }
+
+                return $value->format('Y-m-d H:i:s');
+            },
+        );
+    }
 
     public function author()
     {

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Eloquent\Entries;
 
-use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Statamic\Eloquent\Database\BaseModel;
 

--- a/tests/Entries/EntryModelTest.php
+++ b/tests/Entries/EntryModelTest.php
@@ -55,7 +55,7 @@ class EntryModelTest extends TestCase
         config()->set('app.timezone', 'America/New_York'); // -05:00
         date_default_timezone_set('America/New_York');
 
-        $model = new EntryModel();
+        $model = new EntryModel;
         $model->id = 1;
         $model->site = 'en';
         $model->published = true;
@@ -76,7 +76,7 @@ class EntryModelTest extends TestCase
         config()->set('app.timezone', 'America/New_York'); // -05:00
         date_default_timezone_set('America/New_York');
 
-        $model = new EntryModel();
+        $model = new EntryModel;
         $model->id = 1;
         $model->site = 'en';
         $model->published = true;
@@ -97,7 +97,7 @@ class EntryModelTest extends TestCase
         config()->set('app.timezone', 'America/New_York'); // -05:00
         date_default_timezone_set('America/New_York');
 
-        $model = new EntryModel();
+        $model = new EntryModel;
         $model->id = 1;
         $model->site = 'en';
         $model->published = true;

--- a/tests/Entries/EntryModelTest.php
+++ b/tests/Entries/EntryModelTest.php
@@ -2,12 +2,17 @@
 
 namespace Tests\Entries;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Entries\EntryModel;
 use Tests\TestCase;
 
 class EntryModelTest extends TestCase
 {
+    use RefreshDatabase;
+
     #[Test]
     public function it_gets_attributes_from_json_column()
     {
@@ -21,5 +26,89 @@ class EntryModelTest extends TestCase
         $this->assertEquals('the-slug', $model->slug);
         $this->assertEquals('bar', $model->foo);
         $this->assertEquals(['foo' => 'bar'], $model->data);
+    }
+
+    #[Test]
+    public function it_gets_date_as_utc()
+    {
+        config()->set('app.timezone', 'America/New_York'); // -05:00
+        date_default_timezone_set('America/New_York');
+
+        DB::table('entries')->insert([
+            'id' => '1',
+            'site' => 'en',
+            'published' => 1,
+            'date' => '2025-01-01 12:11:10',
+            'collection' => 'blog',
+            'data' => '{}',
+        ]);
+
+        $date = EntryModel::find(1)->date;
+
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertEquals('2025-01-01T12:11:10+00:00', $date->toIso8601String());
+    }
+
+    #[Test]
+    public function it_sets_utc_date_from_string()
+    {
+        config()->set('app.timezone', 'America/New_York'); // -05:00
+        date_default_timezone_set('America/New_York');
+
+        $model = new EntryModel();
+        $model->id = 1;
+        $model->site = 'en';
+        $model->published = true;
+        $model->collection = 'blog';
+        $model->date = '2025-01-01 12:11:10';
+        $model->data = [];
+        $model->save();
+
+        $this->assertDatabaseHas('entries', [
+            'id' => 1,
+            'date' => '2025-01-01 12:11:10',
+        ]);
+    }
+
+    #[Test]
+    public function it_sets_utc_date_from_carbon()
+    {
+        config()->set('app.timezone', 'America/New_York'); // -05:00
+        date_default_timezone_set('America/New_York');
+
+        $model = new EntryModel();
+        $model->id = 1;
+        $model->site = 'en';
+        $model->published = true;
+        $model->collection = 'blog';
+        $model->date = Carbon::parse('2025-01-01 12:11:10', 'UTC');
+        $model->data = [];
+        $model->save();
+
+        $this->assertDatabaseHas('entries', [
+            'id' => 1,
+            'date' => '2025-01-01 12:11:10',
+        ]);
+    }
+
+    #[Test]
+    public function it_sets_non_utc_date_from_carbon()
+    {
+        config()->set('app.timezone', 'America/New_York'); // -05:00
+        date_default_timezone_set('America/New_York');
+
+        $model = new EntryModel();
+        $model->id = 1;
+        $model->site = 'en';
+        $model->published = true;
+        $model->collection = 'blog';
+        $model->date = Carbon::parse('2025-01-01 12:11:10');
+        $model->data = [];
+        $model->save();
+
+        $this->assertDatabaseHas('entries', [
+            'id' => 1,
+            'date' => '2025-01-01 17:11:10',
+        ]);
     }
 }


### PR DESCRIPTION
This pull request ensures that whenever a date is stored or retreived from the `date` column on the `entries` table, a UTC Carbon object will be returned.

Without our accessor, whenever the `date` attribute was accessed, the returned `Carbon` object would use the application's timezone, not UTC (which is what we want dates to be stored in instead).

Related: https://github.com/statamic/cms/pull/11409