### PR TITLE
[4.x] Fix empty localized values not being set properly

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -15,7 +15,9 @@ class Entry extends FileEntry
 
     public static function fromModel(Model $model)
     {
-        $data = isset($model->data['__localized_fields']) ? collect($model->data)->only($model->data['__localized_fields']) : $model->data;
+        $data = isset($model->data['__localized_fields'])
+            ? collect($model->data['__localized_fields'])->mapWithKeys(fn($field) => [$field => $model->data[$field] ?? null])
+            : $model->data;
 
         foreach ((new self)->getDataColumnMappings($model) as $key) {
             $data[$key] = $model->$key;


### PR DESCRIPTION
Because the original code was only mapping existing values from the model data, when you unset a value in a specific localization that value didn't end up getting retrieved properly. This made it impossible to unset values in a localization that were set in the default site.

To fix this I turned around the code, mapping all of the `__localized_fields` to their model data, ensuring all of the localized fields get a value attached to them.