### PR TITLE
Add serializable classes to allowlist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.3",
-        "statamic/cms": "^6.5"
+        "statamic/cms": "^6.10"
     },
     "require-dev": {
         "doctrine/dbal": "^3.8",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -232,6 +232,28 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerTerms();
         $this->registerTokens();
         $this->registerSites();
+
+        $this->registerSerializableClasses([
+            \Statamic\Eloquent\Assets\Asset::class,
+            \Statamic\Eloquent\Assets\AssetModel::class,
+            \Statamic\Eloquent\Collections\Collection::class,
+            \Statamic\Eloquent\Collections\CollectionModel::class,
+            \Statamic\Eloquent\Entries\Entry::class,
+            \Statamic\Eloquent\Entries\EntryModel::class,
+            \Statamic\Eloquent\Entries\UuidEntryModel::class,
+            \Statamic\Eloquent\Forms\Form::class,
+            \Statamic\Eloquent\Forms\FormModel::class,
+            \Statamic\Eloquent\Forms\Submission::class,
+            \Statamic\Eloquent\Forms\SubmissionModel::class,
+            \Statamic\Eloquent\Globals\GlobalSet::class,
+            \Statamic\Eloquent\Globals\GlobalSetModel::class,
+            \Statamic\Eloquent\Globals\Variables::class,
+            \Statamic\Eloquent\Globals\VariablesModel::class,
+            \Statamic\Eloquent\Taxonomies\Taxonomy::class,
+            \Statamic\Eloquent\Taxonomies\TaxonomyModel::class,
+            \Statamic\Eloquent\Taxonomies\Term::class,
+            \Statamic\Eloquent\Taxonomies\TermModel::class,
+        ]);
     }
 
     private function registerAddonSettings()


### PR DESCRIPTION
This pull request adds additional classes to the serializable classes allowlist to support Laravel 13's stricter deserialization security controls.

Laravel 13 introduced a `serializable_classes` configuration option that restricts which classes can be deserialized from the cache. When data objects like `Entry` are cached, they contain a `$model` property holding the corresponding Eloquent model, so both the data object and its model need to be in the allowlist.

Fixes #564
Related: statamic/cms#14416
