### PR TITLE
Forget the all-list Blink cache when saving containers, taxonomies and globals

### DIFF
--- a/src/Assets/AssetContainerRepository.php
+++ b/src/Assets/AssetContainerRepository.php
@@ -46,6 +46,7 @@ class AssetContainerRepository extends StacheRepository
         $container->save();
 
         Blink::forget("eloquent-assetcontainer-{$container->handle()}");
+        Blink::forget('eloquent-assetcontainers');
     }
 
     public function delete($container)

--- a/src/Globals/GlobalRepository.php
+++ b/src/Globals/GlobalRepository.php
@@ -54,6 +54,7 @@ class GlobalRepository extends StacheRepository
         $entry->model($model->fresh());
 
         Blink::forget("eloquent-globalsets-{$model->handle}");
+        Blink::forget('eloquent-globalsets');
     }
 
     public function delete($entry)

--- a/src/Taxonomies/TaxonomyRepository.php
+++ b/src/Taxonomies/TaxonomyRepository.php
@@ -92,6 +92,7 @@ class TaxonomyRepository extends StacheRepository
         $entry->model($fresh);
 
         Blink::put("eloquent-taxonomies-{$fresh->handle}", $fresh);
+        Blink::forget('eloquent-taxonomies');
     }
 
     public function delete($entry)

--- a/tests/Repositories/AssetContainerRepositoryTest.php
+++ b/tests/Repositories/AssetContainerRepositoryTest.php
@@ -73,4 +73,17 @@ class AssetContainerRepositoryTest extends TestCase
         $this->assertNotNull($item = $this->repo->findByHandle('new'));
         $this->assertEquals($container, $item);
     }
+
+    #[Test]
+    public function saving_a_container_invalidates_the_cached_all_list()
+    {
+        // Warm the Blink cache by reading all() before the new container exists.
+        $this->assertCount(2, $this->repo->all());
+
+        $this->repo->save(Facades\AssetContainer::make('new')->disk('local'));
+
+        $handles = $this->repo->all()->map->handle()->all();
+        $this->assertCount(3, $handles);
+        $this->assertContains('new', $handles);
+    }
 }

--- a/tests/Repositories/GlobalRepositoryTest.php
+++ b/tests/Repositories/GlobalRepositoryTest.php
@@ -97,4 +97,17 @@ class GlobalRepositoryTest extends TestCase
 
         $this->assertNotNull($item = $this->repo->find('new'));
     }
+
+    #[Test]
+    public function saving_a_global_invalidates_the_cached_all_list()
+    {
+        // Warm the Blink cache by reading all() before the new global exists.
+        $this->assertCount(2, $this->repo->all());
+
+        $this->repo->save(GlobalSetAPI::make('new')->title('New')->sites(['en']));
+
+        $handles = $this->repo->all()->map->handle()->all();
+        $this->assertCount(3, $handles);
+        $this->assertContains('new', $handles);
+    }
 }

--- a/tests/Repositories/TaxonomyRepositoryTest.php
+++ b/tests/Repositories/TaxonomyRepositoryTest.php
@@ -102,4 +102,17 @@ class TaxonomyRepositoryTest extends TestCase
     //         $this->assertNotNull($item = $this->repo->findByHandle('new'));
     //         $this->assertEquals(['foo' => 'bar'], $item->cascade()->all());
     //     }
+
+    #[Test]
+    public function saving_a_taxonomy_invalidates_the_cached_all_list()
+    {
+        // Warm the Blink cache by reading all() before the new taxonomy exists.
+        $this->assertCount(2, $this->repo->all());
+
+        $this->repo->save(TaxonomyAPI::make('new')->title('New'));
+
+        $handles = $this->repo->all()->map->handle()->all();
+        $this->assertCount(3, $handles);
+        $this->assertContains('new', $handles);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `Blink::forget('eloquent-assetcontainers')` to `AssetContainerRepository::save()`
- Add `Blink::forget('eloquent-taxonomies')` to `TaxonomyRepository::save()`
- Add `Blink::forget('eloquent-globalsets')` to `GlobalRepository::save()`
- Add a regression test per repository

Mirrors what each `delete()` already does so reads after writes within the same request reflect the new entry rather than the pre-save cached list. `CollectionRepository` was the only repo that got this right; the others now match.

The tests fail on upstream `5.x` and pass with this change. Drafted while triage on #585 is open. Happy to scope down to one repository if you'd prefer separate PRs.

Fixes #585