### PR TITLE
Store model reference on assets

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -5,16 +5,15 @@ namespace Statamic\Eloquent\Assets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Assets\Asset as FileAsset;
-use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Data\HasDirtyState;
-use Statamic\Facades\Blink;
-use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Asset extends FileAsset
 {
+    protected $model;
+
     use HasDirtyState {
         syncOriginal as traitSyncOriginal;
     }
@@ -36,10 +35,8 @@ class Asset extends FileAsset
             ->container($model->container)
             ->path(Str::replace('//', '/', $model->folder.'/'.$model->basename))
             ->hydrateMeta($model->meta)
-            ->syncOriginal();
-
-        Blink::put('eloquent-asset-'.$asset->id(), $asset);
-        Blink::put($asset->metaCacheKey(), $model->meta);
+            ->syncOriginal()
+            ->model($model);
 
         return $asset;
     }
@@ -65,23 +62,17 @@ class Asset extends FileAsset
             return $meta;
         }
 
-        return Blink::once($this->metaCacheKey(), function () {
-            if ($model = app('statamic.eloquent.assets.model')::where([
-                'container' => $this->containerHandle(),
-                'folder' => $this->folder(),
-                'basename' => $this->basename(),
-            ])->first()) {
-                return $model->meta;
-            }
-
-            $meta = $this->generateMeta();
-
-            if (! $meta['data']) {
-                $meta['data'] = [];
-            }
-
+        if ($meta = $this->model()?->meta) {
             return $meta;
-        });
+        }
+
+        $meta = $this->generateMeta();
+
+        if (! $meta['data']) {
+            $meta['data'] = [];
+        }
+
+        return $meta;
     }
 
     public function exists()
@@ -91,18 +82,7 @@ class Asset extends FileAsset
 
     public function metaExists()
     {
-        if (Blink::has($this->metaCacheKey())) {
-            return true;
-        }
-
-        return Blink::once('eloquent-asset-meta-exists-'.$this->id(), function () {
-            return app('statamic.eloquent.assets.model')::query()
-                ->where([
-                    'container' => $this->containerHandle(),
-                    'folder' => $this->folder(),
-                    'basename' => $this->basename(),
-                ])->count() > 0;
-        });
+        return $this->model() ? true : false;
     }
 
     private function metaValue($key)
@@ -136,12 +116,15 @@ class Asset extends FileAsset
 
     public function writeMeta($meta)
     {
-        $meta['data'] = Arr::removeNullValues($meta['data']);
+        $meta['data'] = Arr::removeNullValues($meta['data'] ?? []);
 
-        self::makeModelFromContract($this, $meta)?->save();
+        if (! $model = self::makeModelFromContract($this, $meta)) {
+            return;
+        }
 
-        Blink::put($this->metaCacheKey(), $meta);
-        Blink::put('eloquent-asset-meta-exists-'.$this->id(), true);
+        $model->save();
+
+        $this->model($model);
     }
 
     public static function makeModelFromContract(AssetContract $source, $meta = [])
@@ -150,18 +133,26 @@ class Asset extends FileAsset
             $meta = $source->meta();
         }
 
-        // Make shure that a extension could be found, as the extension field is required.
+        // Make sure that a extension could be found, as the extension field is required.
         if (! $extension = $source->extension()) {
             return null;
         }
 
-        $original = $source->getOriginal();
+        $model = false;
 
