### PR TITLE
Fix taxonomy default blueprint where namespace is null

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -228,11 +228,8 @@ class BlueprintRepository extends StacheRepository
         $eloquentNamespaces = config('statamic.eloquent-driver.blueprints.namespaces', 'all');
 
         if ($eloquentNamespaces !== 'all') {
-            if (! $namespace) {
-                return false;
-            }
 
-            if (! in_array($namespace, Arr::wrap($eloquentNamespaces))) {
+            if ($namespace && ! in_array($namespace, Arr::wrap($eloquentNamespaces))) {
                 return false;
             }
         }


### PR DESCRIPTION
I reported a [bug](https://github.com/statamic/importer/issues/120) in the statamic importer, but it's an eloquent related problem. It's also causing the a problem in the overview of taxonomies (/cp/taxonomies) with the same error.
I created a pull request for a small fix.
