### PR TITLE
Prevent global variables merging origin data

### DIFF
--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -31,10 +31,6 @@ class Variables extends FileEntry
 
         $data = $source->data();
 
-        if ($source->hasOrigin()) {
-            $data = $source->origin()->data()->merge($data);
-        }
-
         return $class::firstOrNew([
             'handle' => $source->globalSet()->handle(),
             'locale' => $source->locale,

--- a/tests/Globals/GlobalVariablesTest.php
+++ b/tests/Globals/GlobalVariablesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Globals;
+
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Globals\VariablesModel;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\GlobalVariablesSaved;
+use Statamic\Facades;
+use Tests\TestCase;
+
+class GlobalVariablesTest extends TestCase
+{
+    #[Test]
+    public function does_not_save_synced_origin_data_to_localizations()
+    {
+        $global = Facades\Globalset::make('test');
+
+        $global->addLocalization($global->makeLocalization('en')->data(['foo' => 'bar', 'baz' => 'qux']));
+        $global->addLocalization($global->makeLocalization('fr')->origin('en')->data([]));
+
+        $global->save();
+
+        $this->assertCount(2, VariablesModel::all());
+        $this->assertSame(VariablesModel::all()->firstWhere('locale', 'fr')->data, []);
+    }
+}

--- a/tests/Globals/GlobalVariablesTest.php
+++ b/tests/Globals/GlobalVariablesTest.php
@@ -2,11 +2,8 @@
 
 namespace Globals;
 
-use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Globals\VariablesModel;
-use Statamic\Events\GlobalSetSaved;
-use Statamic\Events\GlobalVariablesSaved;
 use Statamic\Facades;
 use Tests\TestCase;
 


### PR DESCRIPTION
Variables with an origin shouldnt merge the origin data as it removes any linked 'sync' in the CP.

Closes https://github.com/statamic/eloquent-driver/issues/467