### PR TITLE
Use `QueriesJsonColumns` trait in entry query builder

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -220,7 +220,9 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             return [];
         }
 
-        $collection = Collection::find($collectionWhere['value']);
+        if (! ($collection = Collection::find($collectionWhere['value']))) {
+            return [];
+        }
 
         return $collection->entryBlueprints()
             ->flatMap(function ($blueprint) {

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Eloquent\Entries;
 
+use Illuminate\Support\Collection as IlluminateCollection;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Eloquent\Entries\Entry as EloquentEntry;
@@ -15,13 +16,12 @@ use Statamic\Fields\Field;
 use Statamic\Query\EloquentQueryBuilder;
 use Statamic\Stache\Query\QueriesEntryStatus;
 use Statamic\Stache\Query\QueriesTaxonomizedEntries;
-use Illuminate\Support\Collection as IlluminateCollection;
 
 class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
 {
     use QueriesEntryStatus,
-        QueriesTaxonomizedEntries,
-        QueriesJsonColumns;
+        QueriesJsonColumns,
+        QueriesTaxonomizedEntries;
 
     private $selectedQueryColumns;
 

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -216,11 +216,11 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         $wheres = collect($this->builder->getQuery()->wheres);
         $collectionWhere = $wheres->firstWhere('column', 'collection');
 
-        if (! $collectionWhere || ! isset($collectionWhere['value'])) {
-            return [];
-        }
-
-        if (! ($collection = Collection::find($collectionWhere['value']))) {
+        if (
+            ! $collectionWhere
+            || ! isset($collectionWhere['value'])
+            || ! ($collection = Collection::find($collectionWhere['value']))
+        ) {
             return [];
         }
 

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -764,7 +764,7 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
-    public function entries_can_be_ordered_by_an_float_json_field()
+    public function entries_can_be_ordered_by_a_float_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['float' => ['type' => 'float']]);
         Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
@@ -781,7 +781,7 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
-    public function entries_can_be_ordered_by_an_date_json_field()
+    public function entries_can_be_ordered_by_a_date_json_field()
     {
         $blueprint = Blueprint::makeFromFields(['date_field' => ['type' => 'date', 'time_enabled' => true]]);
         Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));


### PR DESCRIPTION
The `QueriesJsonColumns` trait was introduced in #487. This pull request refactors the `EntryQueryBuilder` to use it to save duplicating logic between the two places.