### PR TITLE
Ensure template is imported

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Entries\Entry as FileEntry;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Support\Arr;
 
 class Entry extends FileEntry
 {
@@ -126,6 +127,10 @@ class Entry extends FileEntry
             'updated_at' => $source->lastModified(),
             'order' => $source->order(),
         ];
+
+        if ($source->template) {
+            $attributes['data']->put('template', $source->template);
+        }
 
         foreach ($dataMappings as $key) {
             $attributes[$key] = $data->get($key);

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -8,7 +8,6 @@ use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Entries\Entry as FileEntry;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Entry as EntryFacade;
-use Statamic\Support\Arr;
 
 class Entry extends FileEntry
 {

--- a/tests/Commands/ImportEntriesTest.php
+++ b/tests/Commands/ImportEntriesTest.php
@@ -82,4 +82,21 @@ class ImportEntriesTest extends TestCase
         $this->assertDatabaseHas('entries', ['collection' => 'pages', 'site' => 'en',  'slug' => 'foo', 'data' => '{"foo":"bar"}']);
         $this->assertDatabaseHas('entries', ['collection' => 'pages', 'site' => 'fr', 'slug' => 'foo', 'data' => '{"foo":"bar","baz":"qux","__localized_fields":[]}']);
     }
+
+    #[Test]
+    public function it_imports_template_correctly()
+    {
+        $collection = tap(Collection::make('pages')->title('Pages'))->save();
+        Entry::make()->collection($collection)->slug('template-test')->data(['foo' => 'bar'])->template('some.template')->save();
+
+        $this->assertCount(0, EntryModel::all());
+
+        $this->artisan('statamic:eloquent:import-entries')
+            ->expectsOutputToContain('Entries imported successfully.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, EntryModel::all());
+
+        $this->assertDatabaseHas('entries', ['collection' => 'pages', 'slug' => 'template-test', 'data' => '{"foo":"bar","template":"some.template"}']);
+    }
 }


### PR DESCRIPTION
As reported in https://github.com/statamic/eloquent-driver/issues/403 template is not currently imported correctly in the entries importer.

This PR ensures this value is brought over when non-null.

Closes https://github.com/statamic/eloquent-driver/issues/403