### PR TITLE
Store `publish_at` on revisions

### DIFF
--- a/database/migrations/2024_03_07_100000_create_revisions_table.php
+++ b/database/migrations/2024_03_07_100000_create_revisions_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
             $table->string('action')->index();
             $table->string('user')->nullable();
             $table->text('message')->nullable();
+            $table->timestamp('publish_at')->nullable();
             $table->jsonb('attributes')->nullable();
             $table->timestamps();
 

--- a/database/migrations/updates/add_publish_at_to_revisions_table.php.stub
+++ b/database/migrations/updates/add_publish_at_to_revisions_table.php.stub
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Eloquent\Database\BaseMigration as Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table($this->prefix('revisions'), function (Blueprint $table) {
+            $table->timestamp('publish_at')->after('message')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix('revisions'), function (Blueprint $table) {
+            $table->dropColumn('publish_at');
+        });
+    }
+};

--- a/src/Commands/ExportRevisions.php
+++ b/src/Commands/ExportRevisions.php
@@ -53,6 +53,7 @@ class ExportRevisions extends Command
                 ->date($model->created_at)
                 ->user($model->user ?? false)
                 ->message($model->message ?? '')
+                ->publishAt($model->publish_at)
                 ->attributes($model->attributes ?? [])
                 ->save();
         });

--- a/src/Commands/ImportRevisions.php
+++ b/src/Commands/ImportRevisions.php
@@ -55,6 +55,7 @@ class ImportRevisions extends Command
                 ->date(Carbon::parse($yaml['date']))
                 ->user($yaml['user'] ?? false)
                 ->message($yaml['message'] ?? '')
+                ->publishAt(($publishAt = $yaml['publish_at'] ?? null) ? Carbon::createFromTimestamp($publishAt, config('app.timezone')) : null)
                 ->attributes($yaml['attributes'] ?? []);
 
             if ($file->getBasename('.yaml') === 'working') {

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -19,6 +19,8 @@ class Revision extends FileEntry
 
     protected $message;
 
+    protected $publishAt;
+
     protected $action = 'revision';
 
     protected $attributes = [];
@@ -33,6 +35,7 @@ class Revision extends FileEntry
             ->date($model->created_at)
             ->user($model->user ?? null)
             ->message($model->message ?? null)
+            ->publishAt($model->publish_at)
             ->attributes($model->attributes ?? [])
             ->model($model);
     }
@@ -45,6 +48,7 @@ class Revision extends FileEntry
             'action' => $this->action(),
             'user' => $this->user()?->id(),
             'message' => with($this->message(), fn ($msg) => $msg == '0' ? '' : $msg),
+            'publish_at' => $this->publishAt(),
             'attributes' => $this->attributes(),
             'updated_at' => $this->date(),
         ]);
@@ -58,6 +62,7 @@ class Revision extends FileEntry
             ->date($item->date())
             ->user($item->user()?->id() ?? null)
             ->message($item->message() ?? null)
+            ->publishAt($item->publishAt())
             ->attributes($item->attributes() ?? []);
     }
 

--- a/src/Revisions/RevisionModel.php
+++ b/src/Revisions/RevisionModel.php
@@ -14,6 +14,7 @@ class RevisionModel extends BaseModel
     {
         return [
             'attributes' => 'json',
+            'publish_at' => 'datetime',
         ];
     }
 }

--- a/src/Revisions/RevisionQueryBuilder.php
+++ b/src/Revisions/RevisionQueryBuilder.php
@@ -13,7 +13,7 @@ class RevisionQueryBuilder extends EloquentQueryBuilder implements QueryBuilderC
     private $selectedQueryColumns;
 
     const COLUMNS = [
-        'id', 'key', 'action', 'user', 'message', 'attributes',
+        'id', 'key', 'action', 'user', 'message', 'publish_at', 'attributes',
     ];
 
     protected function transform($items, $columns = [])

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -65,6 +65,7 @@ class ServiceProvider extends AddonServiceProvider
         \Statamic\Eloquent\Updates\AddOrderToSitesTable::class,
         \Statamic\Eloquent\Updates\DropOriginOnGlobalSetVariables::class,
         \Statamic\Eloquent\Updates\UpdateGlobalVariables::class,
+        \Statamic\Eloquent\Updates\AddPublishAtToRevisionsTable::class,
     ];
 
     public function boot()

