### PR TITLE
Forms 2 compatibility

### DIFF
--- a/src/Commands/ExportForms.php
+++ b/src/Commands/ExportForms.php
@@ -4,6 +4,7 @@ namespace Statamic\Eloquent\Commands;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Forms\Form as FormContract;
@@ -78,15 +79,27 @@ class ExportForms extends Command
 
         $forms = FormModel::all();
 
-        $this->withProgressBar($forms, function ($form) {
-            Form::make()
-                ->handle($form->handle)
-                ->title($form->title)
-                ->store($form->settings['store'] ?? null)
-                ->email($form->settings['email'] ?? null)
-                ->honeypot($form->settings['honeypot'] ?? null)
-                ->data($form->settings['data'] ?? [])
-                ->save();
+        $this->withProgressBar($forms, function ($model) {
+            $settings = collect($model->settings);
+
+            $form = Form::make()
+                ->handle($model->handle)
+                ->title($model->title)
+                ->store($settings->get('store'))
+                ->charts($settings->get('charts'))
+                ->honeypot($settings->get('honeypot'))
+                ->connections($settings->get('connections'))
+                ->data($settings->get('data') ?? []);
+
+            if (! is_null($emails = Arr::get($settings, 'connections.email', $settings->get('email')))) {
+                $form->email($emails);
+            }
+
+            if ($fields = $settings->get('fields')) {
+                $form->formFields($fields);
+            }
+
+            $form->save();
         });
 
         $this->newLine();

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -3,6 +3,7 @@
 namespace Statamic\Eloquent\Forms;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Statamic\Contracts\Forms\Form as Contract;
 use Statamic\Events\FormCreated;
 use Statamic\Events\FormCreating;
@@ -11,6 +12,7 @@ use Statamic\Events\FormDeleting;
 use Statamic\Events\FormSaved;
 use Statamic\Events\FormSaving;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form as FormFacade;
 use Statamic\Forms\Form as FileEntry;
 
@@ -20,14 +22,27 @@ class Form extends FileEntry
 
     public static function fromModel(Model $model)
     {
-        return (new static)
+        $settings = collect($model->settings);
+
+        $form = (new static)
             ->title($model->title)
             ->handle($model->handle)
-            ->store($model->settings['store'] ?? null)
-            ->email($model->settings['email'] ?? null)
-            ->honeypot($model->settings['honeypot'] ?? null)
-            ->data($model->settings['data'] ?? [])
+            ->store($settings->get('store'))
+            ->charts($settings->get('charts'))
+            ->honeypot($settings->get('honeypot'))
+            ->connections($settings->get('connections'))
+            ->data($settings->get('data') ?? [])
             ->model($model);
+
+        if (! is_null($emails = Arr::get($settings, 'connections.email', $settings->get('email')))) {
+            $form->email($emails);
+        }
+
+        if ($fields = $settings->get('fields')) {
+            $form->formFields($fields);
+        }
+
+        return $form;
     }
 
     public function toModel()
@@ -42,10 +57,12 @@ class Form extends FileEntry
         return $class::firstOrNew(['handle' => $source->handle()])->fill([
             'title'    => $source->title() ?? $source->handle(),
             'settings' => [
-                'store'    => $source->store(),
-                'email'    => $source->email(),
-                'honeypot' => $source->honeypot(),
-                'data' => $source->data()->filter(fn ($v) => $v !== null),
+                'fields'      => $source->formFields()->contents(),
+                'charts'      => $source->charts(),
+                'honeypot'    => $source->honeypot(),
+                'connections' => $source->connections()->all(),
+                'store'       => $source->store(),
+                'data'        => $source->data()->filter(fn ($v) => $v !== null),
             ],
         ]);
     }
@@ -88,6 +105,10 @@ class Form extends FileEntry
 
         Blink::forget("eloquent-forms-{$this->handle()}");
         Blink::forget('eloquent-forms');
+
+        if ($blueprint = Blueprint::find("forms.{$this->handle()}")) {
+            $blueprint->delete();
+        }
 
         foreach ($afterSaveCallbacks as $callback) {
             $callback($this);

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -5,10 +5,6 @@ namespace Statamic\Eloquent\Forms;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Statamic\Events\SubmissionCreated;
-use Statamic\Events\SubmissionDeleted;
-use Statamic\Events\SubmissionSaved;
-use Statamic\Events\SubmissionSaving;
 use Statamic\Forms\Submission as FileEntry;
 
 class Submission extends FileEntry
@@ -76,58 +72,5 @@ class Submission extends FileEntry
         }
 
         return $this->date = Carbon::now();
-    }
-
-    public function save()
-    {
-        if (SubmissionSaving::dispatch($this) === false) {
-            return false;
-        }
-
-        $withEvents = $this->withEvents;
-        $this->withEvents = true;
-
-        $afterSaveCallbacks = $this->afterSaveCallbacks;
-        $this->afterSaveCallbacks = [];
-
-        $model = $this->toModel();
-        $model->save();
-
-        if ($isNew = $model->wasRecentlyCreated) {
-            $this->id = $model->getKey();
-        }
-
-        $this->model($model->fresh());
-
-        foreach ($afterSaveCallbacks as $callback) {
-            $callback($this);
-        }
-
-        if ($withEvents) {
-            if ($isNew) {
-                SubmissionCreated::dispatch($this);
-            }
-
-            SubmissionSaved::dispatch($this);
-        }
-    }
-
-    public function delete()
-    {
-        if (! $this->model) {
-            $class = app('statamic.eloquent.form_submissions.model');
-            $this->model = $class::findOrNew($this->id);
-        }
-
-        $withEvents = $this->withEvents;
-        $this->withEvents = true;
-
-        $this->model->delete();
-
-        if ($withEvents) {
-            SubmissionDeleted::dispatch($this);
-        }
-
-        return true;
     }
 }

