### PR TITLE
[4.x] Fix exporting when using UUIDs

### DIFF
--- a/src/Commands/ExportEntries.php
+++ b/src/Commands/ExportEntries.php
@@ -73,21 +73,21 @@ class ExportEntries extends Command
             return ! $model->origin_id;
         });
 
-        if ($entriesWithOrigin->count() > 0) {
+        if ($entriesWithoutOrigin->count() > 0) {
             $this->info('Exporting origin entries');
         }
 
         $this->withProgressBar($entriesWithoutOrigin, function ($model) {
             $entry = Entry::make()
+                ->collection($model->collection)
                 ->locale($model->site)
                 ->slug($model->slug)
-                ->collection($model->collection)
                 ->data($model->data)
                 ->blueprint($model->blueprint)
                 ->template($model->data['template'] ?? null)
                 ->published($model->published);
 
-            if (in_array(HasUuids::class, class_uses_recursive($model))) {
+            if ($model->getKeyType() == 'string' || in_array(HasUuids::class, class_uses_recursive($model))) {
                 $entry->id($model->getKey());
             }
 
@@ -107,15 +107,20 @@ class ExportEntries extends Command
             $this->info('Exporting localized entries');
 
             $this->withProgressBar($entriesWithOrigin, function ($model) {
+
                 $entry = Entry::make()
+                    ->collection($model->collection)
                     ->origin($model->origin_id)
                     ->locale($model->site)
                     ->slug($model->slug)
-                    ->collection($model->collection)
                     ->data($model->data)
                     ->blueprint($model->data['blueprint'] ?? null)
                     ->template($model->data['template'] ?? null)
                     ->published($model->published);
+
+                if ($model->getKeyType() == 'string' || in_array(HasUuids::class, class_uses_recursive($model))) {
+                    $entry->id($model->getKey());
+                }
 
                 if ($model->date && $entry->collection()->dated()) {
                     $entry->date($model->date);


### PR DESCRIPTION
Looks like we've had a regression along then line with exporting UUID entries, as their IDs were not being set correctly. This PR fixes that.

Closes https://github.com/statamic/eloquent-driver/issues/523