### PR TITLE
[6.x] Split asset meta into individual columns

### DIFF
--- a/database/migrations/2024_03_07_100000_create_asset_table.php
+++ b/database/migrations/2024_03_07_100000_create_asset_table.php
@@ -17,6 +17,14 @@ return new class extends Migration
             $table->char('extension', 10)->index();
             $table->string('path')->index();
             $table->jsonb('meta')->nullable();
+
+            $table->integer('duration')->nullable()->default(null);
+            $table->integer('height')->nullable()->default(null);
+            $table->integer('last_modified');
+            $table->string('mime_type');
+            $table->integer('size')->index();
+            $table->integer('width')->nullable()->default(null);
+
             $table->timestamps();
 
             $table->unique(['container', 'folder', 'basename']);

--- a/database/migrations/updates/add_meta_columns_to_assets_table.php.stub
+++ b/database/migrations/updates/add_meta_columns_to_assets_table.php.stub
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Arr;
+use Statamic\Eloquent\Assets\AssetModel;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        if (Schema::hasColumn($this->prefix('assets_meta', 'size')) {
+            return;
+        }
+
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->integer('duration')->nullable()->default(null);
+            $table->integer('height')->nullable()->default(null);
+            $table->integer('last_modified')->default(0);
+            $table->string('mime_type')->default('');
+            $table->integer('size')->default(0)->index();
+            $table->integer('width')->nullable()->default(null);
+        });
+
+        AssetModel::query()
+            ->lazy()
+            ->each(function ($model) {
+                $meta = $model->meta;
+
+                $model->duration = Arr::pull($meta, 'duration', null);
+                $model->height = Arr::pull($meta, 'height', null);
+                $model->last_modified = Arr::pull($meta, 'last_modified', time());
+                $model->mime_type = Arr::pull($meta, 'mime_type', '');
+                $model->size = Arr::pull($meta, 'size', 0);
+                $model->width = Arr::pull($meta, 'height', null);
+
+                $model->meta = $meta['data'];
+                $model->saveQuietly();
+            });
+    }
+
+    public function down()
+    {
+        if (! Schema::hasColumn($this->prefix('assets_meta', 'size')) {
+            return;
+        }
+
+        AssetModel::query()
+            ->lazy()
+            ->each(function ($model) {
+                $meta = $model->meta;
+
+                $meta['duration'] = $model->duration;
+                $meta['height'] = $model->height;
+                $meta['last_modified'] = $model->last_modified;
+                $meta['mime_type'] = $model->mime_type;
+                $meta['size'] = $model->size;
+                $meta['width'] = $model->width;
+
+                $model->meta = $meta;
+
+                $model->saveQuietly();
+            });
+
+        Schema::table($this->prefix('assets_meta'), function (Blueprint $table) {
+            $table->dropColumn(['duration', 'height', 'last_modified', 'mime_type', 'size', 'width']);
+        });
+    }
+};

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -9,19 +9,13 @@ use Statamic\Query\EloquentQueryBuilder;
 class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {
     const COLUMNS = [
-        'id', 'container', 'folder', 'basename', 'filename', 'extension', 'path', 'created_at', 'updated_at',
-    ];
-
-    const META_COLUMNS = [
-        'size', 'width', 'height', 'duration', 'mime_type', 'last_modified',
+        'id', 'container', 'folder', 'basename', 'filename', 'extension', 'path', 'size', 'width', 'height', 'duration', 'mime_type', 'last_modified', 'created_at', 'updated_at',
     ];
 
     protected function column($column)
     {
-        if (in_array($column, self::META_COLUMNS)) {
+        if (! in_array($column, self::COLUMNS)) {
             $column = 'meta->'.$column;
-        } elseif (! in_array($column, self::COLUMNS)) {
-            $column = 'meta->data->'.$column;
         }
 
         return $column;

--- a/src/Updates/AddMetaColumnsToAssetsTable.php
+++ b/src/Updates/AddMetaColumnsToAssetsTable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddMetaColumnsToAssetsTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        $assetsTable = config('statamic.eloquent-driver.table_prefix', '').'assets';
+
+        return Schema::hasTable($assetsTable) && ! Schema::hasColumn($assetsTable, 'size');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/updates/add_meta_columns_to_assets_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_add_meta_columns_to_assets_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -72,7 +72,9 @@ class AssetTest extends TestCase
             'basename' => 'test.jpg',
             'filename' => 'test',
             'extension' => 'jpg',
-            'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
+            'meta' => ['focus' => '50-50-1'],
+            'width' => 100,
+            'height' => 100,
         ]);
 
         $asset = (new Asset)->fromModel($model);
@@ -83,7 +85,7 @@ class AssetTest extends TestCase
         $this->assertSame('test.jpg', $asset->basename());
         $this->assertSame('test', $asset->filename());
         $this->assertSame('jpg', $asset->extension());
-        $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
+        $this->assertSame(['data' => ['focus' => '50-50-1'], 'height' => 100, 'width' => 100], $asset->meta());
     }
 
     #[Test]
@@ -96,7 +98,12 @@ class AssetTest extends TestCase
             'basename' => 'test.jpg',
             'filename' => 'test',
             'extension' => 'jpg',
-            'meta' => ['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']],
+            'meta' => ['focus' => '50-50-1'],
+            'width' => 100,
+            'height' => 100,
+            'last_modified' => $lastModified = time(),
+            'mime_type' => 'image/jpeg',
+            'size' => 1000,
         ]);
 
         $model->save();
@@ -109,7 +116,7 @@ class AssetTest extends TestCase
         $this->assertSame('test.jpg', $asset->basename());
         $this->assertSame('test', $asset->filename());
         $this->assertSame('jpg', $asset->extension());
-        $this->assertSame(['width' => 100, 'height' => 100, 'data' => ['focus' => '50-50-1']], $asset->meta());
+        $this->assertSame(['data' => ['focus' => '50-50-1'], 'height' => 100, 'last_modified' => $lastModified, 'mime_type' => 'image/jpeg', 'size' => 1000, 'width' => 100], $asset->meta());
     }
 
     #[Test]
@@ -168,11 +175,9 @@ class AssetTest extends TestCase
     {
         $this->assertCount(6, AssetModel::all());
 
-        Storage::disk('test')->put('f.jpg', '');
+        Storage::disk('test')->put('test.jpg', '');
 
         $asset = Facades\Asset::make()->container('test')->path('test.jpg');
-        $this->assertCount(6, AssetModel::all());
-
         $asset->save();
 
         $this->assertInstanceOf(AssetModel::class, $asset->model());
@@ -199,7 +204,7 @@ class AssetTest extends TestCase
         $this->assertSame($model->basename, $asset->basename());
         $this->assertSame($model->filename, $asset->filename());
         $this->assertSame($model->extension, $asset->extension());
-        $this->assertSame($model->meta, $asset->meta());
+        $this->assertSame($model->meta, $asset->meta()['data']);
         $this->assertSame($modelId, $asset->model()->getKey());
     }
 


### PR DESCRIPTION
This PR splits duration, height, last_modified, mime_type, size and width into their own columns in asset_meta, rather than them being part of the meta JSON.

This also allows us to bring the real `meta` into the root of the meta column, rather than inside a data key.

Related: https://github.com/statamic/eloquent-driver/issues/420