--- a/src/Forms/SubmissionQueryBuilder.php
+++ b/src/Forms/SubmissionQueryBuilder.php
@@ -34,6 +34,24 @@ class SubmissionQueryBuilder extends EloquentQueryBuilder implements BuilderCont
         return $column;
     }
 
+    public function whereStatus(string $status)
+    {
+        return match ($status) {
+            'any' => $this,
+            'finalized' => $this->whereNotTrue('partial')->whereNotTrue('spam'),
+            'partial' => $this->where('partial', true)->whereNotTrue('spam'),
+            'spam' => $this->where('spam', true),
+            default => throw new \Exception("Invalid status [$status]"),
+        };
+    }
+
+    private function whereNotTrue(string $column)
+    {
+        return $this->where(
+            fn ($query) => $query->whereNull($column)->orWhere($column, '!=', true)
+        );
+    }
+
     protected function transform($items, $columns = [])
     {
         return DataCollection::make($items)->map(function ($model) {

--- a/src/Forms/SubmissionRepository.php
+++ b/src/Forms/SubmissionRepository.php
@@ -13,12 +13,16 @@ class SubmissionRepository extends StacheRepository
         $model = $submission->toModel();
         $model->save();
 
-        $submission->model($submission->fresh());
+        $submission->model($model->fresh());
     }
 
     public function delete($submission)
     {
-        $submission->model()->delete();
+        if (! $model = $submission->model()) {
+            $model = app('statamic.eloquent.form_submissions.model')::find($submission->id());
+        }
+
+        $model?->delete();
     }
 
     public static function bindings(): array

--- a/tests/Commands/ExportFormsTest.php
+++ b/tests/Commands/ExportFormsTest.php
@@ -6,6 +6,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Eloquent\Forms\SubmissionModel;
+use Statamic\Facades\File;
+use Statamic\Facades\YAML;
 use Tests\TestCase;
 
 class ExportFormsTest extends TestCase
@@ -42,6 +44,82 @@ class ExportFormsTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists($this->formsDir.'/contact.yaml');
+    }
+
+    #[Test]
+    public function it_exports_form_fields_connections_and_charts()
+    {
+        $fields = [
+            'sections' => [
+                [
+                    'fields' => [
+                        ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Name']],
+                    ],
+                ],
+            ],
+        ];
+
+        $connections = [
+            'email' => [
+                ['id' => 'abcdefgh', 'to' => '{{ email }}', 'subject' => 'Thanks'],
+            ],
+            'webhook' => [
+                ['url' => 'https://example.com/webhook'],
+            ],
+        ];
+
+        $charts = [
+            ['field' => 'name', 'chart' => 'popular_answers'],
+        ];
+
+        FormModel::create([
+            'handle' => 'contact',
+            'title' => 'Contact',
+            'settings' => [
+                'fields' => $fields,
+                'charts' => $charts,
+                'honeypot' => 'winnie',
+                'connections' => $connections,
+                'store' => true,
+            ],
+        ]);
+
+        $this->artisan('statamic:eloquent:export-forms', ['--only-forms' => true])
+            ->expectsOutputToContain('Forms exported')
+            ->assertExitCode(0);
+
+        $contents = YAML::parse(File::get($this->formsDir.'/contact.yaml'));
+
+        $this->assertSame($fields, $contents['fields']);
+        $this->assertSame($connections, $contents['connections']);
+        $this->assertSame($charts, $contents['charts']);
+        $this->assertSame('winnie', $contents['honeypot']);
+    }
+
+    #[Test]
+    public function it_converts_legacy_email_settings_when_exporting()
+    {
+        FormModel::create([
+            'handle' => 'contact',
+            'title' => 'Contact',
+            'settings' => [
+                'store' => true,
+                'email' => [
+                    ['to' => 'foo@bar.com', 'subject' => 'Feedback'],
+                ],
+            ],
+        ]);
+
+        $this->artisan('statamic:eloquent:export-forms', ['--only-forms' => true])
+            ->expectsOutputToContain('Forms exported')
+            ->assertExitCode(0);
+
+        $contents = YAML::parse(File::get($this->formsDir.'/contact.yaml'));
+
+        $this->assertArrayNotHasKey('email', $contents);
+        $this->assertSame('foo@bar.com', $contents['connections']['email'][0]['to']);
+        $this->assertSame('Feedback', $contents['connections']['email'][0]['subject']);
+        $this->assertNotNull($contents['connections']['email'][0]['id']);
     }
 
     #[Test]

--- a/tests/Commands/ImportFormsTest.php
+++ b/tests/Commands/ImportFormsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Forms\Form as FormContract;
@@ -10,7 +11,11 @@ use Statamic\Contracts\Forms\Submission as SubmissionContract;
 use Statamic\Contracts\Forms\SubmissionRepository as SubmissionRepositoryContract;
 use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Eloquent\Forms\SubmissionModel;
+use Statamic\Eloquent\Forms\SubmissionQueryBuilder;
 use Statamic\Facades\Form;
+use Statamic\Forms\FormRepository;
+use Statamic\Forms\Submission;
+use Statamic\Stache\Repositories\SubmissionRepository;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -26,10 +31,10 @@ class ImportFormsTest extends TestCase
         Facade::clearResolvedInstance(SubmissionRepositoryContract::class);
 
         app()->bind(FormContract::class, \Statamic\Forms\Form::class);
-        app()->bind(SubmissionContract::class, \Statamic\Forms\Submission::class);
-        app()->bind(FormRepositoryContract::class, \Statamic\Forms\FormRepository::class);
-        app()->bind(SubmissionRepositoryContract::class, \Statamic\Stache\Repositories\SubmissionRepository::class);
-        app()->bind(\Statamic\Eloquent\Forms\SubmissionQueryBuilder::class, \Statamic\Stache\Query\SubmissionQueryBuilder::class);
+        app()->bind(SubmissionContract::class, Submission::class);
+        app()->bind(FormRepositoryContract::class, FormRepository::class);
+        app()->bind(SubmissionRepositoryContract::class, SubmissionRepository::class);
+        app()->bind(SubmissionQueryBuilder::class, \Statamic\Stache\Query\SubmissionQueryBuilder::class);
     }
 
     #[Test]
