### PR TITLE
Ensure global variables save

### DIFF
--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -49,13 +49,6 @@ class Variables extends FileEntry
         return $this->globalSet()->in($origin);
     }
 
-    public function save()
-    {
-        $this->toModel()->save();
-
-        return $this;
-    }
-
     public function model($model = null)
     {
         if (func_num_args() === 0) {

--- a/tests/Globals/GlobalsetTest.php
+++ b/tests/Globals/GlobalsetTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Globals;
+
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\GlobalVariablesSaved;
+use Statamic\Facades;
+use Tests\TestCase;
+
+class GlobalsetTest extends TestCase
+{
+    #[Test]
+    public function fires_events_when_globalset_saved()
+    {
+        Event::fake();
+
+        $global = Facades\Globalset::make('test');
+
+        $global->addLocalization(
+            $global->makeLocalization('en')->data(['foo' => 'bar', 'baz' => 'qux'])
+        );
+
+        $global->save();
+
+        Event::assertDispatched(GlobalSetSaved::class);
+        Event::assertDispatched(GlobalVariablesSaved::class);
+    }
+}


### PR DESCRIPTION
Defer to the repository rather than saving ourselves.

Closes https://github.com/statamic/eloquent-driver/issues/441