### PR TITLE
Tidy up entries import

### DIFF
--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -5,12 +5,8 @@ namespace Statamic\Eloquent\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Console\RunsInPlease;
-use Statamic\Contracts\Entries\CollectionRepository as CollectionRepositoryContract;
-use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
-use Statamic\Eloquent\Entries\Entry as EloquentEntry;
 use Statamic\Facades\Entry;
-use Statamic\Stache\Repositories\CollectionRepository;
 use Statamic\Stache\Repositories\EntryRepository;
 use Statamic\Statamic;
 
@@ -47,12 +43,8 @@ class ImportEntries extends Command
     private function useDefaultRepositories(): void
     {
         Facade::clearResolvedInstance(EntryRepositoryContract::class);
-        Facade::clearResolvedInstance(CollectionRepositoryContract::class);
 
         Statamic::repository(EntryRepositoryContract::class, EntryRepository::class);
-        Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
-
-        app()->bind(EntryContract::class, app('statamic.eloquent.entries.entry'));
     }
 
     private function importEntries(): void
@@ -71,7 +63,7 @@ class ImportEntries extends Command
         $this->withProgressBar($entriesWithoutOrigin, function ($entry) {
             $lastModified = $entry->fileLastModified();
 
-            $entry = EloquentEntry::makeModelFromContract($entry)
+            app('statamic.eloquent.entries.entry')::makeModelFromContract($entry)
                 ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                 ->save();
         });
@@ -82,7 +74,7 @@ class ImportEntries extends Command
             $this->withProgressBar($entriesWithOrigin, function ($entry) {
                 $lastModified = $entry->fileLastModified();
 
-                EloquentEntry::makeModelFromContract($entry)
+                app('statamic.eloquent.entries.entry')::makeModelFromContract($entry)
                     ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                     ->save();
             });

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
-use Statamic\Eloquent\Entries\Entry as EloquentEntry;
 use Statamic\Facades\Entry;
 use Statamic\Stache\Repositories\EntryRepository;
 use Statamic\Statamic;
@@ -64,7 +63,7 @@ class ImportEntries extends Command
         $this->withProgressBar($entriesWithoutOrigin, function ($entry) {
             $lastModified = $entry->fileLastModified();
 
-            (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : EloquentEntry)::makeModelFromContract($entry)
+            (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : \Statamic\Eloquent\Entries\Entry)::makeModelFromContract($entry)
                 ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                 ->save();
         });
@@ -75,7 +74,7 @@ class ImportEntries extends Command
             $this->withProgressBar($entriesWithOrigin, function ($entry) {
                 $lastModified = $entry->fileLastModified();
 
-                (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : EloquentEntry)::makeModelFromContract($entry)
+                (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : \Statamic\Eloquent\Entries\Entry)::makeModelFromContract($entry)
                     ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                     ->save();
             });

--- a/src/Commands/ImportEntries.php
+++ b/src/Commands/ImportEntries.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Entries\EntryRepository as EntryRepositoryContract;
+use Statamic\Eloquent\Entries\Entry as EloquentEntry;
 use Statamic\Facades\Entry;
 use Statamic\Stache\Repositories\EntryRepository;
 use Statamic\Statamic;
@@ -63,7 +64,7 @@ class ImportEntries extends Command
         $this->withProgressBar($entriesWithoutOrigin, function ($entry) {
             $lastModified = $entry->fileLastModified();
 
-            app('statamic.eloquent.entries.entry')::makeModelFromContract($entry)
+            (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : EloquentEntry)::makeModelFromContract($entry)
                 ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                 ->save();
         });
@@ -74,7 +75,7 @@ class ImportEntries extends Command
             $this->withProgressBar($entriesWithOrigin, function ($entry) {
                 $lastModified = $entry->fileLastModified();
 
-                app('statamic.eloquent.entries.entry')::makeModelFromContract($entry)
+                (app()->has('statamic.eloquent.entries.entry') ? app('statamic.eloquent.entries.entry') : EloquentEntry)::makeModelFromContract($entry)
                     ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
                     ->save();
             });


### PR DESCRIPTION
Remove collection facade clearing, this is a hangover from when the import entries and collections were the same script.

Ensure we're using the bound entry class if it exists.