### PR TITLE
Remove ensure associations

### DIFF
--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -13,8 +13,6 @@ class TermRepository extends StacheRepository
 {
     public function query()
     {
-        $this->ensureAssociations();
-
         return app(TermQueryBuilder::class);
     }
 

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -122,4 +122,13 @@ class TermRepository extends StacheRepository
             TermContract::class => Term::class,
         ];
     }
+
+    protected function ensureAssociations()
+    {
+        if (config('statamic.eloquent-driver.terms.driver', 'file') === 'eloquent') {
+            return;
+        }
+
+        parent::ensureAssociations();
+    }
 }

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -125,7 +125,7 @@ class TermRepository extends StacheRepository
 
     protected function ensureAssociations()
     {
-        if (config('statamic.eloquent-driver.terms.driver', 'file') === 'eloquent') {
+        if (config('statamic.eloquent-driver.taxonomies.driver', 'file') === 'eloquent') {
             return;
         }
 

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -13,6 +13,8 @@ class TermRepository extends StacheRepository
 {
     public function query()
     {
+        $this->ensureAssociations();
+
         return app(TermQueryBuilder::class);
     }
 

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -4,8 +4,10 @@ namespace Tests\Terms;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Taxonomies\Taxonomy;
 use Statamic\Eloquent\Taxonomies\TermModel;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Term as TermFacade;
 use Tests\TestCase;
 
@@ -56,5 +58,21 @@ class TermTest extends TestCase
 
         $this->assertEquals(now(), $term->updated_at);
         $this->assertEquals(now(), TermFacade::query()->first()->updated_at);
+    }
+
+    #[Test]
+    public function it_gets_entry_count_for_term()
+    {
+        Taxonomy::make('test')->title('test')->save();
+
+        $term = tap(TermFacade::make('test-term')->taxonomy('test')->data([]))->save();
+
+        $collection = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($collection)->slug('charlie')->save();
+
+        $this->assertEquals(2, TermFacade::entriesCount($term));
     }
 }

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -3,16 +3,22 @@
 namespace Tests\Terms;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Taxonomies\TaxonomyRepository as TaxonomyRepositoryContract;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Taxonomies\Taxonomy;
 use Statamic\Eloquent\Taxonomies\TermModel;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Stache;
 use Statamic\Facades\Term as TermFacade;
+use Statamic\Statamic;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class TermTest extends TestCase
 {
+    use PreventsSavingStacheItemsToDisk;
     use RefreshDatabase;
 
     #[Test]
@@ -74,5 +80,27 @@ class TermTest extends TestCase
         (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
 
         $this->assertEquals(2, TermFacade::entriesCount($term));
+    }
+
+    #[Test]
+    public function it_build_stache_associations_when_taxonomy_driver_is_not_eloquent()
+    {
+        Facade::clearResolvedInstance(TaxonomyRepositoryContract::class);
+        Statamic::repository(TaxonomyRepositoryContract::class, \Statamic\Stache\Repositories\TaxonomyRepository::class);
+
+        Taxonomy::make('test')->title('test')->save();
+
+        TermFacade::make('test-term')->taxonomy('test')->data([])->save();
+
+        $taxonomyStore = Stache::stores()->get('terms');
+        $this->assertCount(0, $taxonomyStore->store('test')->index('associations')->items());
+
+        $collection = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
+
+        $this->assertCount(2, $taxonomyStore->store('test')->index('associations')->items());
     }
 }

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -69,9 +69,9 @@ class TermTest extends TestCase
 
         $collection = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
 
-        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->save();
         (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
-        (new Entry)->id(3)->collection($collection)->slug('charlie')->save();
+        (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
 
         $this->assertEquals(2, TermFacade::entriesCount($term));
     }


### PR DESCRIPTION
@ryanmitchell I think this was the other culprit for all the slowness.

The `TermRepository` was calling `$this->ensureAssociations();` which populates the `associations` index : 

```
protected function ensureAssociations()
{
    Taxonomy::all()->each(function ($taxonomy) {
        $this->store->store($taxonomy->handle())->index('associations');
    });
}
```

This store is quite complex (over 10MB in my case) and it's probably not required when using the eloquent driver.

I also added a test to make sure the Terms facade still gets the correct count.

PS. With this change and your other PR the first page load is under 1 second.