### PR TITLE
[5.x] Convert `$casts` property to method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,18 @@ By default, the Eloquent Driver stores all data in a single `data` column. Howev
     
     class Entry extends \Statamic\Eloquent\Entries\EntryModel
     {
-        protected $casts = [
-            // The casts from Statamic's base model...
-            'date'      => 'datetime',
-            'data'      => 'json',
-            'published' => 'boolean',
-    
-            // Your custom casts...
-            'featured_images' => 'json',
-        ];
+        protected function casts(): array
+        {
+            return [
+                // The casts from Statamic's base model...
+                'date'      => 'datetime',
+                'data'      => 'json',
+                'published' => 'boolean',
+        
+                // Your custom casts...
+                'featured_images' => 'json',
+            ];
+        }
     }
     ```
     

--- a/src/Assets/AssetContainerModel.php
+++ b/src/Assets/AssetContainerModel.php
@@ -11,9 +11,12 @@ class AssetContainerModel extends BaseModel
 
     protected $table = 'asset_containers';
 
-    protected $casts = [
-        'settings' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Assets/AssetModel.php
+++ b/src/Assets/AssetModel.php
@@ -10,8 +10,11 @@ class AssetModel extends BaseModel
 
     protected $table = 'assets_meta';
 
-    protected $casts = [
-        'data' => 'json',
-        'meta' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+            'meta' => 'json',
+        ];
+    }
 }

--- a/src/Collections/CollectionModel.php
+++ b/src/Collections/CollectionModel.php
@@ -10,15 +10,18 @@ class CollectionModel extends BaseModel
 
     protected $table = 'collections';
 
-    protected $casts = [
-        'settings'                       => 'json',
-        'settings.routes'                => 'array',
-        'settings.inject'                => 'array',
-        'settings.taxonomies'            => 'array',
-        'settings.structure'             => 'array',
-        'settings.sites'                 => 'array',
-        'settings.revisions'             => 'boolean',
-        'settings.dated'                 => 'boolean',
-        'settings.default_publish_state' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings'                       => 'json',
+            'settings.routes'                => 'array',
+            'settings.inject'                => 'array',
+            'settings.taxonomies'            => 'array',
+            'settings.structure'             => 'array',
+            'settings.sites'                 => 'array',
+            'settings.revisions'             => 'boolean',
+            'settings.dated'                 => 'boolean',
+            'settings.default_publish_state' => 'boolean',
+        ];
+    }
 }

--- a/src/Entries/EntryModel.php
+++ b/src/Entries/EntryModel.php
@@ -11,11 +11,14 @@ class EntryModel extends BaseModel
 
     protected $table = 'entries';
 
-    protected $casts = [
-        'date'      => 'datetime',
-        'data'      => 'json',
-        'published' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'date'      => 'datetime',
+            'data'      => 'json',
+            'published' => 'boolean',
+        ];
+    }
 
     public function author()
     {

--- a/src/Fields/BlueprintModel.php
+++ b/src/Fields/BlueprintModel.php
@@ -11,9 +11,12 @@ class BlueprintModel extends BaseModel
 
     protected $table = 'blueprints';
 
-    protected $casts = [
-        'data' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Fields/FieldsetModel.php
+++ b/src/Fields/FieldsetModel.php
@@ -11,9 +11,12 @@ class FieldsetModel extends BaseModel
 
     protected $table = 'fieldsets';
 
-    protected $casts = [
-        'data' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Forms/FormModel.php
+++ b/src/Forms/FormModel.php
@@ -10,7 +10,10 @@ class FormModel extends BaseModel
 
     protected $table = 'forms';
 
-    protected $casts = [
-        'settings' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'json',
+        ];
+    }
 }

--- a/src/Forms/SubmissionModel.php
+++ b/src/Forms/SubmissionModel.php
@@ -12,9 +12,12 @@ class SubmissionModel extends BaseModel
 
     protected $table = 'form_submissions';
 
-    protected $casts = [
-        'data' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
 
     protected $dateFormat = 'Y-m-d H:i:s.u';
 }

--- a/src/Globals/GlobalSetModel.php
+++ b/src/Globals/GlobalSetModel.php
@@ -11,9 +11,12 @@ class GlobalSetModel extends BaseModel
 
     protected $table = 'global_sets';
 
-    protected $casts = [
-        'settings' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Globals/VariablesModel.php
+++ b/src/Globals/VariablesModel.php
@@ -11,9 +11,12 @@ class VariablesModel extends BaseModel
 
     protected $table = 'global_set_variables';
 
-    protected $casts = [
-        'data' => 'array',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Revisions/RevisionModel.php
+++ b/src/Revisions/RevisionModel.php
@@ -10,7 +10,10 @@ class RevisionModel extends BaseModel
 
     protected $table = 'revisions';
 
-    protected $casts = [
-        'attributes' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'attributes' => 'json',
+        ];
+    }
 }

--- a/src/Sites/SiteModel.php
+++ b/src/Sites/SiteModel.php
@@ -11,9 +11,12 @@ class SiteModel extends BaseModel
 
     protected $table = 'sites';
 
-    protected $casts = [
-        'attributes' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'attributes' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Structures/NavModel.php
+++ b/src/Structures/NavModel.php
@@ -10,7 +10,10 @@ class NavModel extends BaseModel
 
     protected $table = 'navigations';
 
-    protected $casts = [
-        'settings' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'json',
+        ];
+    }
 }

--- a/src/Structures/TreeModel.php
+++ b/src/Structures/TreeModel.php
@@ -10,8 +10,11 @@ class TreeModel extends BaseModel
 
     protected $table = 'trees';
 
-    protected $casts = [
-        'tree'     => 'json',
-        'settings' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'tree'     => 'json',
+            'settings' => 'json',
+        ];
+    }
 }

--- a/src/Taxonomies/TaxonomyModel.php
+++ b/src/Taxonomies/TaxonomyModel.php
@@ -11,10 +11,13 @@ class TaxonomyModel extends BaseModel
 
     protected $table = 'taxonomies';
 
-    protected $casts = [
-        'settings' => 'json',
-        'sites'    => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'json',
+            'sites'    => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Taxonomies/TermModel.php
+++ b/src/Taxonomies/TermModel.php
@@ -11,9 +11,12 @@ class TermModel extends BaseModel
 
     protected $table = 'taxonomy_terms';
 
-    protected $casts = [
-        'data' => 'json',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
 
     public function getAttribute($key)
     {

--- a/src/Tokens/TokenModel.php
+++ b/src/Tokens/TokenModel.php
@@ -10,8 +10,11 @@ class TokenModel extends BaseModel
 
     protected $table = 'tokens';
 
-    protected $casts = [
-        'data' => 'json',
-        'expire_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'json',
+            'expire_at' => 'datetime',
+        ];
+    }
 }


### PR DESCRIPTION
This pull request converts the `$casts` property on models to a method, now that Laravel 11 is the minimum version.


