### PR TITLE
Get AssetContainer::folders() from eloquent table

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -128,11 +128,6 @@ class AssetContainer extends FileEntry
         return true;
     }
 
-    public function folders($folder = '/', $recursive = false)
-    {
-        return $this->disk()->getFolders($folder, $recursive);
-    }
-
     public function metaFiles($folder = '/', $recursive = false)
     {
         // When requesting files() as-is, we want all of them.


### PR DESCRIPTION
This PR updates eloquent AssetContainers to not specify its own folders() method, instead deferring to the method in core, which queries via AssetContainerContents. The end result of this is that when using eloquent assets it will query the folder list from the database. 

Closes https://github.com/statamic/eloquent-driver/issues/443