### PR TITLE
Run GitHub Actions workflows only once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
When creating a pull request from a branch within the same repo (not a fork), the testing workflow is triggered twice - once for `push` and once for `pull_request`.

This PR adds constraints to ensure the workflow only runs once.