### PR TITLE
5.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 5.11.1 (2026-09-03)
+
+### What's fixed
+- Fix entry order test expectations [#611](https://github.com/statamic/eloquent-driver/issues/611) by @duncanmcclean
+- Add release workflow [#614](https://github.com/statamic/eloquent-driver/issues/614) by @duncanmcclean
+
+
+
 ## 5.11.0 (2026-08-11)
 
 ### What's fixed


### PR DESCRIPTION
This pull request prepares the 5.11.1 release.

There are no user-facing changes since 5.11.0. This release exists to test the new release workflow added in #614 before it's relied on for real releases.

Related: #614