### PR TITLE
Make taxonomy queries more performant

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -266,4 +266,43 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             ->filter()
             ->unique();
     }
+
+    protected function addTaxonomyWheres()
+    {
+        if (empty($this->taxonomyWheres)) {
+            return;
+        }
+
+        collect($this->taxonomyWheres)
+            ->each(function ($where) {
+                if ($where['type'] === 'Basic') {
+                    [$taxonomy, $term] = explode('::', $where['value']);
+
+                    $this->whereJsonContains($this->column($taxonomy), $term);
+
+                    return;
+                }
+
+                if ($where['type'] === 'In') {
+                    $this->where(function ($query) use ($where) {
+                        foreach ($where['values'] as $value) {
+                            [$taxonomy, $term] = explode('::', $value);
+
+                            $query->orWhereJsonContains($this->column($taxonomy), $term);
+                        }
+                    });
+
+                    return;
+                }
+
+                $this->where(function ($query) use ($where) {
+                    foreach ($where['values'] as $value) {
+                        [$taxonomy, $term] = explode('::', $value);
+
+                        $query->orWhereJsonDoesntContain($this->column($taxonomy), $term);
+                    }
+                });
+
+            });
+    }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Taxonomy;
 use Tests\TestCase;
 
 class EntryQueryBuilderTest extends TestCase
@@ -1085,5 +1086,40 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function it_gets_entries_by_a_single_taxonomy_term()
+    {
+        Taxonomy::make('tags')->save();
+        Collection::make('blog')->taxonomies(['tags'])->save();
+        EntryFactory::collection('blog')->id('1')->data(['tags' => ['rad']])->create();
+        EntryFactory::collection('blog')->id('2')->data(['tags' => ['rad']])->create();
+        EntryFactory::collection('blog')->id('3')->data(['tags' => ['meh']])->create();
+
+        $this->assertEquals(3, Entry::query()->count());
+        $this->assertEquals([1, 2], Entry::query()->whereTaxonomy('tags::rad')->get()->map->id()->all());
+    }
+
+    #[Test]
+    public function it_gets_entries_in_multiple_taxonomy_terms()
+    {
+        Taxonomy::make('tags')->save();
+        Taxonomy::make('categories')->save();
+        Collection::make('blog')->taxonomies(['tags', 'categories'])->save();
+        EntryFactory::collection('blog')->id('1')->data(['tags' => ['rad'], 'categories' => ['news']])->create();
+        EntryFactory::collection('blog')->id('2')->data(['tags' => ['awesome'], 'categories' => ['events']])->create();
+        EntryFactory::collection('blog')->id('3')->data(['tags' => ['rad', 'awesome']])->create();
+        EntryFactory::collection('blog')->id('4')->data(['tags' => ['meh']])->create();
+
+        $this->assertEquals(4, Entry::query()->count());
+        $this->assertEquals([3], Entry::query()->whereTaxonomy('tags::rad')->whereTaxonomy('tags::awesome')->get()->map->id()->all());
+        $this->assertEquals([1], Entry::query()->whereTaxonomy('tags::rad')->whereTaxonomy('categories::news')->get()->map->id()->all());
+        $this->assertEquals(0, Entry::query()->whereTaxonomy('tags::rad')->whereTaxonomy('categories::events')->count());
+        $this->assertEquals([1, 3, 4], Entry::query()->whereTaxonomyIn(['tags::rad', 'tags::meh'])->get()->map->id()->all());
+        $this->assertEquals([1, 2, 3], Entry::query()->whereTaxonomyIn(['tags::rad', 'categories::events'])->get()->map->id()->all());
+        $this->assertEquals([3], Entry::query()->whereTaxonomyIn(['tags::rad', 'tags::meh'])->whereTaxonomy('tags::awesome')->get()->map->id()->all());
+        $this->assertEquals([2], Entry::query()->whereTaxonomyIn(['tags::meh', 'categories::events'])->whereTaxonomy('tags::awesome')->get()->map->id()->all());
+        $this->assertEquals([2], Entry::query()->whereTaxonomyIn(['tags::meh', 'categories::events'])->whereTaxonomyIn(['tags::awesome', 'tags::rad'])->get()->map->id()->all());
     }
 }


### PR DESCRIPTION
As pointed out in #551, entry query builder taxonomy queries could be more performant by avoiding stache associations.

This PR adjusts the logic to perform queries purely on the database layer.

Thanks to @buddy94 for pointing this out.

