### PR TITLE
Require `spatie/laravel-ray` in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "doctrine/dbal": "^3.8",
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^10.0 || ^11.0",
-        "phpunit/phpunit": "^11.0 || ^12.0"
+        "phpunit/phpunit": "^11.0 || ^12.0",
+        "spatie/laravel-ray": "^1.43"
     },
     "scripts": {
         "test": "phpunit"


### PR DESCRIPTION
This pull request requires `spatie/laravel-ray` - we/I use it all the time during development.