### PR TITLE
Add index to the date column

### DIFF
--- a/database/migrations/entries/2024_03_07_100000_create_entries_table.php
+++ b/database/migrations/entries/2024_03_07_100000_create_entries_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->boolean('published')->default(true);
             $table->string('slug')->nullable();
             $table->string('uri')->nullable()->index();
-            $table->string('date')->nullable();
+            $table->string('date')->nullable()->index();
             $table->integer('order')->nullable()->index();
             $table->string('collection')->index();
             $table->string('blueprint', 30)->nullable()->index();

--- a/database/migrations/entries/2024_03_07_100000_create_entries_table_with_string_ids.php
+++ b/database/migrations/entries/2024_03_07_100000_create_entries_table_with_string_ids.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->boolean('published')->default(true);
             $table->string('slug')->nullable();
             $table->string('uri')->nullable()->index();
-            $table->string('date')->nullable();
+            $table->string('date')->nullable()->index();
             $table->integer('order')->nullable()->index();
             $table->string('collection')->index();
             $table->string('blueprint', 30)->nullable()->index();

--- a/database/migrations/updates/add_index_to_date_on_entries_table.php.stub
+++ b/database/migrations/updates/add_index_to_date_on_entries_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        if (Schema::hasIndex($this->prefix('entries'), 'date')) {
+            return;
+        }
+
+        Schema::table($this->prefix('entries'), function (Blueprint $table) {
+            $table->index(['date']);
+        });
+    }
+
+    public function down()
+    {
+        if (! Schema::hasIndex($this->prefix('entries'), 'date')) {
+            return;
+        }
+
+        Schema::table($this->prefix('entries'), function (Blueprint $table) {
+            $table->dropIndex(['date']);
+        });
+    }
+};

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -57,6 +57,7 @@ class ServiceProvider extends AddonServiceProvider
         \Statamic\Eloquent\Updates\RelateFormSubmissionsByHandle::class,
         \Statamic\Eloquent\Updates\DropStatusOnEntries::class,
         \Statamic\Eloquent\Updates\ChangeFormSubmissionsIdType::class,
+        \Statamic\Eloquent\Updates\AddIndexToDateOnEntriesTable::class,
     ];
 
     public function boot()

--- a/src/Updates/AddIndexToDateOnEntriesTable.php
+++ b/src/Updates/AddIndexToDateOnEntriesTable.php
@@ -10,6 +10,7 @@ class AddIndexToDateOnEntriesTable extends UpdateScript
     public function shouldUpdate($newVersion, $oldVersion)
     {
         return $this->isUpdatingTo('4.23.0')
+            && Schema::hasTable(config('statamic.eloquent-driver.table_prefix', '').'entries')
             && ! Schema::hasIndex(config('statamic.eloquent-driver.table_prefix', '').'entries', 'date');
     }
 

--- a/src/Updates/AddIndexToDateOnEntriesTable.php
+++ b/src/Updates/AddIndexToDateOnEntriesTable.php
@@ -9,7 +9,7 @@ class AddIndexToDateOnEntriesTable extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('4.23.0')
+        return $this->isUpdatingTo('4.22.0')
             && Schema::hasTable(config('statamic.eloquent-driver.table_prefix', '').'entries')
             && ! Schema::hasIndex(config('statamic.eloquent-driver.table_prefix', '').'entries', 'date');
     }

--- a/src/Updates/AddIndexToDateOnEntriesTable.php
+++ b/src/Updates/AddIndexToDateOnEntriesTable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddIndexToDateOnEntriesTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('4.23.0')
+            && ! Schema::hasIndex(config('statamic.eloquent-driver.table_prefix', '').'entries', 'date');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/updates/add_index_to_date_on_entries_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_add_index_to_date_on_entries_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}


### PR DESCRIPTION
This is a very simple PR to add an index to the `date` column of the `entries` table.

Sorting by the date column is a pretty common operation and it can be quite expensive without the index. In a low memory setup I would get a `QLSTATE[HY001]: Memory allocation error: 1038 Out of sort memory, consider increasing server sort buffer size` error even with just 60.000 entries, which is solved just by adding this index.

If there is another reason the date column is not indexed, sorry in advance!