-        $model = app('statamic.eloquent.assets.model')::firstOrNew([
-            'container' => $source->containerHandle(),
-            'folder' => Arr::get($original, 'folder', $source->folder()),
-            'basename' => Arr::get($original, 'basename', $source->basename()),
-        ])->fill([
+        if (method_exists($source, 'model')) {
+            $model = $source->model();
+        }
+
+        if (! $model) {
+            $model = app('statamic.eloquent.assets.model')::make([
+                'container' => $source->containerHandle(),
+                'folder' => $source->folder(),
+                'basename' => $source->basename(),
+            ]);
+        }
+
+        $model->fill([
             'meta' => $meta,
             'filename' => $source->filename(),
             'extension' => $extension,
@@ -179,48 +170,20 @@ class Asset extends FileAsset
         return $model;
     }
 
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        return $this;
+    }
+
     public function metaPath()
     {
         return $this->path();
-    }
-
-    /**
-     * Move the asset to a different location.
-     *
-     * @param  string  $folder  The folder relative to the container.
-     * @param  string|null  $filename  The new filename, if renaming.
-     * @return $this
-     */
-    public function move($folder, $filename = null)
-    {
-        $filename = Uploader::getSafeFilename($filename ?: $this->filename());
-        $oldPath = $this->path();
-        $oldMetaPath = $this->metaPath();
-        $oldFolder = $this->folder();
-        $oldBasename = $this->basename();
-        $newPath = Str::removeLeft(Path::tidy($folder.'/'.$filename.'.'.pathinfo($oldPath, PATHINFO_EXTENSION)), '/');
-
-        $this->hydrate();
-        $this->disk()->rename($oldPath, $newPath);
-        $this->path($newPath);
-        $this->save();
-
-        if ($oldMetaPath != $this->metaPath()) {
-            $oldMetaModel = app('statamic.eloquent.assets.model')::where([
-                'container' => $this->containerHandle(),
-                'folder' => $oldFolder,
-                'basename' => $oldBasename,
-            ])->first();
-
-            if ($oldMetaModel) {
-                $meta = $oldMetaModel->meta;
-                $oldMetaModel->delete();
-
-                $this->writeMeta($meta);
-            }
-        }
-
-        return $this;
     }
 
     public function getCurrentDirtyStateAttributes(): array
@@ -237,8 +200,6 @@ class Asset extends FileAsset
     {
         $this->meta = null;
 
-        Blink::forget("eloquent-asset-{$this->id()}");
-        Blink::forget($this->metaCacheKey());
         Cache::forget($this->metaCacheKey());
     }
 }

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -5,7 +5,6 @@ namespace Statamic\Eloquent\Assets;
 use Statamic\Assets\AssetRepository as BaseRepository;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\QueryBuilder as QueryBuilderContract;
-use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;
 
@@ -18,22 +17,11 @@ class AssetRepository extends BaseRepository
         $filename = Str::afterLast($path, '/');
         $folder = str_contains($path, '/') ? Str::beforeLast($path, '/') : '/';
 
-        $blinkKey = "eloquent-asset-{$id}";
-        $item = Blink::once($blinkKey, function () use ($container, $filename, $folder) {
-            return $this->query()
-                ->where('container', $container)
-                ->where('folder', $folder)
-                ->where('basename', $filename)
-                ->first();
-        });
-
-        if (! $item) {
-            Blink::forget($blinkKey);
-
-            return null;
-        }
-
-        return $item;
+        return $this->query()
+            ->where('container', $container)
+            ->where('folder', $folder)
+            ->where('basename', $filename)
+            ->first();
     }
 
     public function findByUrl(string $url)

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -4,6 +4,7 @@ namespace Assets;
 
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades;
@@ -55,5 +56,19 @@ class AssetContainerTest extends TestCase
         $this->container->folders();
 
         $this->assertTrue($queryExecuted);
+    }
+
+    #[Test]
+    public function creating_a_folder_adds_it_to_the_folder_cache()
+    {
+        $this->assertCount(1, $this->container->folders());
+        $this->assertCount(1, Cache::get('asset-folder-contents-'.$this->container->handle()));
+
+        $this->container->assetFolder('foo')->save();
+
+        $this->assertCount(2, $this->container->folders());
+        $this->assertCount(2, Cache::get('asset-folder-contents-'.$this->container->handle()));
+        $this->assertSame(['/', 'foo'], $this->container->folders()->all());
+
     }
 }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -206,21 +206,4 @@ class AssetTest extends TestCase
         Event::assertDispatched(AssetUploaded::class, fn ($event) => $event->asset === $asset);
         Event::assertDispatched(AssetCreated::class, fn ($event) => $event->asset === $asset);
     }
