### PR TITLE
Fix ordering assets by integers, floats, and date fields

### DIFF
--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -2,14 +2,14 @@
 
 namespace Statamic\Eloquent\Assets;
 
-use Statamic\Facades;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Assets\AssetCollection;
+use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Contracts\Assets\QueryBuilder;
+use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Query\EloquentQueryBuilder;
-use Statamic\Contracts\Assets\AssetContainer;
 
 class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {

--- a/src/Assets/AssetQueryBuilder.php
+++ b/src/Assets/AssetQueryBuilder.php
@@ -2,8 +2,11 @@
 
 namespace Statamic\Eloquent\Assets;
 
+use Illuminate\Support\Str;
 use Statamic\Assets\AssetCollection;
 use Statamic\Contracts\Assets\QueryBuilder;
+use Statamic\Facades\Collection;
+use Statamic\Fields\Field;
 use Statamic\Query\EloquentQueryBuilder;
 
 class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
@@ -15,6 +18,88 @@ class AssetQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     const META_COLUMNS = [
         'size', 'width', 'height', 'duration', 'mime_type', 'last_modified',
     ];
+
+    public function orderBy($column, $direction = 'asc')
+    {
+        $actualColumn = $this->column($column);
+
+        if (Str::contains($actualColumn, 'meta->')) {
+            $wheres = collect($this->builder->getQuery()->wheres);
+
+            if ($wheres->where('column', 'container')->count() == 1) {
+                $containerWhere = $wheres->firstWhere('column', 'container');
+                if (isset($containerWhere['values']) && count($containerWhere['values']) == 1) {
+                    $containerWhere['value'] = $containerWhere['values'][0];
+                }
+
+                if (isset($containerWhere['value'])) {
+                    // todo: the entryquerybuilder expects value to be a string, but here it seems to be an AssetContainer instance
+                    if ($container = $containerWhere['value']) {
+                        $blueprintField = $container->blueprint()->fields()->all()
+                            ->filter(fn ($field) => in_array($field->type(), ['float', 'integer', 'date']))
+                            ->filter()
+                            ->merge(['size' => new Field('size', ['type' => 'integer'])])
+                            ->get($column);
+
+                        if ($blueprintField) {
+                            $castType = '';
+                            $fieldType = $blueprintField->type();
+
+                            $grammar = $this->builder->getConnection()->getQueryGrammar();
+                            $actualColumn = $grammar->wrap($actualColumn);
+
+                            if (in_array($fieldType, ['float'])) {
+                                $castType = 'float';
+                            } elseif (in_array($fieldType, ['integer'])) {
+                                $castType = 'float'; // bit sneaky but mysql doesnt support casting as integer, it wants unsigned
+                            } elseif (in_array($fieldType, ['date'])) {
+                                // Take time into account when enabled
+                                if ($blueprintField->get('time_enabled')) {
+                                    $castType = 'datetime';
+                                } else {
+                                    $castType = 'date';
+                                }
+
+                                // take range into account
+                                if ($blueprintField->get('mode') == 'range') {
+                                    $actualColumnStartDate = $grammar->wrap($this->column($column).'->start');
+                                    $actualColumnEndDate = $grammar->wrap($this->column($column).'->end');
+                                    if (str_contains(get_class($grammar), 'SQLiteGrammar')) {
+                                        $this->builder
+                                            ->orderByRaw("datetime({$actualColumnStartDate}) {$direction}")
+                                            ->orderByRaw("datetime({$actualColumnEndDate}) {$direction}");
+                                    } else {
+                                        $this->builder
+                                            ->orderByRaw("cast({$actualColumnStartDate} as {$castType}) {$direction}")
+                                            ->orderByRaw("cast({$actualColumnEndDate} as {$castType}) {$direction}");
+                                    }
+
+                                    return $this;
+                                }
+
+                                // sqlite casts dates to year, which is pretty unhelpful
+                                if (str_contains(get_class($grammar), 'SQLiteGrammar')) {
+                                    $this->builder->orderByRaw("datetime({$actualColumn}) {$direction}");
+
+                                    return $this;
+                                }
+                            }
+
+                            if ($castType) {
+                                $this->builder->orderByRaw("cast({$actualColumn} as {$castType}) {$direction}");
+
+                                return $this;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        parent::orderBy($column, $direction);
+
+        return $this;
+    }
 
     protected function column($column)
     {

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -509,6 +509,101 @@ class AssetQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function assets_can_be_ordered_by_an_integer_json_column()
+    {
+        $blueprint = Blueprint::makeFromFields(['integer' => ['type' => 'integer']]);
+        Blueprint::shouldReceive('find')->with('assets/test')->andReturn($blueprint);
+
+        Asset::find('test::a.jpg')->data(['integer' => 3])->save();
+        Asset::find('test::b.txt')->data(['integer' => 5])->save();
+        Asset::find('test::c.txt')->data(['integer' => 1])->save();
+        Asset::find('test::d.jpg')->data(['integer' => 35])->save();
+        Asset::find('test::e.jpg')->data(['integer' => 20])->save();
+        Asset::find('test::f.jpg')->data(['integer' => 12])->save();
+
+        $assets = Asset::query()->where('container', 'test')->orderBy('integer', 'asc')->get();
+
+        $this->assertCount(6, $assets);
+        $this->assertEquals(['c', 'a', 'b', 'f', 'e', 'd'], $assets->map->filename()->all());
+    }
+
+    #[Test]
+    public function assets_can_be_ordered_by_a_float_json_column()
+    {
+        $blueprint = Blueprint::makeFromFields(['float' => ['type' => 'float']]);
+        Blueprint::shouldReceive('find')->with('assets/test')->andReturn($blueprint);
+
+        Asset::find('test::a.jpg')->data(['float' => 3.3])->save();
+        Asset::find('test::b.txt')->data(['float' => 5.5])->save();
+        Asset::find('test::c.txt')->data(['float' => 1.1])->save();
+        Asset::find('test::d.jpg')->data(['float' => 35.5])->save();
+        Asset::find('test::e.jpg')->data(['float' => 20.0])->save();
+        Asset::find('test::f.jpg')->data(['float' => 12.2])->save();
+
+        $assets = Asset::query()->where('container', 'test')->orderBy('float', 'asc')->get();
+
+        $this->assertCount(6, $assets);
+        $this->assertEquals(['c', 'a', 'b', 'f', 'e', 'd'], $assets->map->filename()->all());
+    }
+
+    #[Test]
+    public function assets_can_be_ordered_by_a_date_json_field()
+    {
+        $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => true]]);
+        Blueprint::shouldReceive('find')->with('assets/test')->andReturn($blueprint);
+
+        Asset::find('test::a.jpg')->data(['date_field' => '2021-06-15 20:31:04'])->save();
+        Asset::find('test::b.txt')->data(['date_field' => '2021-01-13 20:31:04'])->save();
+        Asset::find('test::c.txt')->data(['date_field' => '2021-11-17 20:31:04'])->save();
+        Asset::find('test::d.jpg')->data(['date_field' => '2023-01-01 20:31:04'])->save();
+        Asset::find('test::e.jpg')->data(['date_field' => '2025-01-01 20:31:04'])->save();
+        Asset::find('test::f.jpg')->data(['date_field' => '2024-01-01 20:31:04'])->save();
+
+        $assets = Asset::query()->where('container', 'test')->orderBy('date_field', 'asc')->get();
+
+        $this->assertCount(6, $assets);
+        $this->assertEquals(['b', 'a', 'c', 'd', 'f', 'e'], $assets->map->filename()->all());
+    }
+
+    #[Test]
+    public function assets_can_be_ordered_by_a_datetime_range_json_field()
+    {
+        $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => true, 'mode' => 'range']]);
+        Blueprint::shouldReceive('find')->with('assets/test')->andReturn($blueprint);
+
+        Asset::find('test::a.jpg')->data(['date_field' => ['start' => '2021-06-15 20:31:04', 'end' => '2021-06-15 21:00:00']])->save();
+        Asset::find('test::b.txt')->data(['date_field' => ['start' => '2021-01-13 20:31:04', 'end' => '2021-06-16 20:31:04']])->save();
+        Asset::find('test::c.txt')->data(['date_field' => ['start' => '2021-11-17 20:31:04', 'end' => '2021-11-17 20:31:04']])->save();
+        Asset::find('test::d.jpg')->data(['date_field' => ['start' => '2021-06-15 20:31:04', 'end' => '2021-06-15 22:00:00']])->save();
+        Asset::find('test::e.jpg')->data(['date_field' => ['start' => '2024-06-15 20:31:04', 'end' => '2024-06-15 22:00:00']])->save();
+        Asset::find('test::f.jpg')->data(['date_field' => ['start' => '2025-06-15 20:31:04', 'end' => '2025-06-15 22:00:00']])->save();
+
+        $assets = Asset::query()->where('container', 'test')->orderBy('date_field', 'asc')->get();
+
+        $this->assertCount(6, $assets);
+        $this->assertEquals(['b', 'a', 'd', 'c', 'e', 'f'], $assets->map->filename()->all());
+    }
+
+    #[Test]
+    public function assets_can_be_ordered_by_a_date_range_json_field()
+    {
+        $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => false, 'mode' => 'range']]);
+        Blueprint::shouldReceive('find')->with('assets/test')->andReturn($blueprint);
+
+        Asset::find('test::a.jpg')->data(['date_field' => ['start' => '2021-06-15', 'end' => '2021-06-15']])->save();
+        Asset::find('test::b.txt')->data(['date_field' => ['start' => '2021-01-13', 'end' => '2021-06-16']])->save();
+        Asset::find('test::c.txt')->data(['date_field' => ['start' => '2021-11-17', 'end' => '2021-11-17']])->save();
+        Asset::find('test::d.jpg')->data(['date_field' => ['start' => '2021-06-15', 'end' => '2021-06-15']])->save();
+        Asset::find('test::e.jpg')->data(['date_field' => ['start' => '2024-06-15', 'end' => '2024-06-15']])->save();
+        Asset::find('test::f.jpg')->data(['date_field' => ['start' => '2025-06-15', 'end' => '2025-06-15']])->save();
+
+        $assets = Asset::query()->where('container', 'test')->orderBy('date_field', 'asc')->get();
+
+        $this->assertCount(6, $assets);
+        $this->assertEquals(['b', 'a', 'd', 'c', 'e', 'f'], $assets->map->filename()->all());
+    }
+
+    #[Test]
     public function it_can_get_assets_using_when()
     {
         $assets = Asset::query()->when(true, function ($query) {

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -764,7 +764,7 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
-    public function entries_can_be_ordered_by_an_float_json_field()
+    public function entries_can_be_ordered_by_a_float_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['float' => ['type' => 'float']]);
         Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
@@ -781,7 +781,7 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
-    public function entries_can_be_ordered_by_an_date_json_field()
+    public function entries_can_be_ordered_by_a_date_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => true]]);
         Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
@@ -808,6 +808,7 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'date_field' => ['start' => '2021-01-13 20:31:04', 'end' => '2021-06-16 20:31:04']])->create();
         EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'date_field' => ['start' => '2021-11-17 20:31:04', 'end' => '2021-11-17 20:31:04']])->create();
         EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'date_field' => ['start' => '2021-06-15 20:31:04', 'end' => '2021-06-15 22:00:00']])->create();
+
         $entries = Entry::query()->where('collection', 'posts')->orderBy('date_field', 'asc')->get();
 
         $this->assertCount(4, $entries);


### PR DESCRIPTION
This pull request aims to fix an issue when ordering assets by integers, floats, dates, where the Eloquent Driver would consider the ints/floats/dates as strings, and order alphabetically, rather than numerically.

This PR takes a similar approach to #154 which fixed the same issue for entries, but I've refactored the logic to make it slightly tidier.

Fixes #420.
Replaces #486.