### PR TITLE
Patch postgres orderby fix (c316473) from 5.x into 4.x

### DIFF
--- a/src/QueriesJsonColumns.php
+++ b/src/QueriesJsonColumns.php
@@ -69,6 +69,10 @@ trait QueriesJsonColumns
             default => null,
         };
 
+        if ($cast === 'datetime' && str_contains(get_class($this->builder->getConnection()->getQueryGrammar()), 'PostgresGrammar')) {
+            $cast = 'timestamp';
+        }
+
         // Date Ranges are dealt with a little bit differently.
         if ($field->type() === 'date' && $field->get('mode') === 'range') {
             $cast = "range_{$cast}";


### PR DESCRIPTION
@ryanmitchell patched the bug on 5.x on the same day I was about to raise a PR which was much appreciated! (https://github.com/statamic/eloquent-driver/commit/c316473b9612cff0350c1185337cbd478052cb7f)

However, I've just come to work on an older site on v5 of Statamic, so this change is needed in the older version until we can update to v6.

Thanks as always.