### PR TITLE
`EntryQueryBuilder::where()`: Forward all arguments to parent, instead of passing them manually

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -181,7 +181,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
         }
 
-        return parent::where($column, $operator, $value, $boolean);
+        return parent::where(...func_get_args());
     }
 
     public function whereIn($column, $values, $boolean = 'and')
@@ -190,7 +190,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
         }
 
-        return parent::whereIn($column, $values, $boolean);
+        return parent::whereIn(...func_get_args());
     }
 
     private function ensureCollectionsAreQueriedForStatusQuery(): void


### PR DESCRIPTION
This ensures that `func_num_args()` in the parent `EloquentQueryBuilder` class returns the correct number of passed arguments to the `->where()` method.

This is necessary so the operator & value can be prepared appropriately (see statamic/cms#11805).

Partially fixes #424.