### PR TITLE
[5.x] Always bind models

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -485,7 +485,7 @@ class ServiceProvider extends AddonServiceProvider
         if (config('statamic.eloquent-driver.revisions.driver', 'file') != 'eloquent') {
             return;
         }
-        
+
         $this->app->bind(RevisionQueryBuilder::class, function ($app) {
             return new RevisionQueryBuilder(
                 $app['statamic.eloquent.revisions.model']::query()


### PR DESCRIPTION
This PR updates the service provider behaviour to always bind models, which ensures imports/exports will continue to work regardless of configuration settings.

Closes https://github.com/statamic/eloquent-driver/issues/519