### PR TITLE
Preserve fallback blueprint

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -347,9 +347,23 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
-        $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () {
-            return (new \Statamic\Eloquent\Fields\BlueprintRepository)
+        // Capture fallbacks (e.g. Statamic core's 'default' fallback) before replacing the singleton
+        // so non-eloquent-driven namespace lookups continue to work the same as the file driver.
+        $fallbacks = [];
+        if ($this->app->bound(\Statamic\Fields\BlueprintRepository::class)) {
+            $previous = $this->app->make(\Statamic\Fields\BlueprintRepository::class);
+            $fallbacks = (new \ReflectionProperty($previous, 'fallbacks'))->getValue($previous);
+        }
+
+        $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () use ($fallbacks) {
+            $repo = (new \Statamic\Eloquent\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'));
+
+            foreach ($fallbacks as $handle => $fallback) {
+                $repo->setFallback($handle, $fallback);
+            }
+
+            return $repo;
         });
     }
 

--- a/tests/Data/Fields/BlueprintTest.php
+++ b/tests/Data/Fields/BlueprintTest.php
@@ -88,4 +88,29 @@ class BlueprintTest extends TestCase
 
         $this->assertCount(1, BlueprintModel::all()); // we check theres no new  database entries, ie its been handled by files
     }
+
+    #[Test]
+    public function it_returns_fallback_for_default_blueprint_when_namespace_is_restricted()
+    {
+        config()->set('statamic.eloquent-driver.blueprints.namespaces', ['forms']);
+
+        app(\Statamic\Fields\BlueprintRepository::class)->setFallback('default', function () {
+            return \Statamic\Facades\Blueprint::make()->setContents([
+                'tabs' => ['main' => ['sections' => [['fields' => [['handle' => 'content', 'field' => ['type' => 'markdown', 'localizable' => true]]]]]]],
+            ]);
+        });
+
+        $blueprint = Blueprint::find('default');
+
+        $this->assertNotNull($blueprint);
+        $this->assertInstanceOf(\Statamic\Fields\Blueprint::class, $blueprint);
+    }
+
+    #[Test]
+    public function it_returns_null_for_default_blueprint_when_namespace_is_restricted_and_no_fallback_is_set()
+    {
+        config()->set('statamic.eloquent-driver.blueprints.namespaces', ['forms']);
+
+        $this->assertNull(Blueprint::find('default'));
+    }
 }


### PR DESCRIPTION
This PR ensures the fallback blueprint is not lost when using eloquent driver for blueprints.

Fixes https://github.com/statamic/eloquent-driver/issues/588