### PR TITLE
Fix taxonomy null caching and ensure taxonomy column in term queries

### DIFF
--- a/src/Taxonomies/TaxonomyRepository.php
+++ b/src/Taxonomies/TaxonomyRepository.php
@@ -40,11 +40,18 @@ class TaxonomyRepository extends StacheRepository
 
     public function findByHandle($handle): ?TaxonomyContract
     {
-        $taxonomyModel = Blink::once("eloquent-taxonomies-{$handle}", function () use ($handle) {
+        $blinkKey = "eloquent-taxonomies-{$handle}";
+        $taxonomyModel = Blink::once($blinkKey, function () use ($handle) {
             return app('statamic.eloquent.taxonomies.model')::whereHandle($handle)->first();
         });
 
-        return $taxonomyModel instanceof Model ? app(TaxonomyContract::class)->fromModel($taxonomyModel) : null;
+        if (! $taxonomyModel instanceof Model) {
+            Blink::forget($blinkKey);
+
+            return null;
+        }
+
+        return app(TaxonomyContract::class)->fromModel($taxonomyModel);
     }
 
     public function findByUri(string $uri, ?string $site = null): ?Taxonomy

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -174,6 +174,11 @@ class TermQueryBuilder extends EloquentQueryBuilder
     {
         $this->applyCollectionAndTaxonomyWheres();
 
+        // Ensure 'taxonomy' is always selected as it's required for Term::fromModel().
+        if (! in_array('*', $columns) && ! in_array('taxonomy', $columns)) {
+            $columns[] = 'taxonomy';
+        }
+
         $items = parent::get($columns);
 
         // If a single collection has been queried, we'll supply it to the terms so
@@ -211,6 +216,11 @@ class TermQueryBuilder extends EloquentQueryBuilder
     public function paginate($perPage = null, $columns = [], $pageName = 'page', $page = null)
     {
         $this->applyCollectionAndTaxonomyWheres();
+
+        // Ensure 'taxonomy' is always selected as it's required for Term::fromModel().
+        if (! empty($columns) && ! in_array('*', $columns) && ! in_array('taxonomy', $columns)) {
+            $columns[] = 'taxonomy';
+        }
 
         return parent::paginate($perPage, $columns, $pageName, $page);
     }


### PR DESCRIPTION
## Summary
- Fix `TaxonomyRepository::findByHandle()` to forget Blink cache when taxonomy is not found (prevents stale null caching)
- Ensure `taxonomy` column is always selected in `TermQueryBuilder::get()` and `paginate()` methods

Fixes #528