--- a/src/Updates/AddPublishAtToRevisionsTable.php
+++ b/src/Updates/AddPublishAtToRevisionsTable.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Statamic\Eloquent\Updates;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddPublishAtToRevisionsTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        $revisionsTable = config('statamic.eloquent-driver.table_prefix', '').'revisions';
+
+        return config('statamic.eloquent-driver.revisions.driver', 'file') === 'eloquent' &&
+            Schema::hasTable($revisionsTable) &&
+            ! Schema::hasColumn($revisionsTable, 'publish_at');
+    }
+
+    public function update()
+    {
+        $source = __DIR__.'/../../database/migrations/updates/add_publish_at_to_revisions_table.php.stub';
+        $dest = database_path('migrations/'.date('Y_m_d_His').'_add_publish_at_to_revisions_table.php');
+
+        $this->files->copy($source, $dest);
+
+        $this->console()->info('Migration created');
+        $this->console()->comment('Remember to run `php artisan migrate` to apply it to your database.');
+    }
+}

--- a/tests/Commands/ExportRevisionsTest.php
+++ b/tests/Commands/ExportRevisionsTest.php
@@ -48,6 +48,7 @@ class ExportRevisionsTest extends TestCase
             'user' => 'abc',
             'message' => 'Initial revision',
             'attributes' => ['foo' => 'bar'],
+            'publish_at' => $publishAt = Carbon::parse('2030-01-01 10:00'),
             'created_at' => Carbon::now(),
         ]);
 
@@ -55,7 +56,9 @@ class ExportRevisionsTest extends TestCase
             ->expectsOutputToContain('Revisions exported')
             ->assertExitCode(0);
 
-        $this->assertCount(1, app('files')->allFiles($this->revisionsDir));
+        $files = app('files')->allFiles($this->revisionsDir);
+        $this->assertCount(1, $files);
+        $this->assertStringContainsString('publish_at: '.$publishAt->timestamp, $files[0]->getContents());
     }
 
     #[Test]

--- a/tests/Commands/ImportRevisionsTest.php
+++ b/tests/Commands/ImportRevisionsTest.php
@@ -56,6 +56,7 @@ class ImportRevisionsTest extends TestCase
             ->action('revision')
             ->date(Carbon::now())
             ->message('Initial revision')
+            ->publishAt($publishAt = Carbon::parse('2030-01-01 10:00'))
             ->attributes(['foo' => 'bar'])
             ->save();
 
@@ -71,6 +72,7 @@ class ImportRevisionsTest extends TestCase
             'key' => 'collections/pages/en/foo',
             'action' => 'revision',
             'message' => 'Initial revision',
+            'publish_at' => $publishAt,
             'attributes' => '{"foo":"bar"}',
         ]);
     }

--- a/tests/Repositories/RevisionRepositoryTest.php
+++ b/tests/Repositories/RevisionRepositoryTest.php
@@ -55,6 +55,7 @@ class RevisionRepositoryTest extends TestCase
             ->key('456')
             ->action('other')
             ->date(now()->subHour())
+            ->publishAt(now()->addHour())
             ->save();
     }
 
@@ -109,5 +110,32 @@ class RevisionRepositoryTest extends TestCase
         $revisions = $builder->where('key', '1234')->get();
         $this->assertInstanceOf(Collection::class, $revisions);
         $this->assertCount(0, $revisions);
+    }
+
+    #[Test]
+    public function it_stores_and_retrieves_publish_at()
+    {
+        $revision = $this->repo->whereKey('456')->first();
+
+        $this->assertEquals(now()->addHour()->timestamp, $revision->publishAt()->timestamp);
+        $this->assertNull($this->repo->whereKey('123')->first()->publishAt());
+    }
+
+    #[Test]
+    public function it_queries_by_publish_at()
+    {
+        $this->assertCount(1, $this->repo->query()->whereNotNull('publish_at')->get());
+        $this->assertCount(0, $this->repo->query()->where('publish_at', '<=', now())->get());
+        $this->assertCount(1, $this->repo->query()->where('publish_at', '<=', now()->addHours(2))->get());
+    }
+
+    #[Test]
+    public function it_clears_publish_at()
+    {
+        $revision = $this->repo->whereKey('456')->first();
+
+        $revision->publishAt(null)->save();
+
+        $this->assertNull($this->repo->whereKey('456')->first()->publishAt());
     }
 }


### PR DESCRIPTION
Companion to statamic/cms#11508 (scheduled revision publishing), which adds a `publish_at` date to revisions. This persists it in the `revisions` table so the core scheduler can query `publish_at` against the eloquent driver.

Adds a nullable `publish_at` timestamp column (fresh installs via the create migration, existing installs via an update script that publishes `add_publish_at_to_revisions_table`), maps it in `Revision::fromModel()`/`toModel()`, exposes it as a real column in `RevisionQueryBuilder` so `whereNotNull('publish_at')` / `where('publish_at', '<=', now())` hit the column rather than `attributes->`, and round-trips it in the import/export commands.

Depends on statamic/cms#11508 for `Revision::publishAt()`, so tests will fail until that ships and the `statamic/cms` constraint is bumped.