@@ -56,6 +61,45 @@ class ImportFormsTest extends TestCase
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jack"}']);
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jason"}']);
         $this->assertDatabaseHas('form_submissions', ['form' => 'contact', 'data' => '{"name":"Jesse"}']);
+    }
+
+    #[Test]
+    public function it_imports_form_fields_connections_and_charts()
+    {
+        $fields = [
+            'sections' => [
+                [
+                    'fields' => [
+                        ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Name']],
+                    ],
+                ],
+            ],
+        ];
+
+        $connections = [
+            'email' => [
+                ['id' => 'abcdefgh', 'to' => '{{ email }}', 'subject' => 'Thanks'],
+            ],
+            'webhook' => [
+                ['url' => 'https://example.com/webhook'],
+            ],
+        ];
+
+        $charts = [
+            ['field' => 'name', 'chart' => 'popular_answers'],
+        ];
+
+        tap(Form::make('contact')->title('Contact')->formFields($fields)->connections($connections)->charts($charts))->save();
+
+        $this->artisan('statamic:eloquent:import-forms', ['--force' => true])
+            ->expectsOutputToContain('Forms imported successfully.')
+            ->assertExitCode(0);
+
+        $model = FormModel::where('handle', 'contact')->first();
+
+        $this->assertSame($fields, Arr::get($model->settings, 'fields'));
+        $this->assertSame($connections, Arr::get($model->settings, 'connections'));
+        $this->assertSame($charts, Arr::get($model->settings, 'charts'));
     }
 
     #[Test]
