### PR TITLE
Only publish global variables origin migration when table exists

### DIFF
--- a/src/Updates/DropOriginOnGlobalSetVariables.php
+++ b/src/Updates/DropOriginOnGlobalSetVariables.php
@@ -2,13 +2,17 @@
 
 namespace Statamic\Eloquent\Updates;
 
+use Illuminate\Support\Facades\Schema;
 use Statamic\UpdateScripts\UpdateScript;
 
 class DropOriginOnGlobalSetVariables extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('5.0.0');
+        $globalSetVariablesTable = config('statamic.eloquent-driver.table_prefix', '').'global_set_variables';
+
+        return $this->isUpdatingTo('5.0.0')
+            && Schema::hasTable($globalSetVariablesTable) && Schema::hasColumn($globalSetVariablesTable, 'origin');
     }
 
     public function update()


### PR DESCRIPTION
This pull request fixes an issue where the `drop_origin_on_global_set_variables` migration would be published, even if the `global_set_variables` table doesn't exist.

Related: https://github.com/statamic/cms/discussions/13856