### PR TITLE
Change revisions message column to be text on new installs

### DIFF
--- a/database/migrations/2024_03_07_100000_create_revisions_table.php
+++ b/database/migrations/2024_03_07_100000_create_revisions_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('key');
             $table->string('action')->index();
             $table->string('user')->nullable();
-            $table->string('message')->nullable();
+            $table->text('message')->nullable();
             $table->jsonb('attributes')->nullable();
             $table->timestamps();
 


### PR DESCRIPTION
Closes #582 

@duncanmcclean My feeling is we don't need to back port this to existing installs. If someone comes against it they can make a migration... what do you think?