@@ -109,7 +153,7 @@ class ImportFormsTest extends TestCase
     #[Test]
     public function it_imports_only_forms_with_console_question()
     {
-        $form = tap(\Statamic\Facades\Form::make('contact')->title('Contact')->store(true))->save();
+        $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
         $form->makeSubmission()->data(['name' => 'Jack'])->save();
         $form->makeSubmission()->data(['name' => 'Jason'])->save();
         $form->makeSubmission()->data(['name' => 'Jesse'])->save();
@@ -159,7 +203,7 @@ class ImportFormsTest extends TestCase
     #[Test]
     public function it_imports_only_form_submissions_with_console_question()
     {
-        $form = tap(\Statamic\Facades\Form::make('contact')->title('Contact')->store(true))->save();
+        $form = tap(Form::make('contact')->title('Contact')->store(true))->save();
         $form->makeSubmission()->data(['name' => 'Jack'])->save();
         $form->makeSubmission()->data(['name' => 'Jason'])->save();
         $form->makeSubmission()->data(['name' => 'Jesse'])->save();

--- a/tests/Forms/FormSubmissionTest.php
+++ b/tests/Forms/FormSubmissionTest.php
@@ -10,6 +10,7 @@ use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Eloquent\Forms\Submission;
 use Statamic\Eloquent\Forms\SubmissionModel;
 use Statamic\Events\SubmissionCreated;
+use Statamic\Events\SubmissionCreating;
 use Statamic\Events\SubmissionDeleted;
 use Statamic\Events\SubmissionSaved;
 use Statamic\Facades;
@@ -121,6 +122,37 @@ class FormSubmissionTest extends TestCase
         ]))->save();
 
         $this->assertArrayNotHasKey('null_value', $submission->model()->data);
+    }
+
+    #[Test]
+    public function it_dispatches_submission_creating_on_first_save()
+    {
+        $form = tap(Facades\Form::make('test')->title('Test'))
+            ->save();
+
+        Event::fake();
+
+        tap($form->makeSubmission()->data([
+            'name' => 'John Doe',
+        ]))->save();
+
+        Event::assertDispatched(SubmissionCreating::class);
+    }
+
+    #[Test]
+    public function partial_submissions_keep_their_lifecycle_keys()
+    {
+        $form = tap(Facades\Form::make('test')->title('Test'))
+            ->save();
+
+        $submission = tap($form->makeSubmission()->data([
+            'name' => 'John Doe',
+        ])->asPartial())->save();
+
+        $fresh = Submission::fromModel($submission->model()->fresh());
+
+        $this->assertTrue($fresh->isPartial());
+        $this->assertSame('partial', $fresh->status());
     }
 
     #[Test]

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Forms;
 
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Eloquent\Forms\FormModel;
 use Statamic\Events\FormCreated;
 use Statamic\Events\FormCreating;
 use Statamic\Events\FormDeleted;
@@ -63,9 +65,9 @@ class FormTest extends TestCase
     #[Test]
     public function finding_a_form_sets_the_blink_cache()
     {
-        Facades\Form::make('test')->title('Test form')->save();
+        Form::make('test')->title('Test form')->save();
 
-        $form = Facades\Form::find('test');
+        $form = Form::find('test');
 
         $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
     }
