### PR TITLE
[6.x] Store term localizations as separate rows 

### DIFF
--- a/database/migrations/2025_07_07_200000_add_origin_to_taxonomy_terms.php
+++ b/database/migrations/2025_07_07_200000_add_origin_to_taxonomy_terms.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix('taxonomy_terms'), function (Blueprint $table) {
+            $table->unsignedBigInteger('origin')->nullable()->after('site');
+            $table->index('origin');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('taxonomy_terms'), function (Blueprint $table) {
+            $table->dropIndex(['origin']);
+            $table->dropColumn('origin');
+        });
+    }
+};

--- a/database/migrations/2025_07_07_300000_move_term_localizations_to_own_rows.php
+++ b/database/migrations/2025_07_07_300000_move_term_localizations_to_own_rows.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $table = $this->prefix('taxonomy_terms');
+
+        DB::table($table)
+            ->whereNull('origin')
+            ->get()
+            ->each(function ($term) use ($table) {
+                $data = json_decode($term->data, true);
+                $localizations = $data['localizations'] ?? [];
+
+                if (empty($localizations)) {
+                    return;
+                }
+
+                unset($data['localizations']);
+
+                DB::table($table)
+                    ->where('id', $term->id)
+                    ->update(['data' => json_encode($data)]);
+
+                foreach ($localizations as $locale => $localeData) {
+                    if ($locale === $term->site) {
+                        continue;
+                    }
+
+                    DB::table($table)->insertOrIgnore([
+                        'site'       => $locale,
+                        'origin'     => $term->id,
+                        'slug'       => $term->slug,
+                        'uri'        => null,
+                        'taxonomy'   => $term->taxonomy,
+                        'data'       => json_encode($localeData),
+                        'created_at' => $term->created_at,
+                        'updated_at' => $term->updated_at,
+                    ]);
+                }
+            });
+    }
+
+    public function down()
+    {
+        // Non-reversible: restoring JSON localizations from rows would require
+        // re-implementing the merge logic, and any rows added after this migration
+        // would be lost. Use a database backup to roll back.
+    }
+};

--- a/src/Commands/ExportTaxonomies.php
+++ b/src/Commands/ExportTaxonomies.php
@@ -97,21 +97,26 @@ class ExportTaxonomies extends Command
             return;
         }
 
-        $terms = EloquentTerm::all();
+        $terms = EloquentTerm::whereNull('origin')->get();
 
