### PR TITLE
Updates form_submission migration stubs to match the package migrations 

### DIFF
--- a/database/migrations/updates/relate_form_submissions_by_handle.php.stub
+++ b/database/migrations/updates/relate_form_submissions_by_handle.php.stub
@@ -14,7 +14,7 @@ return new class extends Migration {
         }
 
         Schema::table($this->prefix('form_submissions'), function (Blueprint $table) {
-            $table->string('form', 30)->nullable()->index()->after('id');
+            $table->string('form')->nullable()->index()->after('id');
         });
 
         $forms = FormModel::all()->pluck('handle', 'id');


### PR DESCRIPTION
After republishing the from migrations the character limit was removed resulting in a varchar(255) string column.

I kind of feel like there's no need to replicate this migration change in the packaged migrations since it's not presently there.

This fix should address anyone who's newly installed the package and who's freshly published the migrations.

closes #502 
ref #503