@@ -73,9 +75,9 @@ class FormTest extends TestCase
     #[Test]
     public function getting_all_forms_sets_the_blink_cache()
     {
-        $form = tap(Facades\Form::make('test')->title('Test form'))->save();
+        $form = tap(Form::make('test')->title('Test form'))->save();
 
-        Facades\Form::all();
+        Form::all();
 
         $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
         $this->assertSame($form->handle(), Facades\Blink::get('eloquent-forms')->first()->handle());
@@ -84,10 +86,10 @@ class FormTest extends TestCase
     #[Test]
     public function saving_a_form_removes_the_blink_cache()
     {
-        Facades\Form::make('test')->title('Test form')->save();
+        Form::make('test')->title('Test form')->save();
 
-        $form = Facades\Form::find('test');
-        Facades\Form::all(); // to set up eloquent-forms blink
+        $form = Form::find('test');
+        Form::all(); // to set up eloquent-forms blink
 
         $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
         $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
@@ -101,10 +103,10 @@ class FormTest extends TestCase
     #[Test]
     public function deleting_a_form_removes_the_blink_cache()
     {
-        Facades\Form::make('test')->title('Test form')->save();
+        Form::make('test')->title('Test form')->save();
 
-        $form = Facades\Form::find('test');
-        Facades\Form::all(); // to set up eloquent-forms blink
+        $form = Form::find('test');
+        Form::all(); // to set up eloquent-forms blink
 
         $this->assertSame(Facades\Blink::get('eloquent-forms-test'), $form);
         $this->assertCount(1, Facades\Blink::get('eloquent-forms'));
@@ -118,7 +120,7 @@ class FormTest extends TestCase
     #[Test]
     public function it_stores_form_data()
     {
-        $form = tap(Facades\Form::make('test')->title('Test form')->data(['some' => 'data']))->save();
+        $form = tap(Form::make('test')->title('Test form')->data(['some' => 'data']))->save();
 
         $this->assertSame(['some' => 'data'], Arr::get($form->model(), 'settings.data'));
     }
@@ -126,9 +128,126 @@ class FormTest extends TestCase
     #[Test]
     public function null_values_are_removed_from_data()
     {
-        $form = tap(Facades\Form::make('test')->title('Test form')->data(['some' => 'data', 'null_value' => null]))->save();
+        $form = tap(Form::make('test')->title('Test form')->data(['some' => 'data', 'null_value' => null]))->save();
 
         $this->assertSame(['some' => 'data'], Arr::get($form->model(), 'settings.data'));
+    }
+
+    #[Test]
+    public function it_stores_form_fields()
+    {
+        $fields = [
+            'sections' => [
+                [
+                    'fields' => [
+                        ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Name']],
+                        ['handle' => 'email', 'field' => ['type' => 'email', 'display' => 'Email', 'validate' => ['required']]],
+                    ],
+                ],
+            ],
+        ];
+
+        $form = tap(Form::make('test')->title('Test form')->formFields($fields))->save();
+
+        $this->assertSame($fields, Arr::get($form->model(), 'settings.fields'));
+        $this->assertSame($fields, Form::find('test')->formFields()->contents());
+    }
+
+    #[Test]
+    public function it_stores_connections()
+    {
+        $connections = [
+            'email' => [
+                ['id' => 'abcdefgh', 'to' => '{{ email }}', 'subject' => 'Thanks for getting in touch'],
+            ],
+            'webhook' => [
+                ['url' => 'https://example.com/webhook'],
+            ],
+        ];
+
+        $form = tap(Form::make('test')->title('Test form')->connections($connections))->save();
+
+        $this->assertSame($connections, Arr::get($form->model(), 'settings.connections'));
+        $this->assertSame($connections, Form::find('test')->connections()->all());
+    }
+
+    #[Test]
+    public function it_stores_charts()
+    {
+        $charts = [
+            ['field' => 'name', 'chart' => 'popular_answers'],
+        ];
+
+        $form = tap(Form::make('test')->title('Test form')->charts($charts))->save();
+
+        $this->assertSame($charts, Arr::get($form->model(), 'settings.charts'));
+        $this->assertSame($charts, Form::find('test')->charts());
+    }
+
+    #[Test]
+    #[DataProvider('legacyEmailProvider')]
+    public function legacy_email_settings_are_converted_to_an_email_connection($email)
+    {
+        FormModel::create([
+            'handle' => 'test',
+            'title' => 'Test form',
+            'settings' => [
+                'store' => true,
+                'honeypot' => 'winnie',
+                'email' => $email,
+            ],
+        ]);
+
+        $form = Form::find('test');
+
+        $emailConnection = $form->connections()->get('email');
+
+        $this->assertCount(1, $emailConnection);
+        $this->assertSame('foo@bar.com', $emailConnection[0]['to']);
+        $this->assertSame('Feedback', $emailConnection[0]['subject']);
+        $this->assertNotNull($emailConnection[0]['id']);
+        $this->assertSame('winnie', $form->honeypot());
+    }
+
+    public static function legacyEmailProvider(): array
+    {
+        return [
+            'single email config' => [['to' => 'foo@bar.com', 'subject' => 'Feedback']],
+            'multiple email configs' => [[['to' => 'foo@bar.com', 'subject' => 'Feedback']]],
+        ];
+    }
+
+    #[Test]
+    public function fields_fall_back_to_a_legacy_blueprint_file()
+    {
+        Facades\Blueprint::make('test')
+            ->setNamespace('forms')
+            ->setContents([
+                'tabs' => [
+                    'main' => [
+                        'sections' => [
+                            [
+                                'fields' => [
+                                    ['handle' => 'name', 'field' => ['type' => 'text', 'display' => 'Name']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+            ->save();
+
+        FormModel::create(['handle' => 'test', 'title' => 'Test form']);
+
+        $form = Form::find('test');
+        $fields = $form->formFields()->contents();
+
+        $this->assertSame('short_answer', Arr::get($fields, 'sections.0.fields.0.field.type'));
+
+        $form->save();
+
+        $this->assertSame($fields, Arr::get($form->model(), 'settings.fields'));
+        $this->assertNull(Facades\Blueprint::find('forms.test'));
     }
 
     #[Test]

--- a/tests/Forms/SubmissionQueryBuilderTest.php
+++ b/tests/Forms/SubmissionQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Forms;
 
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\Form;
@@ -492,5 +493,38 @@ class SubmissionQueryBuilderTest extends TestCase
 
         $submissions = FormSubmission::query()->limit(10)->offset(1)->get();
         $this->assertEquals(['b', 'c'], $submissions->map->get('id')->all());
+    }
+
+    #[Test]
+    #[DataProvider('filterByStatusProvider')]
+    public function it_filters_by_status(string $status, array $expected)
+    {
+        $form = tap(Form::make('test'))->save();
+        FormSubmission::make()->form($form)->data(['id' => 'finalized'])->save();
+        FormSubmission::make()->form($form)->data(['id' => 'partial'])->asPartial()->save();
+        FormSubmission::make()->form($form)->data(['id' => 'spam'])->markAsSpam()->save();
+        FormSubmission::make()->form($form)->data(['id' => 'spam-partial'])->asPartial()->markAsSpam()->save();
+
+        $submissions = FormSubmission::query()->whereStatus($status)->get();
+
+        $this->assertEquals($expected, $submissions->map->get('id')->sort()->values()->all());
+    }
+
+    public static function filterByStatusProvider(): array
+    {
+        return [
+            'any' => ['any', ['finalized', 'partial', 'spam', 'spam-partial']],
+            'finalized' => ['finalized', ['finalized']],
+            'partial' => ['partial', ['partial']],
+            'spam' => ['spam', ['spam', 'spam-partial']],
+        ];
+    }
+
+    #[Test]
+    public function filtering_by_unexpected_status_throws_exception()
+    {
+        $this->expectExceptionMessage('Invalid status [foo]');
+
+        FormSubmission::query()->whereStatus('foo')->get();
     }
 }


### PR DESCRIPTION
This pull request makes the Eloquent Driver compatible with Forms 2 (https://github.com/statamic/cms/pull/15039).

## Forms

- Form fields are now stored under a `fields` key, rather than inside blueprints.
- The `emails` key has been replaced by a `connections` key which also stores configs for other, non-email, integrations (eg. webhooks).
- A new `charts` key is used to store the chart configuration on the Submissions Summary view _(only available when Forms Pro is installed)_

Without explicit support for these keys, they would be silently dropped on import and on every save. These keys are persisted in the `settings` JSON column. No schema changes are necessary.

### Backwards compatibility

We've made an effort to preserve backwards compatibility:

- Legacy `email` configs will be migrated to connections on the next save.
- Forms without inline `fields` will fall back to their legacy blueprint and be converted to a `fields` array on the next save.

## Submissions

The `save()` and `delete()` overrides on the driver's `Submission` class had drifted from core — they never dispatched `SubmissionCreating`, and missed Forms 2's `DeleteTemporaryFiles` dispatch on delete. 

Since core has persisted submissions through the repository since v5, this PR removes the overrides and moves the model persistence into `SubmissionRepository::save()`/`delete()`, letting core drive the lifecycle. This PR also fixes a bug where `SubmissionRepository::save()` refreshed the submission instead of the model.

## Commands

The `statamic:eloquent:import-forms` and `statamic:eloquent:export-forms` commands now round-trip fields, connections and charts, converting legacy `email` settings to an email connection on the way out.
