### PR TITLE
Decode percent-encoded paths in `AssetRepository::findByUrl()`

### DIFF
--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -53,7 +53,7 @@ class AssetRepository extends BaseRepository
             $url = $siteUrl.$url;
         }
 
-        $path = Str::after($url, $containerUrl);
+        $path = rawurldecode(Str::after($url, $containerUrl));
 
         if (Str::startsWith($path, '/')) {
             $path = substr($path, 1);

--- a/tests/Repositories/AssetRepositoryTest.php
+++ b/tests/Repositories/AssetRepositoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Repositories;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades;
+use Tests\TestCase;
+
+class AssetRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/tmp',
+        ]]);
+
+        Storage::fake('test', ['url' => '/assets']);
+
+        tap(Facades\AssetContainer::make('test')->disk('test'))->save();
+    }
+
+    protected function tearDown(): void
+    {
+        app('files')->deleteDirectory(__DIR__.'/tmp');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_finds_an_asset_by_url()
+    {
+        Storage::disk('test')->put('a.jpg', '');
+        $asset = tap(Facades\Asset::make()->container('test')->path('a.jpg'))->save();
+
+        $this->assertEquals($asset->id(), Facades\Asset::findByUrl($asset->url())->id());
+    }
+
+    /**
+     * The URL is written out encoded rather than taken from $asset->url(), because
+     * whether that method encodes has varied across Statamic versions. What matters
+     * here is that an encoded URL resolves, however it was produced.
+     */
+    #[Test]
+    public function it_finds_an_asset_by_url_when_the_path_is_percent_encoded()
+    {
+        Storage::disk('test')->put('my file (1) @ café.jpg', '');
+        $asset = tap(Facades\Asset::make()->container('test')->path('my file (1) @ café.jpg'))->save();
+
+        $this->assertEquals(
+            $asset->id(),
+            Facades\Asset::findByUrl('/assets/my%20file%20%281%29%20%40%20caf%C3%A9.jpg')->id()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #609.

`Statamic\Eloquent\Assets\AssetRepository::findByUrl()` passes the path straight into the database query without decoding it, unlike `Statamic\Assets\AssetRepository::findByUrl()` in core, which does:

```php
$path = rawurldecode(Str::after($url, $containerUrl));
```

Asset URLs are percent-encoded, so any filename containing a space, parentheses, `@`, a comma or an accented character produces a path like `my%20file%20%281%29.jpg`. That never matches the stored `basename`, and `findByUrl()` returns `null` for an asset that exists.

This is easy to hit in practice: the returned `null` reaches `ImageGenerator::generateByAsset()` via the `glide` tag, which has no null check and throws `Call to a member function isVideo() on null`. Because that's an `\Error` and `Glide::generate()` only catches `\Exception`, it escapes the tag's own error handling and 500s the whole page rather than skipping the image. SEO Pro renders `og:image` through that path, so one asset with a space in its name can take down every page referencing it.

### The change

Restores the `rawurldecode()` call so the Eloquent driver matches core.

### Tests

Added `tests/Repositories/AssetRepositoryTest.php` with two cases: a plain filename (passes before and after, guards against regressions) and a percent-encoded one (fails with `Call to a member function id() on null` before the change, passes after).

The two pre-existing failures in `tests/Entries/EntryRepositoryTest.php` are also present on a clean `5.x` checkout and are unrelated to this change.