### PR TITLE
Make entries count more performant when we use eloquent for terms and entries

### DIFF
--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -3,7 +3,6 @@
 namespace Statamic\Eloquent\Taxonomies;
 
 use Statamic\Contracts\Taxonomies\Term as TermContract;
-use Statamic\Eloquent\Taxonomies\Term;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -140,8 +140,7 @@ class TermRepository extends StacheRepository
             return parent::entriesCount($term, $status);
         }
 
-        $query = Entry::query()
-            ->whereTaxonomy($term->taxonomyHandle().'::'.$term->inDefaultLocale()->slug());
+        $query = Entry::query()->whereTaxonomy($term->inDefaultLocale()->reference());
 
         if ($term instanceof LocalizedTerm) {
             $query->where('site', $term->locale());

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -3,11 +3,14 @@
 namespace Statamic\Eloquent\Taxonomies;
 
 use Statamic\Contracts\Taxonomies\Term as TermContract;
+use Statamic\Eloquent\Taxonomies\Term;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Repositories\TermRepository as StacheRepository;
 use Statamic\Support\Str;
+use Statamic\Taxonomies\LocalizedTerm;
 
 class TermRepository extends StacheRepository
 {
@@ -130,5 +133,29 @@ class TermRepository extends StacheRepository
         }
 
         parent::ensureAssociations();
+    }
+
+    public function entriesCount(TermContract $term, ?string $status = null): int
+    {
+        if (config('statamic.eloquent-driver.entries.driver', 'file') !== 'eloquent') {
+            return parent::entriesCount($term, $status);
+        }
+
+        $query = Entry::query()
+            ->whereTaxonomy($term->taxonomyHandle().'::'.$term->inDefaultLocale()->slug());
+
+        if ($term instanceof LocalizedTerm) {
+            $query->where('site', $term->locale());
+        }
+
+        if ($collection = $term->collection()) {
+            $query->where('collection', $collection->handle());
+        }
+
+        if ($status) {
+            $query->whereStatus($status);
+        }
+
+        return $query->count();
     }
 }

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -140,7 +140,8 @@ class TermRepository extends StacheRepository
             return parent::entriesCount($term, $status);
         }
 
-        $query = Entry::query()->whereTaxonomy($term->inDefaultLocale()->reference());
+        $query = Entry::query()
+            ->whereTaxonomy($term->taxonomyHandle().'::'.$term->inDefaultLocale()->slug());
 
         if ($term instanceof LocalizedTerm) {
             $query->where('site', $term->locale());

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -15,6 +15,7 @@ use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy as TaxonomyFacade;
 use Statamic\Facades\Term as TermFacade;
 use Statamic\Statamic;
+use Statamic\Taxonomies\Term;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -82,6 +83,63 @@ class TermTest extends TestCase
         (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3'])->slug('charlie')->save();
 
         $this->assertEquals(2, TermFacade::entriesCount($term));
+    }
+
+    #[Test]
+    public function it_gets_entry_count_for_term_filtered_by_status()
+    {
+        Taxonomy::make('test')->title('test')->save();
+
+        $term = tap(TermFacade::make('test-term')->taxonomy('test')->data([]))->save();
+
+        $collection = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($collection)->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->published(true)->save();
+        (new Entry)->id(2)->collection($collection)->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->published(false)->save();
+        (new Entry)->id(3)->collection($collection)->data(['title' => 'Post 3', 'test' => ['test-term']])->slug('charlie')->published(false)->save();
+
+        $this->assertEquals(1, TermFacade::entriesCount($term, 'published'));
+        $this->assertEquals(2, TermFacade::entriesCount($term, 'draft'));
+    }
+
+    #[Test]
+    public function it_gets_entry_count_for_term_scoped_to_collection()
+    {
+        Taxonomy::make('test')->title('test')->save();
+
+        $term = tap(TermFacade::make('test-term')->taxonomy('test')->data([]))->save();
+
+        $blog = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->save();
+        $news = Collection::make('news')->routes('news/{slug}')->taxonomies(['test'])->save();
+
+        (new Entry)->id(1)->collection($blog)->data(['title' => 'Blog 1', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($blog)->data(['title' => 'Blog 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($news)->data(['title' => 'News 1', 'test' => ['test-term']])->slug('charlie')->save();
+
+        $this->assertEquals(2, TermFacade::entriesCount(TermFacade::find('test::test-term')->collection($blog)));
+        $this->assertEquals(1, TermFacade::entriesCount(TermFacade::find('test::test-term')->collection($news)));
+    }
+
+    #[Test]
+    public function it_gets_entry_count_for_term_filtered_by_site()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
+        ]);
+
+        Taxonomy::make('test')->title('test')->sites(['en', 'fr'])->save();
+
+        $term = tap(TermFacade::make('test-term')->taxonomy('test')->data([]))->save();
+
+        $collection = Collection::make('blog')->routes('blog/{slug}')->taxonomies(['test'])->sites(['en', 'fr'])->save();
+
+        (new Entry)->id(1)->collection($collection)->locale('en')->data(['title' => 'Post 1', 'test' => ['test-term']])->slug('alfa')->save();
+        (new Entry)->id(2)->collection($collection)->locale('en')->data(['title' => 'Post 2', 'test' => ['test-term']])->slug('bravo')->save();
+        (new Entry)->id(3)->collection($collection)->locale('fr')->data(['title' => 'Post 3', 'test' => ['test-term']])->slug('charlie')->save();
+
+        $this->assertEquals(2, TermFacade::entriesCount($term->in('en')));
+        $this->assertEquals(1, TermFacade::entriesCount($term->in('fr')));
     }
 
     #[Test]

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -15,7 +15,6 @@ use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy as TaxonomyFacade;
 use Statamic\Facades\Term as TermFacade;
 use Statamic\Statamic;
-use Statamic\Taxonomies\Term;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 


### PR DESCRIPTION
When using eloquent for both terms and entries, we can use the database directly for entriesCount() making it much more performant.

Thanks to @buddy94 for highlighting this issue.
