### PR TITLE
Ensure namespaced fieldsets and blueprints are returned

### DIFF
--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -30,7 +30,8 @@ class FieldsetRepository extends StacheRepository
                         ->setContents($model->data);
                 });
             });
-        });
+        })
+            ->merge($this->getNamespacedFieldsets());
     }
 
     public function find($handle): ?Fieldset

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -79,4 +79,18 @@ class BlueprintTest extends TestCase
 
         $this->assertCount(1, BlueprintModel::all()); // we check theres no new  database entries, ie its been handled by files
     }
+
+    #[Test]
+    public function it_handles_blueprints_registered_by_addons()
+    {
+        $this->assertCount(0, Blueprint::in('my-addon'));
+
+        Blueprint::addNamespace(
+            'my-addon',
+            directory: __DIR__.'/../../__fixtures__/resources/blueprints'
+        );
+
+        $this->assertCount(1, Blueprint::in('my-addon'));
+        $this->assertSame('collection', Blueprint::in('my-addon')->first()->handle());
+    }
 }

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -21,17 +21,8 @@ class BlueprintTest extends TestCase
                 ->setDirectory(resource_path('blueprints'));
         });
 
-        $this->app->singleton(
-            'Statamic\Fields\FieldsetRepository',
-            'Statamic\Eloquent\Fields\FieldsetRepository'
-        );
-
-        $this->app->bind('statamic.eloquent.blueprints.blueprint_model', function () {
+        $this->app->bind('statamic.eloquent.blueprints.model', function () {
             return \Statamic\Eloquent\Fields\BlueprintModel::class;
-        });
-
-        $this->app->bind('statamic.eloquent.blueprints.fieldset_model', function () {
-            return \Statamic\Eloquent\Fields\FieldsetModel::class;
         });
     }
 

--- a/tests/Data/Fields/FieldsetTest.php
+++ b/tests/Data/Fields/FieldsetTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Data\Fields;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Fieldset;
+use Tests\TestCase;
+
+class FieldsetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->singleton(
+            'Statamic\Fields\FieldsetRepository',
+            'Statamic\Eloquent\Fields\FieldsetRepository'
+        );
+
+        $this->app->bind('statamic.eloquent.fieldsets.model', function () {
+            return \Statamic\Eloquent\Fields\FieldsetModel::class;
+        });
+    }
+
+    #[Test]
+    public function it_handles_fieldsets_registered_by_addons()
+    {
+        Fieldset::addNamespace(
+            'my-addon',
+            directory: __DIR__.'/../../__fixtures__/resources/fieldsets'
+        );
+
+        $this->assertCount(1, Fieldset::all()); // we check theres no new  database entries, ie its been handled by files
+    }
+}

--- a/tests/Data/Fields/FieldsetTest.php
+++ b/tests/Data/Fields/FieldsetTest.php
@@ -28,11 +28,14 @@ class FieldsetTest extends TestCase
     #[Test]
     public function it_handles_fieldsets_registered_by_addons()
     {
+        $this->assertCount(0, Fieldset::all());
+
         Fieldset::addNamespace(
             'my-addon',
             directory: __DIR__.'/../../__fixtures__/resources/fieldsets'
         );
 
-        $this->assertCount(1, Fieldset::all()); // we check theres no new  database entries, ie its been handled by files
+        $this->assertCount(1, Fieldset::all());
+        $this->assertSame('my-addon::seo', Fieldset::all()->first()->handle());
     }
 }

--- a/tests/__fixtures__/resources/blueprints/collection.yaml
+++ b/tests/__fixtures__/resources/blueprints/collection.yaml
@@ -1,0 +1,80 @@
+tabs:
+  main:
+    display: Main
+    sections:
+      -
+        fields:
+          -
+            handle: title
+            field:
+              type: text
+              required: true
+              validate:
+                - required
+          -
+            handle: content
+            field:
+              buttons:
+                - h2
+                - h3
+                - bold
+                - italic
+                - unorderedlist
+                - orderedlist
+                - removeformat
+                - anchor
+              smart_typography: false
+              save_html: true
+              inline: false
+              toolbar_mode: fixed
+              reading_time: false
+              word_count: false
+              fullscreen: true
+              allow_source: true
+              enable_input_rules: true
+              enable_paste_rules: true
+              remove_empty_nodes: false
+              antlers: false
+              link_noopener: false
+              link_noreferrer: false
+              target_blank: false
+              always_show_set_button: false
+              collapse: false
+              previews: true
+              type: bard
+              display: Content
+              icon: bard
+              listable: hidden
+              instructions_position: above
+              visibility: visible
+              hide_display: false
+          -
+            handle: featured_image
+            field:
+              max_files: 1
+              mode: list
+              container: shopify
+              restrict: false
+              allow_uploads: true
+              show_filename: true
+              show_set_alt: true
+              type: assets
+              display: 'Featured image'
+              icon: assets
+              listable: hidden
+              instructions_position: above
+              visibility: visible
+              hide_display: false
+  sidebar:
+    display: Sidebar
+    sections:
+      -
+        fields:
+          -
+            handle: slug
+            field:
+              type: slug
+              required: true
+              validate:
+                - required
+title: 'Product Collection'

--- a/tests/__fixtures__/resources/fieldsets/seo.yaml
+++ b/tests/__fixtures__/resources/fieldsets/seo.yaml
@@ -1,0 +1,30 @@
+title: 'Advanced SEO (Sitemap)'
+fields:
+  -
+    handle: seo_section_sitemap
+    field:
+      type: advanced_seo
+      display: 'Sitemap'
+      field: seo_section_sitemap
+      visibility: hidden
+  -
+    handle: seo_sitemap_enabled
+    field:
+      type: advanced_seo
+      display: 'Enabled'
+      field: seo_sitemap_enabled
+      visibility: hidden
+  -
+    handle: seo_sitemap_priority
+    field:
+      type: advanced_seo
+      display: 'Priority'
+      field: seo_sitemap_priority
+      visibility: hidden
+  -
+    handle: seo_sitemap_change_frequency
+    field:
+      type: advanced_seo
+      display: 'Change Frequency'
+      field: seo_sitemap_change_frequency
+      visibility: hidden


### PR DESCRIPTION
This PR ensures that any blueprints and field sets registered using `Blueprint::addNamespace` and `Fieldset::addNamespace` (or by autoloading in add-ons) are returned by this driver, by merging them in with the database entries. 

Any that you had overridden in the database would already have been handled.

Closes https://github.com/statamic/eloquent-driver/issues/406