### PR TITLE
Fix and improve asset and collection export commands

### DIFF
--- a/src/Commands/ExportAssets.php
+++ b/src/Commands/ExportAssets.php
@@ -5,7 +5,6 @@ namespace Statamic\Eloquent\Commands;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Str;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainer;
 use Statamic\Assets\AssetRepository;
@@ -45,20 +44,18 @@ class ExportAssets extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $this->usingDefaultRepositories(function () {
             $this->exportAssetContainers();
             $this->exportAssets();
         });
 
-        return 0;
+        return self::SUCCESS;
     }
 
-    private function usingDefaultRepositories(Closure $callback)
+    private function usingDefaultRepositories(Closure $callback): void
     {
         Facade::clearResolvedInstance(AssetContainerRepositoryContract::class);
         Facade::clearResolvedInstance(AssetRepositoryContract::class);
@@ -102,13 +99,10 @@ class ExportAssets extends Command
         $assets = AssetModel::all();
 
         $this->withProgressBar($assets, function ($model) {
-            $container = Str::before($model->handle, '::');
-            $path = Str::after($model->handle, '::');
-
             AssetFacade::make()
-                ->container($container)
-                ->path($path)
-                ->writeMeta($model->data);
+                ->container($model->container)
+                ->path($model->path)
+                ->writeMeta($model->meta);
         });
 
         $this->newLine();

--- a/src/Commands/ExportAssets.php
+++ b/src/Commands/ExportAssets.php
@@ -30,7 +30,11 @@ class ExportAssets extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:eloquent:export-assets {--force : Force the export to run, with all prompts answered "yes"}';
+    protected $signature = 'statamic:eloquent:export-assets
+        {--force : Force the export to run, with all prompts answered "yes"}
+        {--only-asset-containers : Only export asset containers}
+        {--only-assets : Only export assets}
+    ';
 
     /**
      * The console command description.
@@ -68,9 +72,9 @@ class ExportAssets extends Command
         $callback();
     }
 
-    private function exportAssetContainers()
+    private function exportAssetContainers(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export asset containers?')) {
+        if (! $this->shouldExportAssetContainers()) {
             return;
         }
 
@@ -89,9 +93,9 @@ class ExportAssets extends Command
         $this->info('Asset containers imported');
     }
 
-    private function exportAssets()
+    private function exportAssets(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export assets?')) {
+        if (! $this->shouldExportAssets()) {
             return;
         }
 
@@ -109,5 +113,19 @@ class ExportAssets extends Command
 
         $this->newLine();
         $this->info('Assets imported');
+    }
+
+    private function shouldExportAssetContainers(): bool
+    {
+        return $this->option('only-asset-containers')
+            || ! $this->option('only-assets')
+            && ($this->option('force') || $this->confirm('Do you want to export asset containers?'));
+    }
+
+    private function shouldExportAssets(): bool
+    {
+        return $this->option('only-assets')
+            || ! $this->option('only-asset-containers')
+            && ($this->option('force') || $this->confirm('Do you want to export assets?'));
     }
 }

--- a/src/Commands/ExportAssets.php
+++ b/src/Commands/ExportAssets.php
@@ -83,6 +83,7 @@ class ExportAssets extends Command
                 ->handle($model->handle)
                 ->disk($model->disk ?? config('filesystems.default'))
                 ->searchIndex($model->settings['search_index'] ?? null)
+                ->sourcePreset($model->settings['source_preset'] ?? null)
                 ->save();
         });
 

--- a/src/Commands/ExportCollections.php
+++ b/src/Commands/ExportCollections.php
@@ -46,8 +46,11 @@ class ExportCollections extends Command
      */
     public function handle(): int
     {
-        $this->usingDefaultRepositories(function () {
+        $this->usingDefaultCollectionRepositories(function () {
             $this->exportCollections();
+        });
+
+        $this->usingDefaultCollectionTreeRepositories(function () {
             $this->exportCollectionTrees();
         });
 
@@ -57,16 +60,37 @@ class ExportCollections extends Command
         return self::SUCCESS;
     }
 
-    private function usingDefaultRepositories(Closure $callback): void
+    private function usingDefaultCollectionRepositories(Closure $callback): void
     {
+        $originalRepo = get_class(app()->make(CollectionRepositoryContract::class));
+        $originalCollection = get_class(app()->make(CollectionContract::class));
+
         Facade::clearResolvedInstance(CollectionRepositoryContract::class);
-        Facade::clearResolvedInstance(CollectionTreeRepositoryContract::class);
 
         Statamic::repository(CollectionRepositoryContract::class, CollectionRepository::class);
-        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
         app()->bind(CollectionContract::class, EloquentCollection::class);
 
         $callback();
+
+        Statamic::repository(CollectionRepositoryContract::class, $originalRepo);
+        app()->bind(CollectionContract::class, $originalCollection);
+
+        Facade::clearResolvedInstance(CollectionRepositoryContract::class);
+    }
+
+    private function usingDefaultCollectionTreeRepositories(Closure $callback): void
+    {
+        $originalTreeRepo = get_class(app()->make(CollectionTreeRepositoryContract::class));
+
+        Facade::clearResolvedInstance(CollectionTreeRepositoryContract::class);
+
+        Statamic::repository(CollectionTreeRepositoryContract::class, CollectionTreeRepository::class);
+
+        $callback();
+
+        Statamic::repository(CollectionTreeRepositoryContract::class, $originalTreeRepo);
+
+        Facade::clearResolvedInstance(CollectionTreeRepositoryContract::class);
     }
 
     private function exportCollections(): void

--- a/src/Commands/ExportCollections.php
+++ b/src/Commands/ExportCollections.php
@@ -29,7 +29,10 @@ class ExportCollections extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:eloquent:export-collections {--force : Force the export to run, with all prompts answered "yes"}';
+    protected $signature = 'statamic:eloquent:export-collections
+        {--force : Force the export to run, with all prompts answered "yes"}
+        {--only-collections : Only export collections}
+        {--only-collection-trees : Only export collection trees}';
 
     /**
      * The console command description.
@@ -40,10 +43,8 @@ class ExportCollections extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $this->usingDefaultRepositories(function () {
             $this->exportCollections();
@@ -53,10 +54,10 @@ class ExportCollections extends Command
         $this->newLine();
         $this->info('Collections exported');
 
-        return 0;
+        return self::SUCCESS;
     }
 
-    private function usingDefaultRepositories(Closure $callback)
+    private function usingDefaultRepositories(Closure $callback): void
     {
         Facade::clearResolvedInstance(CollectionRepositoryContract::class);
         Facade::clearResolvedInstance(CollectionTreeRepositoryContract::class);
@@ -68,9 +69,9 @@ class ExportCollections extends Command
         $callback();
     }
 
-    private function exportCollections()
+    private function exportCollections(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export collections?')) {
+        if (! $this->shouldExportCollections()) {
             return;
         }
 
@@ -109,9 +110,9 @@ class ExportCollections extends Command
         $this->info('Collections exported');
     }
 
-    private function exportCollectionTrees()
+    private function exportCollectionTrees(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export collection trees?')) {
+        if (! $this->shouldExportCollectionTrees()) {
             return;
         }
 
@@ -129,5 +130,19 @@ class ExportCollections extends Command
 
         $this->newLine();
         $this->info('Collection trees exported');
+    }
+
+    private function shouldExportCollections(): bool
+    {
+        return $this->option('only-collections')
+            || ! $this->option('only-collection-trees')
+            && ($this->option('force') || $this->confirm('Do you want to export collections?'));
+    }
+
+    private function shouldExportCollectionTrees(): bool
+    {
+        return $this->option('only-collection-trees')
+            || ! $this->option('only-collections')
+            && ($this->option('force') || $this->confirm('Do you want to export collections trees?'));
     }
 }

--- a/src/Commands/ExportNavs.php
+++ b/src/Commands/ExportNavs.php
@@ -28,7 +28,10 @@ class ExportNavs extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:eloquent:export-navs {--force : Force the export to run, with all prompts answered "yes"}';
+    protected $signature = 'statamic:eloquent:export-navs
+        {--force : Force the export to run, with all prompts answered "yes"}
+        {--only-navs : Only export navigations}
+        {--only-nav-trees : Only export navigation trees}';
 
     /**
      * The console command description.
@@ -39,20 +42,18 @@ class ExportNavs extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $this->usingDefaultRepositories(function () {
             $this->exportNavs();
             $this->exportNavTrees();
         });
 
-        return 0;
+        return self::SUCCESS;
     }
 
-    private function usingDefaultRepositories(Closure $callback)
+    private function usingDefaultRepositories(Closure $callback): void
     {
         Facade::clearResolvedInstance(NavigationRepositoryContract::class);
         Facade::clearResolvedInstance(NavTreeRepositoryContract::class);
@@ -66,16 +67,16 @@ class ExportNavs extends Command
         $callback();
     }
 
-    private function exportNavs()
+    private function exportNavs(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export navs?')) {
+        if (! $this->shouldExportNavigations()) {
             return;
         }
 
         $navs = NavModel::all();
 
         $this->withProgressBar($navs, function ($model) {
-            $nav = NavFacade::make()
+            NavFacade::make()
                 ->handle($model->handle)
                 ->title($model->title)
                 ->collections($model->settings['collections'] ?? null)
@@ -88,9 +89,9 @@ class ExportNavs extends Command
         $this->info('Navs exported');
     }
 
-    private function exportNavTrees()
+    private function exportNavTrees(): void
     {
-        if (! $this->option('force') && ! $this->confirm('Do you want to export nav trees?')) {
+        if (! $this->shouldExportNavigationTrees()) {
             return;
         }
 
@@ -112,5 +113,19 @@ class ExportNavs extends Command
 
         $this->newLine();
         $this->info('Nav trees exported');
+    }
+
+    private function shouldExportNavigations(): bool
+    {
+        return $this->option('only-navs')
+            || ! $this->option('only-nav-trees')
+            && ($this->option('force') || $this->confirm('Do you want to export navs?'));
+    }
+
+    private function shouldExportNavigationTrees(): bool
+    {
+        return $this->option('only-nav-trees')
+            || ! $this->option('only-navs')
+            && ($this->option('force') || $this->confirm('Do you want to export nav trees?'));
     }
 }


### PR DESCRIPTION
Fixed several issues and improved flexibility for data import and export commands.

*Import*
- Added `source_preset` to the asset container export

*Export*
- Added support for `--only-asset-containers` and `--only-assets` flags in the assets export command
- Added support for `--only-collections` and `--only-collection-trees` flags in the collection export command
- Added support for `--only-navs` and `--only-nav-trees` flags in the collection export command
- Fixed bug in assets export
- Enabled independent exporting of collection trees. This allows collections to be maintained in static files while their trees are stored in the database (Eloquent).