### PR TITLE
[6.x] Match entries with an unset field when querying with a not equals operator

### DIFF
--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -115,10 +115,15 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
         }
 
+        $actualColumn = $this->column($column);
+
+        // A field that was never set isn't in the data column at all, so json_extract gives
+        // us null and the entry falls out of the results. The Stache matches it, so we do too.
         if (
             func_num_args() > 2
+            && ! is_null($value)
             && in_array($operator, ['!=', '<>'], true)
-            && $this->isFieldColumn($actualColumn = $this->column($column))
+            && $this->isTopLevelDataColumn($actualColumn)
         ) {
             $this->builder->where(function ($query) use ($actualColumn, $operator, $value) {
                 $query->whereNull($actualColumn)->orWhere($actualColumn, $operator, $value);
@@ -139,7 +144,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         return parent::whereIn(...func_get_args());
     }
 
-    private function isFieldColumn($column)
+    private function isTopLevelDataColumn($column)
     {
         return Str::contains($column, 'data->') && ! Str::contains(Str::after($column, 'data->'), '->');
     }

--- a/src/Entries/EntryQueryBuilder.php
+++ b/src/Entries/EntryQueryBuilder.php
@@ -115,6 +115,18 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
             trigger_error('Filtering by status is deprecated. Use whereStatus() instead.', E_USER_DEPRECATED);
         }
 
+        if (
+            func_num_args() > 2
+            && in_array($operator, ['!=', '<>'], true)
+            && $this->isFieldColumn($actualColumn = $this->column($column))
+        ) {
+            $this->builder->where(function ($query) use ($actualColumn, $operator, $value) {
+                $query->whereNull($actualColumn)->orWhere($actualColumn, $operator, $value);
+            }, null, null, $boolean);
+
+            return $this;
+        }
+
         return parent::where(...func_get_args());
     }
 
@@ -125,6 +137,11 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         }
 
         return parent::whereIn(...func_get_args());
+    }
+
+    private function isFieldColumn($column)
+    {
+        return Str::contains($column, 'data->') && ! Str::contains(Str::after($column, 'data->'), '->');
     }
 
     private function ensureCollectionsAreQueriedForStatusQuery(): void

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -54,36 +54,6 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
-    public function entries_without_the_field_are_found_using_where_not_equals()
-    {
-        Collection::make('posts')->save();
-
-        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
-        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'archived' => false])->create();
-        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'archived' => true])->create();
-
-        $entries = Entry::query()->where('archived', '!=', true)->get();
-
-        $this->assertCount(2, $entries);
-        $this->assertEquals(['Post 1', 'Post 2'], $entries->map->title->all());
-    }
-
-    #[Test]
-    public function entries_with_a_null_column_are_not_found_using_where_not_equals()
-    {
-        Collection::make('posts')->save();
-        Collection::make('events')->dated(true)->save();
-
-        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
-        EntryFactory::id('2')->slug('event-1')->collection('events')->date('2024-01-01')->data(['title' => 'Event 1'])->create();
-
-        $entries = Entry::query()->where('date', '!=', '2023-01-01')->get();
-
-        $this->assertCount(1, $entries);
-        $this->assertEquals(['Event 1'], $entries->map->title->all());
-    }
-
-    #[Test]
     public function entries_are_found_using_or_where()
     {
         $this->createDummyCollectionAndEntries();
@@ -559,6 +529,38 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(3, $entries);
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_without_the_field_are_found_using_where_not_equals()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'archived' => false])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'archived' => true])->create();
+
+        $entries = Entry::query()->where('archived', '!=', true)->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 2'], $entries->map->title->all());
+
+        $entries = Entry::query()->where('archived', false)->orWhere('archived', true)->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_with_a_null_column_are_not_found_using_where_not_equals()
+    {
+        Collection::make('events')->dated(true)->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
+        EntryFactory::id('2')->slug('event-1')->collection('events')->date('2024-01-01')->data(['title' => 'Event 1'])->create();
+
+        $entries = Entry::query()->where('date', '!=', '2023-01-01')->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Event 1'], $entries->map->title->all());
     }
 
     #[Test]

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -54,6 +54,36 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_without_the_field_are_found_using_where_not_equals()
+    {
+        Collection::make('posts')->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'archived' => false])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'archived' => true])->create();
+
+        $entries = Entry::query()->where('archived', '!=', true)->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 2'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_with_a_null_column_are_not_found_using_where_not_equals()
+    {
+        Collection::make('posts')->save();
+        Collection::make('events')->dated(true)->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1'])->create();
+        EntryFactory::id('2')->slug('event-1')->collection('events')->date('2024-01-01')->data(['title' => 'Event 1'])->create();
+
+        $entries = Entry::query()->where('date', '!=', '2023-01-01')->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Event 1'], $entries->map->title->all());
+    }
+
+    #[Test]
     public function entries_are_found_using_or_where()
     {
         $this->createDummyCollectionAndEntries();


### PR DESCRIPTION
When a blueprint field has never been set on an entry, its key is simply missing from the data column, so json_extract returns NULL and `where('archived', '!=', true)` skips the entry. The Stache matches it. A template like `{{ collection:things archived:isnt="true" }}` therefore lists everything on the file driver and nothing here.

I've deliberately kept this much narrower than the change suggested in the issue. It only applies to `!=` and `<>`, and only to a top level field key in the data column. Real columns are left alone, so `where('date', '!=', ...)` still follows normal SQL null rules. Nested paths are untouched too, so `where('content->value', '<>', 1)` still ignores entries whose content isn't shaped that way, as `entries_are_found_using_where_with_json_value` expects. No existing test needed changing.

Fixes #603.