-        $this->withProgressBar($terms, function ($model) {
-            $data = $model->data;
+        $this->withProgressBar($terms, function ($canonicalModel) {
+            $data = $canonicalModel->data;
 
             $term = TermFacade::make()
-                ->slug($model->slug)
-                ->taxonomy($model->taxonomy)
-                ->blueprint($model->data['blueprint'] ?? null);
+                ->slug($canonicalModel->slug)
+                ->taxonomy($canonicalModel->taxonomy)
+                ->blueprint($data['blueprint'] ?? null);
+
+            // Load locale rows (per-row storage) and fall back to embedded JSON
+            // localizations for terms that pre-date the migration.
+            EloquentTerm::where('slug', $canonicalModel->slug)
+                ->where('taxonomy', $canonicalModel->taxonomy)
+                ->where('origin', $canonicalModel->id)
+                ->get()
+                ->each(fn ($localeModel) => $term->dataForLocale($localeModel->site, $localeModel->data ?? []));
 
             collect($data['localizations'] ?? [])
-                ->except($term->defaultLocale())
-                ->each(function ($localeData, $locale) use ($term) {
-                    $term->dataForLocale($locale, $localeData);
-                });
+                ->each(fn ($localeData, $locale) => $term->dataForLocale($locale, $localeData));
 
             unset($data['localizations']);
 
@@ -124,7 +129,7 @@ class ExportTaxonomies extends Command
             $term->data($data);
 
             if (config('statamic.system.track_last_update')) {
-                $term->set('updated_at', $model->updated_at ?? $model->created_at);
+                $term->set('updated_at', $canonicalModel->updated_at ?? $canonicalModel->created_at);
             }
 
             $term->save();

--- a/src/Commands/ImportTaxonomies.php
+++ b/src/Commands/ImportTaxonomies.php
@@ -90,10 +90,32 @@ class ImportTaxonomies extends Command
 
         $this->withProgressBar(TermFacade::all()->map->term()->unique(), function ($term) {
             $lastModified = $term->fileLastModified();
+            $defaultLocale = $term->defaultLocale();
 
-            EloquentTerm::makeModelFromContract($term)
-                ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified])
-                ->save();
+            $canonicalModel = EloquentTerm::makeModelFromContract($term)
+                ->fill(['created_at' => $lastModified, 'updated_at' => $lastModified]);
+            $canonicalModel->save();
+
+            $class = app('statamic.eloquent.terms.model');
+
+            foreach ($term->localizations() as $locale => $localizedTerm) {
+                if ($locale === $defaultLocale) {
+                    continue;
+                }
+
+                $class::firstOrNew([
+                    'slug'     => $term->getOriginal('slug', $term->slug()),
+                    'taxonomy' => $term->taxonomyHandle(),
+                    'site'     => $locale,
+                ])->fill([
+                    'slug'       => $term->slug(),
+                    'uri'        => $localizedTerm->uri(),
+                    'origin'     => $canonicalModel->id,
+                    'data'       => $term->dataForLocale($locale)->toArray(),
+                    'created_at' => $lastModified,
+                    'updated_at' => $lastModified,
+                ])->save();
+            }
         });
 
         $this->components->info('Terms imported successfully.');

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -5,37 +5,38 @@ namespace Statamic\Eloquent\Taxonomies;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Statamic\Contracts\Taxonomies\Term as Contract;
+use Statamic\Facades\Blink;
 use Statamic\Taxonomies\Term as FileEntry;
 
 class Term extends FileEntry
 {
     protected $model;
 
-    public static function fromModel(Model $model, $preloadedLocaleModels = null)
+    public static function fromModel(Model $model)
     {
         $modelClass = app('statamic.eloquent.terms.model');
+
+        // Locale rows preloaded by TermQueryBuilder::transform() are cached in
+        // Blink to avoid N+1. Fall back to a direct DB query when not present
+        // (e.g. when fromModel() is called outside of a query builder context).
+        $blinkKey = "eloquent-term-locale-rows-{$model->taxonomy}::{$model->slug}";
+        $allRows = Blink::has($blinkKey)
+            ? Blink::get($blinkKey)
+            : $modelClass::where('slug', $model->slug)->where('taxonomy', $model->taxonomy)->get();
 
         // Non-canonical rows (origin set) don't carry term-level attributes like
         // blueprint or collection, so we always read those from the canonical row.
         $canonicalModel = $model->origin
-            ? ($preloadedLocaleModels?->firstWhere('origin', null) ?? $modelClass::find($model->origin) ?? $model)
+            ? ($allRows->firstWhere('origin', null) ?? $modelClass::find($model->origin) ?? $model)
             : $model;
 
         $data = $canonicalModel->data;
 
-        /** @var Term $term */
         $term = (new static)
             ->slug($model->slug)
             ->taxonomy($model->taxonomy)
             ->model($canonicalModel)
             ->blueprint($data['blueprint'] ?? null);
-
-        // Load every locale row for this term into the Term object. When called
-        // from transform() the rows are preloaded in one query to avoid N+1.
-        $allRows = $preloadedLocaleModels
-            ?? $modelClass::where('slug', $model->slug)
-                ->where('taxonomy', $model->taxonomy)
-                ->get();
 
         $allRows->each(function ($localeModel) use ($term) {
             $term->dataForLocale($localeModel->site, $localeModel->data ?? []);

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -11,31 +11,46 @@ class Term extends FileEntry
 {
     protected $model;
 
-    public static function fromModel(Model $model)
+    public static function fromModel(Model $model, $preloadedLocaleModels = null)
     {
-        $data = $model->data;
+        $modelClass = app('statamic.eloquent.terms.model');
+
+        // Non-canonical rows (origin set) don't carry term-level attributes like
+        // blueprint or collection, so we always read those from the canonical row.
+        $canonicalModel = $model->origin
+            ? ($preloadedLocaleModels?->firstWhere('origin', null) ?? $modelClass::find($model->origin) ?? $model)
+            : $model;
+
+        $data = $canonicalModel->data;
 
         /** @var Term $term */
         $term = (new static)
             ->slug($model->slug)
             ->taxonomy($model->taxonomy)
-            ->model($model)
-            ->blueprint($model->data['blueprint'] ?? null);
+            ->model($canonicalModel)
+            ->blueprint($data['blueprint'] ?? null);
 
+        // Load every locale row for this term into the Term object. When called
+        // from transform() the rows are preloaded in one query to avoid N+1.
+        $allRows = $preloadedLocaleModels
+            ?? $modelClass::where('slug', $model->slug)
+                ->where('taxonomy', $model->taxonomy)
+                ->get();
+
+        $allRows->each(function ($localeModel) use ($term) {
+            $term->dataForLocale($localeModel->site, $localeModel->data ?? []);
+        });
+
+        // Backward compat: terms saved before the per-row migration may still
+        // carry localizations embedded in the data JSON column.
         collect($data['localizations'] ?? [])
-            ->except($term->defaultLocale())
             ->each(function ($localeData, $locale) use ($term) {
                 $term->dataForLocale($locale, $localeData);
             });
 
-        unset($data['localizations']);
-
         if (isset($data['collection'])) {
             $term->collection($data['collection']);
-            unset($data['collection']);
         }
-
-        $term->data($data);
 
         if (config('statamic.system.track_last_update')) {
             $updatedAt = ($model->updated_at ?? $model->created_at);
@@ -65,11 +80,8 @@ class Term extends FileEntry
             $data['blueprint'] = $source->blueprint;
         }
 
-        $data['localizations'] = $source->localizations()->keys()->reduce(function ($carry, $locale) use ($source) {
-            $carry[$locale] = $source->dataForLocale($locale)->toArray();
-
-            return $carry;
-        }, []);
+        // Localizations are now stored as separate rows; remove from the data column.
+        unset($data['localizations']);
 
         if ($collection = $source->collection()) {
             $data['collection'] = $collection;
@@ -82,6 +94,7 @@ class Term extends FileEntry
         ])->fill([
             'slug'       => $source->slug(),
             'uri'        => $source->uri(),
+            'origin'     => null,
             'data'       => collect($data)->filter(fn ($v) => $v !== null),
             'updated_at' => $source->lastModified(),
         ]);

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -29,18 +29,17 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     protected function transform($items, $columns = [])
     {
-        // Preload all locale rows in a single query to avoid N+1 when fromModel()
-        // loads siblings for each term.
+        // Preload all locale rows in a single query and cache them in Blink so
+        // fromModel() can avoid N+1 without needing an extra parameter.
         $modelClass = app('statamic.eloquent.terms.model');
-        $preloaded = $modelClass::whereIn('slug', collect($items)->pluck('slug'))
+        $modelClass::whereIn('slug', collect($items)->pluck('slug'))
             ->whereIn('taxonomy', collect($items)->pluck('taxonomy')->unique()->values())
             ->get()
-            ->groupBy(fn ($m) => $m->taxonomy.'::'.$m->slug);
+            ->groupBy(fn ($m) => $m->taxonomy.'::'.$m->slug)
+            ->each(fn ($rows, $key) => Blink::put("eloquent-term-locale-rows-{$key}", $rows));
 
-        return TermCollection::make($items)->map(function ($model) use ($preloaded) {
-            $siblings = $preloaded->get($model->taxonomy.'::'.$model->slug, collect());
-
-            return app(TermContract::class)::fromModel($model, $siblings)
+        return TermCollection::make($items)->map(function ($model) {
+            return app(TermContract::class)::fromModel($model)
                 ->in($model->site ?? Site::default()->handle());
         });
     }

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -21,14 +21,27 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     protected $taxonomies = [];
 
+    protected $siteFilterApplied = false;
+
     protected $columns = [
-        'id', 'data', 'site', 'slug', 'uri', 'taxonomy', 'created_at', 'updated_at',
+        'id', 'data', 'site', 'origin', 'slug', 'uri', 'taxonomy', 'created_at', 'updated_at',
     ];
 
     protected function transform($items, $columns = [])
     {
-        return TermCollection::make($items)->map(function ($model) {
-            return app(TermContract::class)::fromModel($model)->in($model->site ?? Site::default()->handle());
+        // Preload all locale rows in a single query to avoid N+1 when fromModel()
+        // loads siblings for each term.
+        $modelClass = app('statamic.eloquent.terms.model');
+        $preloaded = $modelClass::whereIn('slug', collect($items)->pluck('slug'))
+            ->whereIn('taxonomy', collect($items)->pluck('taxonomy')->unique()->values())
+            ->get()
+            ->groupBy(fn ($m) => $m->taxonomy.'::'.$m->slug);
+
+        return TermCollection::make($items)->map(function ($model) use ($preloaded) {
+            $siblings = $preloaded->get($model->taxonomy.'::'.$model->slug, collect());
+
+            return app(TermContract::class)::fromModel($model, $siblings)
+                ->in($model->site ?? Site::default()->handle());
         });
     }
 
@@ -49,6 +62,10 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if ($column === 'site') {
+            $this->siteFilterApplied = true;
+        }
+
         if (func_num_args() === 2) {
             [$value, $operator] = [$operator, '='];
         }
@@ -102,6 +119,10 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     public function whereIn($column, $values, $boolean = 'and')
     {
+        if ($column === 'site') {
+            $this->siteFilterApplied = true;
+        }
+
         if (in_array($column, ['taxonomy', 'taxonomies'])) {
             if (! $values) {
                 return $this;
@@ -199,8 +220,17 @@ class TermQueryBuilder extends EloquentQueryBuilder
         return parent::paginate($perPage, $columns, $pageName, $page);
     }
 
+    private function applyOriginFilter()
+    {
+        if (! $this->siteFilterApplied) {
+            $this->builder->whereNull('origin');
+        }
+    }
+
     private function applyCollectionAndTaxonomyWheres()
     {
+        $this->applyOriginFilter();
+
         if (! empty($this->collections)) {
             $this->builder->where(function ($query) {
                 $taxonomies = empty($this->taxonomies)
@@ -225,6 +255,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                             $termsTable = (new $termClass)->getTable();
 
                             return TermModel::where('taxonomy', $taxonomy)
+                                ->whereNull('origin')
                                 ->whereExists(function ($query) use ($entriesTable, $taxonomy, $termsTable) {
                                     $wrappedColumn = $query->getGrammar()->wrap("{$termsTable}.slug");
                                     $value = match ($query->getConnection()->getDriverName()) {
@@ -242,6 +273,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
                         }
 
                         return TermModel::where('taxonomy', $taxonomy)
+                            ->whereNull('origin')
                             ->select('slug')
                             ->get()
                             ->map(function ($term) use ($taxonomy) {

--- a/src/Taxonomies/TermQueryBuilder.php
+++ b/src/Taxonomies/TermQueryBuilder.php
@@ -19,8 +19,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
 {
     protected $collections = [];
 
-    protected $site = null;
-
     protected $taxonomies = [];
 
     protected $columns = [
@@ -29,13 +27,8 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     protected function transform($items, $columns = [])
     {
-        $site = $this->site;
-        if (! $site) {
-            $site = Site::default()->handle();
-        }
-
-        return TermCollection::make($items)->map(function ($model) use ($site) {
-            return app(TermContract::class)::fromModel($model)->in($site);
+        return TermCollection::make($items)->map(function ($model) {
+            return app(TermContract::class)::fromModel($model)->in($model->site ?? Site::default()->handle());
         });
     }
 
@@ -56,12 +49,6 @@ class TermQueryBuilder extends EloquentQueryBuilder
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if ($column === 'site') {
-            $this->site = $operator;
-
-            return $this;
-        }
-
         if (func_num_args() === 2) {
             [$value, $operator] = [$operator, '='];
         }
@@ -159,13 +146,8 @@ class TermQueryBuilder extends EloquentQueryBuilder
         $model = parent::find($id, $columns);
 
         if ($model) {
-            $site = $this->site;
-            if (! $site) {
-                $site = Site::default()->handle();
-            }
-
             return app(TermContract::class)::fromModel($model)
-                ->in($site)
+                ->in($model->site ?? Site::default()->handle())
                 ->selectedQueryColumns($columns);
         }
     }
@@ -188,15 +170,7 @@ class TermQueryBuilder extends EloquentQueryBuilder
             $items->each->collection(Collection::findByHandle($this->collections[0]));
         }
 
-        $items = Term::applySubstitutions($items);
-
-        return $items->map(function ($term) {
-            if ($this->site) {
-                return $term->in($this->site);
-            }
-
-            return $term->inDefaultLocale();
-        });
+        return Term::applySubstitutions($items);
     }
 
     public function pluck($column, $key = null)

--- a/src/Taxonomies/TermRepository.php
+++ b/src/Taxonomies/TermRepository.php
@@ -101,10 +101,31 @@ class TermRepository extends StacheRepository
 
     public function save($entry)
     {
-        $model = $entry->toModel();
-        $model->save();
+        $canonicalModel = $entry->toModel();
+        $canonicalModel->save();
 
-        $entry->model($model->fresh());
+        $entry->model($canonicalModel->fresh());
+
+        $class = app('statamic.eloquent.terms.model');
+        $defaultLocale = $entry->defaultLocale();
+
+        foreach ($entry->localizations() as $locale => $localizedTerm) {
+            if ($locale === $defaultLocale) {
+                continue;
+            }
+
+            $class::firstOrNew([
+                'slug'     => $entry->getOriginal('slug', $entry->slug()),
+                'taxonomy' => $entry->taxonomyHandle(),
+                'site'     => $locale,
+            ])->fill([
+                'slug'       => $entry->slug(),
+                'uri'        => $localizedTerm->uri(),
+                'origin'     => $canonicalModel->id,
+                'data'       => $entry->dataForLocale($locale)->toArray(),
+                'updated_at' => $entry->lastModified(),
+            ])->save();
+        }
 
         Blink::put("eloquent-term-{$entry->id()}", $entry);
         Blink::put("eloquent-term-{$entry->uri()}", $entry);
@@ -112,7 +133,11 @@ class TermRepository extends StacheRepository
 
     public function delete($entry)
     {
-        $entry->model()->delete();
+        $class = app('statamic.eloquent.terms.model');
+
+        $class::where('slug', $entry->slug())
+            ->where('taxonomy', $entry->taxonomyHandle())
+            ->delete();
 
         Blink::forget("eloquent-term-{$entry->id()}");
         Blink::forget("eloquent-term-{$entry->uri()}");

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -162,20 +162,37 @@ class TermQueryBuilderTest extends TestCase
             'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
         ]);
 
-        // Tags has 'en' as its primary site, so terms are stored with site='en'.
         Taxonomy::make('tags')->sites(['en', 'fr'])->save();
-        Term::make('en-1')->taxonomy('tags')->data([])->save();
-        Term::make('en-2')->taxonomy('tags')->data([])->save();
 
-        // Categories has 'fr' as its primary site, so terms are stored with site='fr'.
-        Taxonomy::make('categories')->sites(['fr', 'en'])->save();
-        Term::make('fr-1')->taxonomy('categories')->data([])->save();
+        Term::make('a')->taxonomy('tags')
+            ->dataForLocale('en', ['title' => 'Term A'])
+            ->dataForLocale('fr', ['title' => 'Terme A'])
+            ->save();
 
+        Term::make('b')->taxonomy('tags')
+            ->dataForLocale('en', ['title' => 'Term B'])
+            ->save();
+
+        // No site filter: returns canonical (origin IS NULL) rows only, each in its own locale.
+        $terms = Term::query()->get();
+        $this->assertCount(2, $terms);
+        $this->assertTrue($terms->every(fn ($t) => $t->locale() === 'en'));
+
+        // where('site', 'en') filters to the canonical en rows.
         $enTerms = Term::query()->where('site', 'en')->get();
-        $this->assertEquals(['en-1', 'en-2'], $enTerms->map->slug()->sort()->values()->all());
+        $this->assertCount(2, $enTerms);
+        $this->assertEquals(['a', 'b'], $enTerms->map->slug()->sort()->values()->all());
+        $this->assertTrue($enTerms->every(fn ($t) => $t->locale() === 'en'));
 
+        // where('site', 'fr') returns the fr locale row for every term in the taxonomy.
         $frTerms = Term::query()->where('site', 'fr')->get();
-        $this->assertEquals(['fr-1'], $frTerms->map->slug()->sort()->values()->all());
+        $this->assertCount(2, $frTerms);
+        $this->assertEquals(['a', 'b'], $frTerms->map->slug()->sort()->values()->all());
+        $this->assertTrue($frTerms->every(fn ($t) => $t->locale() === 'fr'));
+
+        // French-specific data is accessible on the fr LocalizedTerm.
+        $frTermA = $frTerms->first(fn ($t) => $t->slug() === 'a');
+        $this->assertEquals('Terme A', $frTermA->get('title'));
     }
 
     #[Test]

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -155,6 +155,30 @@ class TermQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function it_filters_by_site()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        // Tags has 'en' as its primary site, so terms are stored with site='en'.
+        Taxonomy::make('tags')->sites(['en', 'fr'])->save();
+        Term::make('en-1')->taxonomy('tags')->data([])->save();
+        Term::make('en-2')->taxonomy('tags')->data([])->save();
+
+        // Categories has 'fr' as its primary site, so terms are stored with site='fr'.
+        Taxonomy::make('categories')->sites(['fr', 'en'])->save();
+        Term::make('fr-1')->taxonomy('categories')->data([])->save();
+
+        $enTerms = Term::query()->where('site', 'en')->get();
+        $this->assertEquals(['en-1', 'en-2'], $enTerms->map->slug()->sort()->values()->all());
+
+        $frTerms = Term::query()->where('site', 'fr')->get();
+        $this->assertEquals(['fr-1'], $frTerms->map->slug()->sort()->values()->all());
+    }
+
+    #[Test]
     public function it_filters_by_taxonomy()
     {
         Taxonomy::make('tags')->save();

--- a/tests/Terms/TermTest.php
+++ b/tests/Terms/TermTest.php
@@ -215,7 +215,7 @@ class TermTest extends TestCase
     }
 
     #[Test]
-    public function it_stores_localizations_in_the_model_when_saving()
+    public function it_stores_localizations_as_separate_rows_when_saving()
     {
         $this->setSites([
             'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
@@ -228,11 +228,16 @@ class TermTest extends TestCase
         $term->dataForLocale('fr', ['title' => 'Tag de test']);
         $term->save();
 
-        $model = TermModel::first();
+        $this->assertEquals(2, TermModel::count());
 
-        $this->assertArrayHasKey('localizations', $model->data);
-        $this->assertArrayHasKey('fr', $model->data['localizations']);
-        $this->assertEquals('Tag de test', $model->data['localizations']['fr']['title']);
+        $canonical = TermModel::whereNull('origin')->first();
+        $this->assertArrayNotHasKey('localizations', $canonical->data);
+        $this->assertEquals('Test Tag', $canonical->data['title']);
+
+        $frRow = TermModel::whereNotNull('origin')->first();
+        $this->assertEquals($canonical->id, $frRow->origin);
+        $this->assertEquals('fr', $frRow->site);
+        $this->assertEquals('Tag de test', $frRow->data['title']);
     }
 
     #[Test]


### PR DESCRIPTION
Previously, all locale data for a term was embedded in a single database row under a data->localizations JSON key. This made it impossible to query terms by site using a real WHERE site = ? clause, since translations stored inside a row's JSON are invisible to SQL.                                                         
                                                                                                                                                                           
This PR moves each localization to its own database row. The canonical (default-locale) row keeps origin = NULL, and each translation row stores origin = <canonical_id>.

This aligns with how entries already work.

Closes #578 