-
-    #[Test]
-    public function making_an_asset_without_saving_doesnt_make_a_meta_exists_blink_cache_entry()
-    {
-        Facades\Blink::flush();
-
-        $this->assertCount(0, Facades\Blink::allStartingWith('eloquent-asset-meta-exists-'));
-
-        Storage::disk('test')->put('test.jpg', '');
-        $asset = Facades\Asset::make()->container('test')->path('test.jpg');
-
-        $this->assertCount(0, Facades\Blink::allStartingWith('eloquent-asset-meta-exists-'));
-
-        $asset->save();
-
-        $this->assertCount(1, Facades\Blink::allStartingWith('eloquent-asset-meta-exists-'));
-    }
 }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2,10 +2,19 @@
 
 namespace Tests\Assets;
 
+use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Assets\Asset;
+use Statamic\Eloquent\Assets\AssetModel;
+use Statamic\Events\AssetCreated;
+use Statamic\Events\AssetCreating;
+use Statamic\Events\AssetSaved;
+use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
 use Tests\TestCase;
 
@@ -19,7 +28,16 @@ class AssetTest extends TestCase
     {
         parent::setUp();
 
+        config(['cache.default' => 'file']);
+        Cache::clear();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/tmp',
+        ]]);
+
         Storage::fake('test', ['url' => '/assets']);
+        Storage::fake('attributes-cache');
 
         $this->container = tap(Facades\AssetContainer::make('test')->disk('test'))->save();
 
