### PR TITLE
[4.x] Always load model for assets

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -173,6 +173,14 @@ class Asset extends FileAsset
     public function model($model = null)
     {
         if (func_num_args() === 0) {
+            if (! $this->model) {
+                $this->model = app('statamic.eloquent.assets.model')::query()->where([
+                    'container' => $this->containerHandle(),
+                    'folder' => $this->folder(),
+                    'basename' => $this->basename(),
+                ])->first();
+            }
+
             return $this->model;
         }
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -173,13 +173,17 @@ class Asset extends FileAsset
     public function model($model = null)
     {
         if (func_num_args() === 0) {
-            if (! $this->model) {
-                $this->model = app('statamic.eloquent.assets.model')::query()->where([
+            if ($this->model) {
+                return $this->model;
+            }
+
+            $this->model = app('statamic.eloquent.assets.model')::query()
+                ->where([
                     'container' => $this->containerHandle(),
                     'folder' => $this->folder(),
                     'basename' => $this->basename(),
-                ])->first();
-            }
+                ])
+                ->first();
 
             return $this->model;
         }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -74,6 +74,7 @@ class AssetTest extends TestCase
             'extension' => 'jpg',
             'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
         ]);
+        $model->save();
 
         $asset = (new Asset)->fromModel($model);
 
@@ -87,7 +88,7 @@ class AssetTest extends TestCase
 
         $asset = $this->container->asset($model->path);
 
-        $this->assertSame($model, $asset->model());
+        $this->assertSame($model->id, $asset->model()->id);
         $this->assertSame('test-folder/test.jpg', $asset->path());
         $this->assertSame('test-folder', $asset->folder());
         $this->assertSame('test.jpg', $asset->basename());
@@ -227,8 +228,6 @@ class AssetTest extends TestCase
         $this->assertCount(6, AssetModel::all());
 
         $asset = $this->container->makeAsset('a.jpg');
-
-        $this->assertNull($asset->model());
 
         $asset->save();
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -58,6 +58,8 @@ class AssetTest extends TestCase
 
         Storage::disk('test')->put('f.jpg', '');
         Facades\Asset::make()->container('test')->path('f.jpg')->save();
+
+        Storage::disk('test')->put('test-folder/test.jpg', '');
     }
 
     #[Test]

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -229,9 +229,13 @@ class AssetTest extends TestCase
 
         $asset = $this->container->makeAsset('a.jpg');
 
+        $model = $asset->model(); // it should find the existing model meta
+        $this->assertNotNull($model);
+
         $asset->save();
 
         $this->assertNotNull($asset->model());
+        $this->assertSame($model, $asset->model());
 
         Event::assertDispatched(AssetSaved::class, fn ($event) => $event->asset === $asset);
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -70,7 +70,7 @@ class AssetTest extends TestCase
             'basename' => 'test.jpg',
             'filename' => 'test',
             'extension' => 'jpg',
-            'meta' => ['width' => 100, 'height' => 100, 'data' => []],
+            'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
         ]);
 
         $asset = (new Asset)->fromModel($model);
@@ -81,7 +81,17 @@ class AssetTest extends TestCase
         $this->assertSame('test.jpg', $asset->basename());
         $this->assertSame('test', $asset->filename());
         $this->assertSame('jpg', $asset->extension());
-        $this->assertSame(['width' => 100, 'height' => 100, 'data' => []], $asset->meta());
+        $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
+
+        $asset = $this->container->makeAsset($model->path);
+
+        $this->assertSame($model, $asset->model());
+        $this->assertSame('test-folder/test.jpg', $asset->path());
+        $this->assertSame('test-folder', $asset->folder());
+        $this->assertSame('test.jpg', $asset->basename());
+        $this->assertSame('test', $asset->filename());
+        $this->assertSame('jpg', $asset->extension());
+        $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
     }
 
     #[Test]

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -74,7 +74,6 @@ class AssetTest extends TestCase
             'extension' => 'jpg',
             'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
         ]);
-        $model->save();
 
         $asset = (new Asset)->fromModel($model);
 
@@ -85,10 +84,26 @@ class AssetTest extends TestCase
         $this->assertSame('test', $asset->filename());
         $this->assertSame('jpg', $asset->extension());
         $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
+    }
+
+    #[Test]
+    public function it_loads_from_an_existing_model_outside_the_query_builder()
+    {
+        $model = new AssetModel([
+            'container' => 'test',
+            'path' => 'test-folder/test.jpg',
+            'folder' => 'test-folder',
+            'basename' => 'test.jpg',
+            'filename' => 'test',
+            'extension' => 'jpg',
+            'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
+        ]);
+
+        $model->save();
 
         $asset = $this->container->asset($model->path);
 
-        $this->assertSame($model->id, $asset->model()->id);
+        $this->assertSame($model->getKey(), $asset->model()->getKey());
         $this->assertSame('test-folder/test.jpg', $asset->path());
         $this->assertSame('test-folder', $asset->folder());
         $this->assertSame('test.jpg', $asset->basename());

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -83,7 +83,7 @@ class AssetTest extends TestCase
         $this->assertSame('jpg', $asset->extension());
         $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
 
-        $asset = $this->container->makeAsset($model->path);
+        $asset = $this->container->asset($model->path);
 
         $this->assertSame($model, $asset->model());
         $this->assertSame('test-folder/test.jpg', $asset->path());


### PR DESCRIPTION
This PR fixes the same issue I was trying (but failed) to address in this PR to core: https://github.com/statamic/cms/pull/11983

It solves the issue of assets being only partially loaded when using the `AssetContainer()->asset()` method.  That method is used by a few critical locations chief among them being the `GlideController` in core.  This is the method call chain that causes issue:
- `Statamic\Assets\AssetContainer->asset()`
- `Statamic\Assets\AssetContainer->makeAsset()`
- `Statamic\Assets\Asset->hydrate()`
- `Statamic\Eloquent\Assets\Asset->meta()`
- `Statamic\Eloquent\Assets\Asset->model()`

Notice that chain never calls the `Statamic\Eloquent\Assets\Asset->fromModel()` method like the `Statamic\Eloquent\Assets\AssetQueryBuilder` does.  This means that when `Asset->meta()` calls `Asset->model()` to get the meta from the current model it will be empty.

To solve this, I am simply adding a check that if the model is empty we will fill it using the result of a model query (copied from the `Statamic\Eloquent\Assets\Asset->makeModelFromContract()` method).

Let me know if there is anything else I can clarify or change.