### PR TITLE
[4.x] Use closest origin that has field localized to determine if a field can be forgotten in `makeModelFromContract` method of `Entry`

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -61,7 +61,7 @@ class Entry extends FileEntry
 
         $date = $source->hasDate() ? $source->date() : null;
 
-        $origin = $source->origin();
+        $directOrigin = $source->origin();
 
         if ($source->hasOrigin()) {
             if ($blueprint = $source->blueprint()) {
@@ -73,13 +73,23 @@ class Entry extends FileEntry
                     ->handle()
                     ->all();
 
-                $originData = $origin->data();
+                $directOriginData = $directOrigin->data();
 
                 // remove any fields in entry data that are marked as localized but value is present, and does not match origin
                 $localizedFields = [];
                 foreach ($localizedBlueprintFields as $blueprintField) {
                     if ($data->has($blueprintField)) {
-                        if ($data->get($blueprintField) === $originData->get($blueprintField)) {
+                        $fieldOrigin = $directOrigin;
+                        $fieldOriginData = $directOriginData;
+                        while (
+                            $fieldOrigin->hasOrigin()
+                            && ! in_array($blueprintField, $fieldOriginData->get('__localized_fields') ?? [])
+                        ) {
+                            $fieldOrigin = $fieldOrigin->origin();
+                            $fieldOriginData = $fieldOrigin->data();
+                        }
+
+                        if ($data->get($blueprintField) === $fieldOriginData->get($blueprintField)) {
                             $data->forget($blueprintField);
                         } else {
                             $localizedFields[] = $blueprintField;
@@ -87,12 +97,12 @@ class Entry extends FileEntry
                     }
                 }
 
-                $data = $originData->merge($data);
+                $data = $directOrigin->data()->merge($data);
 
                 $data->put('__localized_fields', $localizedFields);
 
                 if (! in_array('date', $localizedFields)) {
-                    $date = $origin->hasDate() ? $origin->date() : null;
+                    $date = $directOrigin->hasDate() ? $directOrigin->date() : null;
                 }
             }
         }
@@ -117,7 +127,7 @@ class Entry extends FileEntry
 
         $attributes = [
             ...$attributes,
-            'origin_id' => $origin?->id(),
+            'origin_id' => $directOrigin?->id(),
             'site' => $source->locale(),
             'slug' => $source->slug(),
             'uri' => $source->uri() ?? $source->routableUri(),

--- a/tests/Entries/EntryTest.php
+++ b/tests/Entries/EntryTest.php
@@ -288,6 +288,54 @@ class EntryTest extends TestCase
     }
 
     #[Test]
+    public function it_localizes_null_values_for_non_direct_descendants()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'nl' => ['name' => 'Dutch', 'locale' => 'nl_NL', 'url' => 'http://nl.test.com/'],
+            'nl-BE' => ['name' => 'Flemish', 'locale' => 'nl_BE', 'url' => 'http://test.com/nl-be/'],
+        ]);
+
+        $blueprint = Facades\Blueprint::makeFromFields(['foo' => ['type' => 'text', 'localizable' => true]])->setHandle('test');
+        $blueprint->save();
+
+        BlueprintRepository::shouldReceive('in')->with('collections/pages')->andReturn(collect(['test' => $blueprint]));
+
+        $collection = (new Collection)
+            ->handle('pages')
+            ->propagate(true)
+            ->sites(['en', 'nl', 'nl-BE'])
+            ->save();
+
+        /** @var Entry $originEntry */
+        $originEntry = (new Entry)
+            ->id(1)
+            ->locale('en')
+            ->collection($collection)
+            ->blueprint('test')
+            ->data(['foo' => 'bar']);
+        $originEntry->save();
+
+        /** @var Entry $directLocalizationEntry */
+        $directLocalizationEntry = $originEntry->in('nl');
+        $directLocalizationEntry->toModel()->save();
+        $indirectLocalizationEntry = $directLocalizationEntry->in('nl-BE');
+        $indirectLocalizationEntry->origin($directLocalizationEntry);
+
+        $this->assertSame($originEntry, $directLocalizationEntry->origin());
+        $this->assertSame($directLocalizationEntry, $indirectLocalizationEntry->origin());
+
+        $indirectLocalizationEntry->data(['foo' => null]);
+        $indirectLocalizationEntry->toModel()->save();
+
+        $directLocalizationEntry = Entry::fromModel($directLocalizationEntry->model()->fresh());
+        $indirectLocalizationEntry = Entry::fromModel($indirectLocalizationEntry->model()->fresh());
+
+        $this->assertEquals('bar', $directLocalizationEntry->value('foo'));
+        $this->assertEquals(null, $indirectLocalizationEntry->value('foo'));
+    }
+
+    #[Test]
     public function it_stores_and_retrieves_mapped_data_values()
     {
         config()->set('statamic.eloquent-driver.entries.map_data_to_columns', true);


### PR DESCRIPTION
When working with localizations of localizations, the localized fields are not handled appropriately, specifically whenever a localization field is left empty it only checks the direct origin and sees null == null and thus it think it does not need to be localized (even though the origin that the value is then inherited from might not be null).

This change will make it so for each localized field, it will check the closest origin that has the field localized, ensuring that this is cascaded correctly.

While I personally need this fixed in the 4.x branch, it seems this issue also exists in the 5.x branch...should I make a separate PR for 5.x or how would it be best to approach this?
The method is slightly expanded in the new version, but the logic that determines which localized fields can be forgotten seems to be the same, and could thus likely receive the same patch.