### PR TITLE
[5.x] Drop Laravel 10 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.4
-            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "doctrine/dbal": "^3.8",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.28 || ^9.6.1",
+        "orchestra/testbench": "^9.6.1",
         "phpunit/phpunit": "^10.5.35"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "statamic/cms": "^5.41"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request drops support for Laravel 10, and therefore also drops support for PHP 8.1.