@@ -43,15 +61,149 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function saving_an_asset_clears_the_eloquent_blink_cache()
+    public function it_loads_from_asset_model()
     {
-        $asset = Facades\Asset::find('test::f.jpg');
+        $model = new AssetModel([
+            'container' => 'test',
+            'path' => 'test-folder/test.jpg',
+            'folder' => 'test-folder',
+            'basename' => 'test.jpg',
+            'filename' => 'test',
+            'extension' => 'jpg',
+            'meta' => ['width' => 100, 'height' => 100, 'data' => []],
+        ]);
 
-        $this->assertTrue(Facades\Blink::has("eloquent-asset-{$asset->id()}"));
-        $this->assertInstanceOf(Asset::class, Facades\Blink::get("eloquent-asset-{$asset->id()}"));
+        $asset = (new Asset)->fromModel($model);
+
+        $this->assertSame($model, $asset->model());
+        $this->assertSame('test-folder/test.jpg', $asset->path());
+        $this->assertSame('test-folder', $asset->folder());
+        $this->assertSame('test.jpg', $asset->basename());
+        $this->assertSame('test', $asset->filename());
+        $this->assertSame('jpg', $asset->extension());
+        $this->assertSame(['width' => 100, 'height' => 100, 'data' => []], $asset->meta());
+    }
+
+    #[Test]
+    public function it_finds_an_asset_and_blinks_it()
+    {
+        Facades\Blink::flush();
+
+        $this->expectsDatabaseQueryCount(2); // 1 for the container, 1 for the asset meta
+
+        $this->assertCount(0, Facades\Blink::allStartingWith('eloquent-asset-'));
+
+        $asset = Facades\Asset::find('test::a.jpg');
+
+        $this->assertInstanceOf(Asset::class, $asset);
+
+        $this->assertCount(1, Facades\Blink::allStartingWith('eloquent-asset-'));
+
+        Facades\Asset::find('test::a.jpg'); // this checks we don't perform another query
+    }
+
+    #[Test]
+    public function deleting_an_asset_deletes_the_model_and_the_blink_cache()
+    {
+        Facades\Blink::flush();
+
+        $this->assertCount(6, AssetModel::all());
+
+        $asset = Facades\Asset::find('test::a.jpg');
+
+        $this->assertCount(1, Facades\Blink::allStartingWith('eloquent-asset-'));
+
+        $asset->delete();
+
+        $this->assertCount(5, AssetModel::all());
+        $this->assertCount(0, Facades\Blink::allStartingWith('eloquent-asset-'));
+    }
+
+    #[Test]
+    public function updating_an_assets_meta_updates_the_same_model()
+    {
+        $asset = Facades\Asset::find('test::a.jpg');
+
+        $this->assertCount(6, AssetModel::all());
+
+        $model = $asset->model();
+
+        $asset->writeMeta(['width' => 900]);
+        $asset->save();
+
+        $this->assertSame($model, $asset->model());
+        $this->assertCount(6, AssetModel::all());
+    }
+
+    #[Test]
+    public function making_and_saving_an_asset_creates_a_new_model()
+    {
+        $this->assertCount(6, AssetModel::all());
+
+        Storage::disk('test')->put('f.jpg', '');
+
+        $asset = Facades\Asset::make()->container('test')->path('test.jpg');
+        $this->assertCount(6, AssetModel::all());
 
         $asset->save();
 
-        $this->assertFalse(Facades\Blink::has("eloquent-asset-{$asset->id()}"));
+        $this->assertInstanceOf(AssetModel::class, $asset->model());
+        $this->assertCount(7, AssetModel::all());
+    }
+
+    #[Test]
+    public function moving_an_asset_updates_the_same_model()
+    {
+        $asset = Facades\Asset::find('test::a.jpg');
+
+        $this->assertCount(6, AssetModel::all());
+
+        $model = $asset->model();
+        $modelId = $model->getKey();
+
+        $asset->move('new-folder', 'new-name');
+
+        $this->assertSame($model, $asset->model());
+        $this->assertCount(6, AssetModel::all());
+
+        $this->assertSame($model->path, $asset->path());
+        $this->assertSame($model->folder, $asset->folder());
+        $this->assertSame($model->basename, $asset->basename());
+        $this->assertSame($model->filename, $asset->filename());
+        $this->assertSame($model->extension, $asset->extension());
+        $this->assertSame($model->meta, $asset->meta());
+        $this->assertSame($modelId, $asset->model()->getKey());
+    }
+
+    #[Test]
+    public function uploads_a_file()
+    {
+        Event::fake();
+        $asset = (new \Statamic\Eloquent\Assets\Asset)->container($this->container)->path('path/to/asset.jpg')->syncOriginal();
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+        Storage::disk('test')->assertMissing('path/to/asset.jpg');
+
+        // This should only get called when glide processing source image on upload...
+        ImageValidator::partialMock()->shouldReceive('isValidImage')->never();
+
+        $return = $asset->upload(UploadedFile::fake()->image('asset.jpg', 13, 15));
+
+        $this->assertEquals($asset, $return);
+        Storage::disk('test')->assertExists('path/to/asset.jpg');
+        $this->assertEquals('path/to/asset.jpg', $asset->path());
+
+        $meta = $asset->meta();
+        $this->assertEquals(13, $meta['width']);
+        $this->assertEquals(15, $meta['height']);
+        $this->assertEquals('image/jpeg', $meta['mime_type']);
+        $this->assertArrayHasKey('size', $meta);
+        $this->assertArrayHasKey('last_modified', $meta);
+        $this->assertInstanceOf(AssetModel::class, $asset->model());
+
+        Event::assertDispatched(AssetCreating::class, fn ($event) => $event->asset === $asset);
+        Event::assertDispatched(AssetSaved::class, fn ($event) => $event->asset === $asset);
+        Event::assertDispatched(AssetUploaded::class, fn ($event) => $event->asset === $asset);
+        Event::assertDispatched(AssetCreated::class, fn ($event) => $event->asset === $asset);
     }
 }


### PR DESCRIPTION
This PR refactors assets to store $model to avoid the blink cache/meta issues.