### PR TITLE
Asset blink should cache the asset not the model

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -38,7 +38,6 @@ class Asset extends FileAsset
             ->hydrateMeta($model->meta)
             ->syncOriginal();
 
-        Blink::put('eloquent-asset-'.$asset->id(), $model);
         Blink::put($asset->metaCacheKey(), $model->meta);
 
         return $asset;

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -38,6 +38,7 @@ class Asset extends FileAsset
             ->hydrateMeta($model->meta)
             ->syncOriginal();
 
+        Blink::put('eloquent-asset-'.$asset->id(), $asset);
         Blink::put($asset->metaCacheKey(), $model->meta);
 
         return $asset;

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -5,6 +5,7 @@ namespace Tests\Assets;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Assets\Asset;
 use Statamic\Facades;
 use Tests\TestCase;
 
@@ -47,6 +48,7 @@ class AssetTest extends TestCase
         $asset = Facades\Asset::find('test::f.jpg');
 
         $this->assertTrue(Facades\Blink::has("eloquent-asset-{$asset->id()}"));
+        $this->assertInstanceOf(Asset::class, Facades\Blink::get("eloquent-asset-{$asset->id()}"));
 
         $asset->save();
 


### PR DESCRIPTION
Closes https://github.com/statamic/eloquent-driver/issues/448