### PR TITLE
Taxonomy wheres should use entry query builder, not stache

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -256,7 +256,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             return app('statamic.eloquent.entries.model')::query()
                 ->select(['id'])
                 ->where(function ($query) use ($taxonomy, $terms) {
-                    foreach ($terms as  $term) {
+                    foreach ($terms as $term) {
                         $query->orWhereJsonContains($this->column($taxonomy), $term);
                     }
                 })

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -115,4 +115,13 @@ class EntryRepository extends StacheRepository
                 $dispatch->onQueue(config('statamic.eloquent-driver.collections.update_entry_parent_queue', 'default'));
             });
     }
+
+    public function taxonomize($entry)
+    {
+        if (config('statamic.eloquent-driver.terms.driver') === 'eloquent') {
+            return;
+        }
+
+        parent::taxonomize($entry);
+    }
 }

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -118,7 +118,7 @@ class EntryRepository extends StacheRepository
 
     public function taxonomize($entry)
     {
-        if (config('statamic.eloquent-driver.terms.driver') === 'eloquent') {
+        if (config('statamic.eloquent-driver.taxonomies.driver') === 'eloquent') {
             return;
         }
 

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -4,17 +4,25 @@ namespace Tests\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Eloquent\Collections\Collection;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
+use Statamic\Eloquent\Taxonomies\Taxonomy;
 use Statamic\Facades;
 use Statamic\Facades\Collection as CollectionFacade;
 use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Facades\Stache;
+use Statamic\Facades\Term as TermFacade;
+use Statamic\Statamic;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class EntryTest extends TestCase
 {
+    use PreventsSavingStacheItemsToDisk;
     use RefreshDatabase;
 
     #[Test]
@@ -345,5 +353,48 @@ class EntryTest extends TestCase
         $entry->save();
 
         $this->assertArrayNotHasKey('null_value', $entry->model()->data);
+    }
+
+    #[Test]
+    public function it_doesnt_build_stache_associations_when_taxonomy_driver_is_eloquent()
+    {
+        Taxonomy::make('test')->title('test')->save();
+
+        TermFacade::make('test-term')->taxonomy('test')->data([])->save();
+
+        $taxonomyStore = Stache::stores()->get('terms');
+        $this->assertCount(0, $taxonomyStore->store('test')->index('associations')->items());
+
+        $collection = \Statamic\Facades\Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
+
+        $this->assertCount(0, $taxonomyStore->store('test')->index('associations')->items());
+    }
+
+    #[Test]
+    public function it_build_stache_associations_when_taxonomy_driver_is_not_eloquent()
+    {
+        config()->set('statamic.eloquent-driver.taxonomies.driver', 'file');
+
+        Facade::clearResolvedInstance(TaxonomyRepositoryContract::class);
+        Statamic::repository(TaxonomyRepositoryContract::class, \Statamic\Stache\Repositories\TaxonomyRepository::class);
+
+        Taxonomy::make('test')->title('test')->save();
+
+        TermFacade::make('test-term')->taxonomy('test')->data([])->save();
+
+        $taxonomyStore = Stache::stores()->get('terms');
+        $this->assertCount(0, $taxonomyStore->store('test')->index('associations')->items());
+
+        $collection = \Statamic\Facades\Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
+
+        $this->assertCount(2, $taxonomyStore->store('test')->index('associations')->items());
     }
 }

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -85,6 +85,8 @@ class TermTest extends TestCase
     #[Test]
     public function it_build_stache_associations_when_taxonomy_driver_is_not_eloquent()
     {
+        config()->set('statamic.eloquent-driver.taxonomies.driver', 'file');
+
         Facade::clearResolvedInstance(TaxonomyRepositoryContract::class);
         Statamic::repository(TaxonomyRepositoryContract::class, \Statamic\Stache\Repositories\TaxonomyRepository::class);
 


### PR DESCRIPTION
When getting the where's for taxonomy lookups we should do another entry query, rather than relying on stache associations. This is a big performance win when you have lots of terms.