### PR TITLE
Add order to sites column

### DIFF
--- a/database/migrations/2024_07_16_100000_create_sites_table.php
+++ b/database/migrations/2024_07_16_100000_create_sites_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->string('locale');
             $table->string('lang');
             $table->jsonb('attributes');
+            $table->integer('order')->default(0)->index();
             $table->timestamps();
         });
     }

--- a/database/migrations/updates/add_order_to_sites_table.php.stub
+++ b/database/migrations/updates/add_order_to_sites_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+use Statamic\Facades\Entry;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table($this->prefix('sites'), function (Blueprint $table) {
+            $table->integer('order')->default(0)->after('attributes')->index();
+        });
+
+        $count = 0;
+        app('statamic.eloquent.sites.model')::all()
+            ->each(function ($siteModel) use (&$count) {
+                $siteModel->order = ++$count;
+                $siteModel->save();
+            });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('sites'), function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,6 +58,7 @@ class ServiceProvider extends AddonServiceProvider
         \Statamic\Eloquent\Updates\DropStatusOnEntries::class,
         \Statamic\Eloquent\Updates\ChangeFormSubmissionsIdType::class,
         \Statamic\Eloquent\Updates\AddIndexToDateOnEntriesTable::class,
+        \Statamic\Eloquent\Updates\AddOrderToSitesTable::class,
     ];
 
     public function boot()

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -15,7 +15,7 @@ class Sites extends \Statamic\Sites\Sites
             return $this->getFallbackConfig();
         }
 
-        $sites = app('statamic.eloquent.sites.model')::all();
+        $sites = app('statamic.eloquent.sites.model')::query()->orderBy('order')->get();
 
         return $sites->isEmpty() ? $this->getFallbackConfig() : $sites->mapWithKeys(function ($model) {
             return [
@@ -32,6 +32,7 @@ class Sites extends \Statamic\Sites\Sites
 
     protected function saveToStore()
     {
+        $count = 0;
         foreach ($this->config() as $handle => $config) {
             $lang = $config['lang'] ?? Str::before($config['locale'] ?? '', '_') ?? 'en';
 
@@ -42,6 +43,7 @@ class Sites extends \Statamic\Sites\Sites
                     'locale' => $config['locale'] ?? '',
                     'url' => $config['url'] ?? '',
                     'attributes' => $config['attributes'] ?? [],
+                    'order' => ++$count;
                 ])
                 ->save();
         }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -43,7 +43,7 @@ class Sites extends \Statamic\Sites\Sites
                     'locale' => $config['locale'] ?? '',
                     'url' => $config['url'] ?? '',
                     'attributes' => $config['attributes'] ?? [],
-                    'order' => ++$count;
+                    'order' => ++$count,
                 ])
                 ->save();
         }

--- a/src/Updates/AddOrderToSitesTable.php
+++ b/src/Updates/AddOrderToSitesTable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddOrderToSitesTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        $sitesTable = config('statamic.eloquent-driver.table_prefix', '').'sites';
+
+        return Schema::hasTable($sitesTable) && ! Schema::hasColumn($sitesTable, 'order');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/updates/add_order_to_sites_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_add_order_to_sites_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/src/Updates/AddOrderToSitesTable.php
+++ b/src/Updates/AddOrderToSitesTable.php
@@ -17,7 +17,7 @@ class AddOrderToSitesTable extends UpdateScript
     public function update()
     {
         $source = __DIR__.'/../../database/migrations/updates/add_order_to_sites_table.php.stub';
-        $dest = database_path('migrations/'.date('Y_m_d_His').'_add_order_to_sites_table.php');
+        $dest = database_path('migrations/2025_07_03_add_order_to_sites_table.php');
 
         $this->files->copy($source, $dest);
 

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -73,4 +73,27 @@ class SitesTest extends TestCase
         $this->assertCount(3, SiteModel::all());
         $this->assertSame(['en', 'fr', 'es'], SiteModel::all()->pluck('handle')->all());
     }
+
+    #[Test]
+    public function it_honours_order_when_saving_sites()
+    {
+        $this->assertCount(0, SiteModel::all());
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
+        Site::save();
+
+        $this->assertSame([1, 2, 3, 4], SiteModel::all()->pluck('order')->all());
+
+        SiteModel::all()->reverse()->each(fn ($site) => $site->update(['order' => 5 - $site->order]));
+
+        Site::setSites();
+
+        $this->assertSame(['de', 'es', 'fr', 'en'], Site::all()->pluck('handle')->all());
+    }
 }


### PR DESCRIPTION
This PR adds `order` to the sites table to ensure that sites can be re-ordered once initially created.

Closes https://github.com/statamic/eloquent-driver/issues/465