### PR TITLE
Load model from config

### DIFF
--- a/database/migrations/updates/add_order_to_sites_table.php.stub
+++ b/database/migrations/updates/add_order_to_sites_table.php.stub
@@ -13,7 +13,7 @@ return new class extends Migration {
         });
 
         $count = 0;
-        app('statamic.eloquent.sites.model')::all()
+        config('statamic.eloquent-driver.sites.model')::all()
             ->each(function ($siteModel) use (&$count) {
                 $siteModel->order = ++$count;
                 $siteModel->save();


### PR DESCRIPTION
When the sites driver is kept on file and this migration gets added to your project the following error occurs when running the migrations.

<img width="1205" height="454" alt="Screenshot 2025-08-27 at 13 42 28" src="https://github.com/user-attachments/assets/7cde8b6a-9c6c-4bcf-9fcd-d53381c61baa" />

This is correct because the model is only binded on the app if the sites driver is configured as eloquent.

<img width="726" height="240" alt="Screenshot 2025-08-27 at 13 45 00" src="https://github.com/user-attachments/assets/2f9071ea-3699-4f66-b3a7-1374a292fd02" />

I changed the migration to use the model from the config instead, this way it's always available.