### PR TITLE
Fix speed regression on model status query by going through eloquent model

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -145,7 +145,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         // If no IDs were queried, fall back to all collections.
         $ids->isEmpty()
             ? $this->whereIn('collection', Collection::handles())
-            : $this->whereIn('collection', app(static::class)->whereIn('id', $ids)->pluck('collection')->map(fn ($collection) => $collection?->handle)->filter()->unique()->values());
+            : $this->whereIn('collection', app('statamic.eloquent.entries.model')::query()->whereIn('id', $ids)->distinct('collection')->pluck('collection')->values());
     }
 
     private function getCollectionsForStatusQuery(): \Illuminate\Support\Collection


### PR DESCRIPTION
[491](https://github.com/statamic/eloquent-driver/pull/491) caused speed regressions on some installs due to how pluck() is now taking place in core's eloquent base model.

This PR works around that by going through the model's query builder.