### PR TITLE
Require spatie/laravel-ray in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "doctrine/dbal": "^3.8",
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
-        "phpunit/phpunit": "^10.5.35 || ^11.0"
+        "phpunit/phpunit": "^10.5.35 || ^11.0",
+        "spatie/laravel-ray": "^1.40"
     },
     "scripts": {
         "test": "phpunit"


### PR DESCRIPTION
We use [Ray](https://spatie.be/products/ray) often during development. 

This pull request requires the `spatie/laravel-ray` package, allowing us to use `ray()` in our tests. It's already a dev dependency on `cms`.